### PR TITLE
Do not run artifact removal code if no artifacts

### DIFF
--- a/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
+++ b/src/nwb_datajoint/spikesorting/spikesorting_sorting.py
@@ -114,10 +114,10 @@ class SpikeSorting(dj.Computed):
         # load valid times
         artifact_times = (ArtifactRemovedIntervalList &
                           key).fetch1('artifact_times')
-        if artifact_times.ndim == 1:
-            artifact_times = np.expand_dims(artifact_times, 0)
-
         if len(artifact_times):
+            if artifact_times.ndim == 1:
+                artifact_times = np.expand_dims(artifact_times, 0)
+
             # convert valid intervals to indices
             list_triggers = []
             for interval in artifact_times:


### PR DESCRIPTION
The dimension expansion (previous line 118) led to attempted artifact removal even when no artifacts exist, which gave an index error. By putting the dimension expansion after checking the length of artifact_times, this can be avoided.