### PR TITLE
implement create-spyglass-view

### DIFF
--- a/examples/cli_examples/create_session_group.py
+++ b/examples/cli_examples/create_session_group.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import nwb_datajoint.common as ndc
+
+nwb_file_name = 'RN2_20191110_.nwb'
+
+ndc.SessionGroup.add_group('group1', 'Group1', skip_duplicates=True)
+ndc.SessionGroup.add_session_to_group(nwb_file_name, 'group1', skip_duplicates=True)
+print(
+    ndc.SessionGroup.get_group_sessions('group1')
+)

--- a/examples/cli_examples/create_spyglass_view.sh
+++ b/examples/cli_examples/create_spyglass_view.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+thisdir=`dirname "$0"`
+spyglass create-spyglass-view group1

--- a/examples/cli_examples/readme.md
+++ b/examples/cli_examples/readme.md
@@ -102,3 +102,16 @@ spyglass insert-spike-sorter-parameters parameters.yaml
 
 spyglass list-spike-sorter-parameters
 ```
+
+### Create a session group
+
+A session group is a collection of sessions that can be viewed via spyglassview.
+
+See [session_groups.md](../../docs/session_groups.md) and [create_session_group.py](./create_session_group.py).
+
+### Create spyglass view
+
+```bash
+# This will print a URL pointing to the view
+create-spyglass-view <groupname> 
+```

--- a/src/nwb_datajoint/cli/cli.py
+++ b/src/nwb_datajoint/cli/cli.py
@@ -347,6 +347,14 @@ def list_spike_sortings(nwb_file_name: str):
     results = ndc.SpikeSorting & {'nwb_file_name': nwb_file_name}
     print(results)
 
+@click.command(help="Create spyglass view of a session group.")
+@click.argument('session_group_name')
+def create_spyglass_view(session_group_name: str):
+    import nwb_datajoint.common as ndc
+    F = ndc.SessionGroup.create_spyglass_view(session_group_name)
+    url = F.url(label=session_group_name)
+    print(url)
+
 cli.add_command(insert_session)
 cli.add_command(list_sessions)
 cli.add_command(insert_lab_team)
@@ -370,3 +378,4 @@ cli.add_command(insert_spike_sorter_parameters)
 cli.add_command(list_spike_sorter_parameters)
 cli.add_command(run_spike_sorting)
 cli.add_command(list_spike_sortings)
+cli.add_command(create_spyglass_view)

--- a/src/nwb_datajoint/common/common_session.py
+++ b/src/nwb_datajoint/common/common_session.py
@@ -1,3 +1,4 @@
+import os
 import datajoint as dj
 
 from .common_device import CameraDevice, DataAcquisitionDevice, Probe
@@ -160,6 +161,17 @@ class SessionGroup(dj.Manual):
             {'nwb_file_name': result['nwb_file_name']}
             for result in results
         ]
+    @staticmethod
+    def create_spyglass_view(session_group_name: str):
+        import figurl as fig
+        FIGURL_CHANNEL = os.getenv('FIGURL_CHANNEL')
+        assert FIGURL_CHANNEL, 'Environment variable not set: FIGURL_CHANNEL'
+        data = {
+            'type': 'spyglassview',
+            'sessionGroupName': session_group_name
+        }
+        F = fig.Figure(view_url='gs://figurl/spyglassview-1', data=data)
+        return F
 
 # The reason this is not implemented as a dj.Part is that
 # datajoint prohibits deleting from a subtable without

--- a/src/nwb_datajoint/common/common_session.py
+++ b/src/nwb_datajoint/common/common_session.py
@@ -128,11 +128,11 @@ class SessionGroup(dj.Manual):
     session_group_description: varchar(2000)
     """
     @staticmethod
-    def add_group(session_group_name: str, session_group_description):
+    def add_group(session_group_name: str, session_group_description: str, *, skip_duplicates: bool=False):
         SessionGroup.insert1({
             'session_group_name': session_group_name,
             'session_group_description': session_group_description
-        })
+        }, skip_duplicates=skip_duplicates)
     @staticmethod
     def update_session_group_description(session_group_name: str, session_group_description):
         SessionGroup.update1({
@@ -140,11 +140,11 @@ class SessionGroup(dj.Manual):
             'session_group_description': session_group_description
         })
     @staticmethod
-    def add_session_to_group(nwb_file_name: str, session_group_name: str):
+    def add_session_to_group(nwb_file_name: str, session_group_name: str, *, skip_duplicates: bool=False):
         SessionGroupSession.insert1({
             'session_group_name': session_group_name,
             'nwb_file_name': nwb_file_name
-        })
+        }, skip_duplicates=skip_duplicates)
     @staticmethod
     def remove_session_from_group(nwb_file_name: str, session_group_name: str):
         query = {'session_group_name': session_group_name, 'nwb_file_name': nwb_file_name}


### PR DESCRIPTION
Added a new command for creating a spyglassview figURL for a particular session group.

From command line:

```bash
# prints a figURL
spyglass create-spyglass-view <session_group_name>
```

or from Python

```python
from nwb_datajoint.common import SessionGroup
session_group_name = '...'
url = SessionGroup.create_spyglass_view(session_group_name)
print(url)
```

Here's an example spyglassview figURL: https://www.figurl.org/f?v=gs://figurl/spyglassview-1&d=1292f87b3fd4d77b4ed5569597c3f64dd07ddfb7&channel=flatiron1&label=spyglass%20view

For info on creating a session group: [session_groups.md](https://github.com/LorenFrankLab/nwb_datajoint/blob/master/docs/session_groups.md)

Also added `skip_duplicates` parameter in `SessionGroup.add_group()` and `SessionGroup.add_session_to_group()`