### PR TITLE
disable checksum for files > 1 GB

### DIFF
--- a/config/dj_config.py
+++ b/config/dj_config.py
@@ -14,6 +14,8 @@ def set_configuration(user_name):
     dj.config['enable_python_native_blobs'] = True
     dj.config['database.use_tls'] = True
     dj.config['database.user'] = user_name
+    # disable checksum for files > 1 GB
+    dj.config['filepath_checksum_size_limit'] = 1 * 1024**3
 
     # change password; this will prompt you to type in a new password
     dj.set_password()
@@ -21,7 +23,8 @@ def set_configuration(user_name):
     # next, set up external stores
     # (read about them here: https://docs.datajoint.io/python/admin/5-blob-config.html)
 
-    assert os.getenv('SPYGLASS_BASE_DIR') is not None, 'environment variable SPYGLASS_BASE_DIR must be set'
+    assert os.getenv(
+        'SPYGLASS_BASE_DIR') is not None, 'environment variable SPYGLASS_BASE_DIR must be set'
 
     data_dir = pathlib.Path(os.environ['SPYGLASS_BASE_DIR'])
     raw_dir = data_dir / 'raw'


### PR DESCRIPTION
This pull request disables the checksum for large files (>1 GB). Large files can take a long time to checksum and slows down the ability to analyze files.

One thing I'm not sure about is if there are other places where this bit of code should be run. Right now this is only in dj.config, which people run when they are setting up an account. Other users will have to do this on their own.

Secondly, I'm unsure of the impact of this setting this variable if people do not have the latest version of datajoint (>13.6).

This PR is related to issue #275 