### PR TITLE
Exception->Warning concerning whitened peak-offset

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -411,8 +411,9 @@ class MetricSelection(dj.Manual):
             'metric_params')
         if 'peak_offset' in metric_params:
             if waveform_params['whiten']:
-                raise Exception("metric 'peak_offset' needs to be "
-                                "calculated on unwhitened waveforms")
+                raise Warning("Calculating 'peak_offset' metric on "
+                            "whitened waveforms may result in slight "
+                            "discrepancies")
         if 'peak_channel' in metric_params:
             if waveform_params['whiten']:
                 Warning("Calculating 'peak_channel' metric on "

--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -5,6 +5,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import List
+import warnings
 
 import datajoint as dj
 import numpy as np
@@ -411,7 +412,7 @@ class MetricSelection(dj.Manual):
             'metric_params')
         if 'peak_offset' in metric_params:
             if waveform_params['whiten']:
-                raise Warning("Calculating 'peak_offset' metric on "
+                warnings.warn("Calculating 'peak_offset' metric on "
                             "whitened waveforms may result in slight "
                             "discrepancies")
         if 'peak_channel' in metric_params:


### PR DESCRIPTION
Before, the code would error out when calculating peak offset using whitened waveforms. With testing, we see there are only small differences between the two (thus, we should keep the note for future users, but make it a warning instead of an exception).