### PR TITLE
apply zscore across times, within electrode

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/spikesorting_artifact.py
@@ -196,13 +196,13 @@ def _get_artifact_times(recording, zscore_thresh=None, amplitude_thresh=None,
         above_thresh = np.ravel(np.argwhere(
             np.sum(above_a, axis=1) >= nelect_above))
     elif ((amplitude_thresh is None) and (zscore_thresh is not None)):
-        dataz = np.abs(stats.zscore(data, axis=1))
+        dataz = np.abs(stats.zscore(data, axis=0))
         above_z = dataz > zscore_thresh
         above_thresh = np.ravel(np.argwhere(
             np.sum(above_z, axis=1) >= nelect_above))
     else:
         above_a = np.abs(data) > amplitude_thresh
-        dataz = np.abs(stats.zscore(data, axis=1))
+        dataz = np.abs(stats.zscore(data, axis=0))
         above_z = dataz > zscore_thresh
         above_thresh = np.ravel(np.argwhere(
             np.sum(np.logical_or(above_z, above_a), axis=1) >= nelect_above))


### PR DESCRIPTION
Variable `data` in `_get_artifact_times` is a spikeinterface recording with the `.get_traces()` method applied. This variable `data` has shape (timepoints, electrodes). Z-scoring with axis=1 is z-scoring across all electrodes at one timepoint. Instead, the z-scoring should be applied to axis=0 such that we z-score across all timepoints of one electrode.

This was identified by @emilymonroe95 who noticed that some z score threshold crossings should have been identified but weren't detected by the artifact detection algorithm. This change has been tested locally.

The axes can get a bit confusing so would greatly appreciate if someone can confirm that this is what you also think we want to do here. Thank you.

If helpful, see @emilymonroe95 initial exploration with a small example dataset here, with 5 timepoints and 2 electrodes, illustrating that z-scoring with axis=0 will take the z-score across the 5 timepoints within each electrode:
![image](https://user-images.githubusercontent.com/46034181/170771841-a121b54c-ec6a-4446-82ac-d8569a06d39d.png)