### PR TITLE
Iss201

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -370,10 +370,14 @@ class MetricParameters(dj.Manual):
         self.insert1(
             ['franklab_default', self.metric_default_params], skip_duplicates=True)
     
-    def get_available_metric_functions(self):
+    def get_available_metrics(self):
         for metric in _metric_name_to_func:
             if metric in self.available_metrics:
-                print(f'metric : {_metric_name_to_func[metric]}\n')
+                metric_string = ("{metric_name} : {metric_doc}").format(
+                metric_name=metric, 
+                metric_doc=_metric_name_to_func[
+                    metric].__doc__.split("\n")[0])
+                print(metric_string+'\n')
     
     # TODO
     def _validate_metrics_list(self, key):
@@ -475,6 +479,8 @@ class QualityMetrics(dj.Computed):
 
 
 def _compute_isi_violation_fractions(waveform_extractor, **metric_params):
+    """Computes the per unit fraction of interspike interval violations to total spikes.
+    """
     isi_threshold_ms = metric_params['isi_threshold_ms']
     min_isi_ms = metric_params['min_isi_ms']
 
@@ -491,6 +497,8 @@ def _compute_isi_violation_fractions(waveform_extractor, **metric_params):
 
 
 def _get_peak_offset(waveform_extractor: si.WaveformExtractor, peak_sign: str, **metric_params):
+    """Computes the shift of the waveform peak from center of window. 
+    """
     if 'peak_sign' in metric_params:
         del metric_params['peak_sign']
     peak_offset_inds = st.get_template_extremum_channel_peak_shift(

--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -354,10 +354,13 @@ class MetricParameters(dj.Manual):
                              'n_neighbors': 5,
                              'n_components': 7,
                              'radius_um': 100,
-                             'seed': 0},
-        'peak_offset': {'peak_sign': 'neg'}
+                             'seed': 0}
     }
-    available_metrics = list(metric_default_params.keys())
+    # Example of peak_offset parameters 'peak_offset': {'peak_sign': 'neg'}
+    available_metrics = [
+        'snr', 'isi_violation',
+        'nn_isolation', 'nn_noise_overlap', 'peak_offset'
+        ]
 
     def get_metric_default_params(self, metric: str):
         "Returns default params for the given metric"
@@ -366,7 +369,12 @@ class MetricParameters(dj.Manual):
     def insert_default(self):
         self.insert1(
             ['franklab_default', self.metric_default_params], skip_duplicates=True)
-
+    
+    def get_available_metric_functions(self):
+        for metric in _metric_name_to_func:
+            if metric in self.available_metrics:
+                print(f'metric : {_metric_name_to_func[metric]}\n')
+    
     # TODO
     def _validate_metrics_list(self, key):
         """Checks whether a row to be inserted contains only the available metrics


### PR DESCRIPTION
Addressing #201 by removing `peak_offset` from default parameter dictionary. Left a comment with example parameter dictionary for `peak_offset` in case users are interested. Would like to have a better solution to telling user what parameters are available/required for each metric, but that might be a separate issue. Also added `get_available_metrics` to provide user with description of what each metric aims to calculate based off function docstring. These are not ideal solutions, so open to any and all suggestions. 