### PR TITLE
Artifact bug fix

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/spikesorting_artifact.py
@@ -194,18 +194,18 @@ def _get_artifact_times(recording, zscore_thresh=None, amplitude_thresh=None,
     if ((amplitude_thresh is not None) and (zscore_thresh is None)):
         above_a = np.abs(data) > amplitude_thresh
         above_thresh = np.ravel(np.argwhere(
-            np.sum(above_a, axis=0) >= nelect_above))
+            np.sum(above_a, axis=1) >= nelect_above))
     elif ((amplitude_thresh is None) and (zscore_thresh is not None)):
         dataz = np.abs(stats.zscore(data, axis=1))
         above_z = dataz > zscore_thresh
         above_thresh = np.ravel(np.argwhere(
-            np.sum(above_z, axis=0) >= nelect_above))
+            np.sum(above_z, axis=1) >= nelect_above))
     else:
         above_a = np.abs(data) > amplitude_thresh
         dataz = np.abs(stats.zscore(data, axis=1))
         above_z = dataz > zscore_thresh
         above_thresh = np.ravel(np.argwhere(
-            np.sum(np.logical_or(above_z, above_a), axis=0) >= nelect_above))
+            np.sum(np.logical_or(above_z, above_a), axis=1) >= nelect_above))
 
     if len(above_thresh) == 0:
         recording_interval = np.asarray(

--- a/src/spyglass/spikesorting/spikesorting_sorting.py
+++ b/src/spyglass/spikesorting/spikesorting_sorting.py
@@ -132,7 +132,7 @@ class SpikeSorting(dj.Computed):
 
         # first, get the timestamps
         timestamps = SpikeSortingRecording._get_recording_timestamps(recording)
-
+        fs = recording.get_sampling_frequency()
         # then concatenate the recordings
         # Note: the timestamps are lost upon concatenation,
         # i.e. concat_recording.get_times() doesn't return true timestamps anymore.
@@ -157,11 +157,11 @@ class SpikeSorting(dj.Computed):
                     np.arange(np.searchsorted(timestamps, interval[0]),
                               np.searchsorted(timestamps, interval[1])))
             list_triggers = [list(np.concatenate(list_triggers))]
