### PR TITLE
use min_segment_length when creating spikesorting recording

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/spikesorting_recording.py
@@ -13,7 +13,7 @@ import probeinterface as pi
 from ..common.common_device import Probe
 from ..common.common_ephys import Electrode, ElectrodeGroup
 from ..common.common_interval import (IntervalList, interval_list_intersect,
-                                      union_adjacent_index)
+                                      union_adjacent_index, intervals_by_length)
 from ..common.common_lab import LabTeam
 from ..common.common_nwbfile import Nwbfile
 from ..common.common_session import Session
@@ -373,6 +373,12 @@ class SpikeSortingRecording(dj.Computed):
                                 ).fetch1('valid_times')
         valid_sort_times = interval_list_intersect(
             sort_interval, valid_interval_times)
+        # Exclude intervals shorter than specified length
+        params = (SpikeSortingPreprocessingParameters &
+                  key).fetch1('preproc_params')
+        if 'min_segment_length' in params:
+            valid_sort_times = intervals_by_length(valid_sort_times,
+                                                   min_length=params['min_segment_length'])
         return valid_sort_times
 
     def _get_filtered_recording(self, key: dict):


### PR DESCRIPTION
Fix for issue #276. In brief, the current pipeline raises an error when trying to generate spikesorting recording files from recordings with small valid segments. This pull request allows a user to pass an optional parameter called 'min_segment_length' which is used to exclude intervals shorter than the value specified by the parameter.

With the proposed code, I was able to generate a spikesorting recording for a file with small segments that was previously giving an error. I also checked that the interval list of valid times stored after excluding small segments was as expected (contained no segments less than min_segment_length and contained all segments larger than min_segment_length).