### PR TITLE
Fix ambiguous truth value of an array

### DIFF
--- a/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
+++ b/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
@@ -116,7 +116,7 @@ class SpikeSorting(dj.Computed):
         if artifact_times.ndim == 1:
             artifact_times = np.expand_dims(artifact_times, 0)
 
-        if artifact_times:
+        if len(artifact_times):
             # convert valid intervals to indices
             list_triggers = []
             for interval in artifact_times:


### PR DESCRIPTION
Use `if len(artifact_times)` instead of just `if artifact_times` because truth value of an array with more than one element is ambiguous. The latter gave me an error about the ambiguity of "if artifact_times." Please check whether this is the intended boolean evaluation to use here, or whether another use such as .any() or .all() is what was intended. Thanks.