-            
+            pad = 2 * (1 / fs) * 1000
             recording = sit.remove_artifacts(
                 recording=recording,
                 list_triggers=list_triggers,
-                ms_before=0, ms_after=0, mode='zeros')
+                ms_before=0, ms_after=pad, mode='zeros')
 
         print(f'Running spike sorting on {key}...')
         sorter, sorter_params = (SpikeSorterParameters & key).fetch1(


### PR DESCRIPTION
Bug fix in `spikesorting_artifact.py`
In `spikesorting_sorting.py` added minimum possible pad to `ms_after` argument in call to `si.toolkit.remove_artifacts()` to ensure zeroing of artifact times. 

Tested `ArtifactDetection` using `artifact_params_name`s: 'test_amp_no_z', 'test_no_amp_z', 'test_no_amp_no_z', 'test_amp_z'.
Tested removal of artifacts using below (see .md for jupyter notebook):
```python
from pathlib import Path
import datajoint as dj
import os
os.environ['SPYGLASS_BASE_DIR'] = "/stelmo/nwb/"
os.environ['SPYGLASS_RECORDING_DIR'] = "/stelmo/nwb/recording"
os.environ['SPYGLASS_SORTING_DIR'] = "/stelmo/nwb/sorting"
os.environ['SPYGLASS_WAVEFORMS_DIR'] = "/stelmo/nwb/waveforms"
os.environ['SPYGLASS_TEMP_DIR'] = "/stelmo/nwb/tmp"
os.environ['KACHERY_DAEMON_HOST'] = "typhoon"
os.environ['KACHERY_DAEMON_PORT'] = "14747"
os.environ['KACHERY_STORAGE_DIR'] = "/stelmo/nwb/kachery-storage"
os.environ['KACHERY_TEMP_DIR'] = "/stelmo/nwb/tmp"
os.environ['FIGURL_CHANNEL'] = "franklab2"
os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = "TRUE"
dj.config["enable_python_native_blobs"] = True
```


```python
import spyglass as sg
import spyglass.common as sgc
import spyglass.spikesorting as sgss
import spikeinterface as si
```


```python
import numpy as np
import matplotlib.pyplot as plt
import warnings
warnings.filterwarnings("ignore", category=DeprecationWarning) 
warnings.simplefilter('ignore', category=ResourceWarning)

# set nwb file name
nwb_file_name = 'fern20211007_.nwb'
```

### Set artifact/recording keys first


```python
artifact_key = {'nwb_file_name': 'fern20211007_.nwb',
                'sort_group_id': 8,
                'sort_interval_name': '04_r2_test_1000s',
                'preproc_params_name': 'franklab_tetrode_hippocampus',
                'team_name': 'JG_DG',
                'artifact_params_name': 'test_amp_no_z'}
recording_key = {'nwb_file_name': 'fern20211007_.nwb',
                 'sort_group_id': 8,
                 'sort_interval_name': '04_r2_test_1000s',
                 'preproc_params_name': 'franklab_tetrode_hippocampus',
                 'interval_list_name': '04_r2',
                 'team_name': 'JG_DG'}
```


```python
artifact_removed_interval_list_name = (sgss.ArtifactDetection & artifact_key).fetch1('artifact_removed_interval_list_name')
recording_path = (sgss.SpikeSortingRecording & recording_key).fetch1('recording_path')
recording = si.load_extractor(recording_path)

# first, get the timestamps
timestamps = sgss.SpikeSortingRecording._get_recording_timestamps(recording)
fs = recording.get_sampling_frequency()
# then concatenate the recordings
# Note: the timestamps are lost upon concatenation,
# i.e. concat_recording.get_times() doesn't return true timestamps anymore.
# but concat_recording.recoring_list[i].get_times() will return correct
# timestamps for ith recording.
if recording.get_num_segments() > 1 and isinstance(recording, si.AppendSegmentRecording):
    recording = si.concatenate_recordings(recording.recording_list)
elif recording.get_num_segments() > 1 and isinstance(recording, si.BinaryRecordingExtractor):
    recording = si.concatenate_recordings([recording])

# load artifact intervals
artifact_times = (sgss.ArtifactRemovedIntervalList &
                  {'artifact_removed_interval_list_name': artifact_removed_interval_list_name}).fetch1('artifact_times')
if len(artifact_times):
    if artifact_times.ndim == 1:
        artifact_times = np.expand_dims(artifact_times, 0)

    # convert artifact intervals to indices
    list_triggers = []
    for interval in artifact_times:
        list_triggers.append(
            np.arange(np.searchsorted(timestamps, interval[0]),
                      np.searchsorted(timestamps, interval[1])))
    list_triggers = [list(np.concatenate(list_triggers))]
    pad = 2 * (1 / fs) * 1000
    recording = si.toolkit.remove_artifacts(
        recording=recording,
        list_triggers=list_triggers,
        ms_before=0, ms_after=pad, mode='zeros')
data = recording.get_traces()
num_chs = recording.get_num_channels()
fig, axs = plt.subplots(nrows=num_chs, figsize=(20,30))
for ch in range(0,num_chs):
    axs[ch].scatter(recording.get_times(), data[:,ch], c=f'C{ch}')
    axs[ch].scatter(recording.get_times()[list_triggers[0]], np.repeat(-1000, len(list_triggers[0])), c='r')
```


    
![png](output_5_0.png)
    



```python

```

![output_5_0](https://user-images.githubusercontent.com/57648931/166614449-e423803e-6fc4-4d6d-88b8-c286afc4c9b1.png)
