### PR TITLE
Concatenate recording before computing waveforms

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -273,6 +273,9 @@ class Waveforms(dj.Computed):
 
     def make(self, key):
         recording = Curation.get_recording(key)
+        if recording.get_num_segments() > 1:
+            recording = si.concatenate_recordings([recording])
+        
         sorting = Curation.get_curated_sorting(key)
 
         print('Extracting waveforms...')


### PR DESCRIPTION
If a recording has multiple (disjoint) sort intervals, it is saved as `AppendSegmentRecording` with each sort interval as a recording segment to preserve timestamps. But a sorting is always single-segment, because MS4 has to concatenate the recording segments before sorting (i.e. cannot sort multi-segment recordings). So there can be a mismatch in the number of segments. This PR concatenates the recording segments to a single segment before computing waveforms. 