### PR TITLE
 insert_manual_curation- fetch "quality_metrics" instead of "metrics"

### DIFF
--- a/src/spyglass/spikesorting/sortingview.py
+++ b/src/spyglass/spikesorting/sortingview.py
@@ -195,7 +195,7 @@ class SortingviewWorkspace(dj.Computed):
             metrics = {}
         else:
             # get the metrics from the parent curation
-            metrics = (Curation & key).fetch1('metrics')
+            metrics = (Curation & key).fetch1('quality_metrics')
 
         # insert this curation into the  Table
         return Curation.insert_curation(


### PR DESCRIPTION
@dpeg22  and I (in reference to issue #269) found that the insert_manual_curation function was fetching a 'metrics' attribute where it should be named 'quality_metrics', as seen in the Curation table. I tested this change locally and it fetches the desired metrics, and adds the correct manual curation to the Curation table.