### PR TITLE
Update _get_peak_offset()

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -517,7 +517,7 @@ def _get_peak_offset(waveform_extractor: si.WaveformExtractor, peak_sign: str, *
     peak_offset_inds = st.get_template_extremum_channel_peak_shift(
         waveform_extractor=waveform_extractor,
         peak_sign=peak_sign, **metric_params)
-    peak_offset = {key: int(val) for key, val in peak_offset_inds.items()}
+    peak_offset = {key: int(abs(val)) for key, val in peak_offset_inds.items()}
     return peak_offset
 
 def _get_peak_channel(waveform_extractor: si.WaveformExtractor, peak_sign: str, **metric_params):


### PR DESCRIPTION
This takes the absolute value of the peak offset so that users can set a single, positive threshold during autocuration. (peak_offset no longer tells you whether the offset peak comes before or after the spike time, just its distance away). Tested locally and it returns only positive offsets within spyglass and in the URL. (in response to issue #281 )