### PR TITLE
Enable adding >1 dataframes to an analysis nwb

### DIFF
--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -262,7 +262,7 @@ class AnalysisNwbfile(dj.Manual):
             base_dir / 'analysis' / analysis_nwb_file_name)
         return analysis_nwb_file_abspath
 
-    def add_nwb_object(self, analysis_file_name, nwb_object):
+    def add_nwb_object(self, analysis_file_name, nwb_object, table_name='pandas_table'):
         # TODO: change to add_object with checks for object type and a name parameter, which should be specified if
         # it is not an NWB container
         """Add an NWB object to the analysis file in the scratch area and returns the NWB object ID
@@ -273,6 +273,8 @@ class AnalysisNwbfile(dj.Manual):
             The name of the analysis NWB file.
         nwb_object : pynwb.core.NWBDataInterface
             The NWB object created by PyNWB.
+        table_name : str (optional, defaults to 'pandas_table')
+            The name of the DynamicTable made from a dataframe.
 
         Returns
         -------
@@ -282,7 +284,7 @@ class AnalysisNwbfile(dj.Manual):
         with pynwb.NWBHDF5IO(path=self.get_abs_path(analysis_file_name), mode="a", load_namespaces=True) as io:
             nwbf = io.read()
             if isinstance(nwb_object, pd.DataFrame):
-                dt_object = DynamicTable.from_dataframe(name='pandas_table', df=nwb_object)
+                dt_object = DynamicTable.from_dataframe(name=table_name, df=nwb_object)
                 nwbf.add_scratch(dt_object)
                 io.write(nwbf)
                 return dt_object.object_id


### PR DESCRIPTION
See issue #252 . This change enables the user to set the name of the dynamic table when created from a dataframe before adding it as an nwb object to an analysis nwb file. Previously, the name was hard coded as 'pandas_table' which disallowed the entry of more than one dataframe into an analysis nwb file, because they would have the same name. Now, the user can set a name for each table so that multiple dataframes can be converted to hdmf dynamic tables and added as uniquely named nwb objects to an analysis nwb file. Tested locally. This change does not impact file reading as far as I understand, because nwb objects are fetched using the object id regardless of the nwb object type.