### PR TITLE
query SortInterval with full key when populating CuratedSpikeSorting

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -778,8 +778,7 @@ class CuratedSpikeSorting(dj.Computed):
         # get the sort_interval and sorting interval list
         sort_interval_name = (SpikeSortingRecording &
                               key).fetch1('sort_interval_name')
-        sort_interval = (SortInterval & {
-                         'sort_interval_name': sort_interval_name}).fetch1('sort_interval')
+        sort_interval = (SortInterval & key).fetch1('sort_interval')
         sort_interval_list_name = (SpikeSorting & key).fetch1(
             'artifact_removed_interval_list_name')
 


### PR DESCRIPTION
Currently, when populating CuratedSpikeSorting, the query of SortInterval returns multiple items when it is meant to return one, because the query is not specific enough (nwb file is not included). This results in an error. This pull request uses the full key (with nwb file) to query SortInterval. This change has been tested. Thanks @dpeg22 for help with debugging this. 