### PR TITLE
Use defined method name

### DIFF
--- a/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
+++ b/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import time
+import uuid
 from pathlib import Path
 
 import datajoint as dj
@@ -147,7 +148,7 @@ class SpikeSorting(dj.Computed):
 
         print('Saving sorting results...')
         sorting_folder = Path(os.getenv('NWB_DATAJOINT_SORTING_DIR'))
-        sorting_name = self._get_recording_name(key)
+        sorting_name = self._get_sorting_name(key)
         key['sorting_path'] = str(sorting_folder / Path(sorting_name))
         if os.path.exists(key['sorting_path']):
             shutil.rmtree(key['sorting_path'])
@@ -208,12 +209,10 @@ class SpikeSorting(dj.Computed):
                 shutil.rmtree(
                     str(Path(os.environ['NWB_DATAJOINT_SORTING_DIR']) / dir))
 
-    def _get_recording_name(self, key):
+    def _get_sorting_name(self, key):
         recording_name = SpikeSortingRecording._get_recording_name(key)
         sorting_name = recording_name + '_' \
-            + key['sorter'] + '_' \
-            + key['sorter_params_name'] + '_' \
-            + key['artifact_removed_interval_list_name']
+            + str(uuid.uuid4())[0:8] + '_spikesorting'
         return sorting_name
 
     # TODO: write a function to import sortings done outside of dj

--- a/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
+++ b/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
@@ -147,7 +147,7 @@ class SpikeSorting(dj.Computed):
 
         print('Saving sorting results...')
         sorting_folder = Path(os.getenv('NWB_DATAJOINT_SORTING_DIR'))
-        sorting_name = self._get_sorting_name(key)
+        sorting_name = self._get_recording_name(key)
         key['sorting_path'] = str(sorting_folder / Path(sorting_name))
         if os.path.exists(key['sorting_path']):
             shutil.rmtree(key['sorting_path'])


### PR DESCRIPTION
Looks like only `_get_recording_name` was defined for SpikeSorting() - I don't see `_get_sorting_name` defined - so it seems like `_get_recording_name` should be called here? If someone prefers to rename the method that approach could work too I think.