### PR TITLE
temporary fix to get around  pubnub package issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - tqdm
   - nb_conda
   - pip:
+    - pubnub<6.4.0
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git
     - pynwb>=2.0.0,<3


### PR DESCRIPTION
prevents latest version of pubnum from breaking sortingview; will need to be removed later.