### PR TITLE
Find correct artifact time

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_sorting.py
+++ b/src/spyglass/spikesorting/spikesorting_sorting.py
@@ -145,7 +145,7 @@ class SpikeSorting(dj.Computed):
 
         # load artifact intervals
         artifact_times = (ArtifactRemovedIntervalList &
-                          key).fetch1('artifact_times')
+                          key['artifact_removed_interval_list_name']).fetch1('artifact_times')
         if len(artifact_times):
             if artifact_times.ndim == 1:
                 artifact_times = np.expand_dims(artifact_times, 0)


### PR DESCRIPTION
Cannot just use intersection of ArtifactRemovedIntervalList and key for retrieving the artifact intervals in case where the artifact interval was computed with a different sort interval; making it more specific