### PR TITLE
use device attribute in nwb video file object

### DIFF
--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -643,10 +643,9 @@ class PositionVideo(dj.Computed):
             position_info_df[['head_orientation']])
         video_time = np.asarray(nwb_video.timestamps)
         position_time = np.asarray(position_info_df.index)
-        for device_name in nwb_video.devices:
-            cm_per_pixel = (
-                nwb_video.devices[device_name].meters_per_pixel
-                * M_TO_CM)
+        cm_per_pixel = (
+            nwb_video.device.meters_per_pixel
+            * M_TO_CM)
 
         print('Making video...')
         self.make_video(video_filename, centroids, head_position_mean,


### PR DESCRIPTION
The existing code in common_position for generating video files with trackers overlaid uses an attribute, the .devices attribute, that appears to no longer exist in the nwb video file object. As a result, running:
`sgc.common_position.PositionVideo().make({'nwb_file_name': nwb_file_name,
                                              'interval_list_name': interval_list_name,
                                              'position_info_param_name': 'default'
                                             })`
resulted in the error:
`---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [10], in <cell line: 1>()
      1 for interval_list_name in interval_list_names:
----> 2     sgc.common_position.PositionVideo().make({'nwb_file_name': nwb_file_name,
      3                                               'interval_list_name': interval_list_name,
      4                                               'position_info_param_name': 'default'
      5                                              })

File ~/Src/spyglass/src/spyglass/common/common_position.py:646, in PositionVideo.make(self, key)
    644 video_time = np.asarray(nwb_video.timestamps)
    645 position_time = np.asarray(position_info_df.index)
--> 646 for device_name in nwb_video.devices:
    647     cm_per_pixel = (
    648         nwb_video.devices[device_name].meters_per_pixel
    649         * M_TO_CM)
    651 print('Making video...')

AttributeError: 'ImageSeries' object has no attribute 'devices'`

The .devices attribute was used to get meters_per_pixel. This is now available through the .device attribute. This pull request uses the .device attribute to avoid the above error. I was able to generate a video file with trackers overlaid after making this change.