### PR TITLE
Limit sortingview version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
     - ghostipy
     - pymysql>=1.0.*
     - h5py==2.10.*
-    - sortingview>=0.7.3
+    - sortingview==0.7.4
     - git+https://github.com/LorenFrankLab/ndx-franklab-novela.git
     - pyyaml
     - click


### PR DESCRIPTION
This PR limits sortingview version to 0.7.4. The newer versions break our code because it is not backwards compatible. We will remove this once we make a switch to the new sortingview.

