### PR TITLE
cleaned up and force h5py 2.10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,9 @@ name: spyglass
 channels:
   - defaults
   - franklab
+  - anaconda
   - conda-forge
   - edeno
-  - anaconda
 dependencies:
   - python>=3.8,<3.10
   - jupyterlab>=3.*
@@ -23,7 +23,7 @@ dependencies:
   - tqdm
   - nb_conda
   - skan
-  - h5py<=2.10
+  - h5py<3
   - pip:
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: spyglass-test
+name: spyglass
 channels:
   - defaults
   - franklab
@@ -20,8 +20,8 @@ dependencies:
   - ipympl
   - tqdm
   - nb_conda
+  - skan
   - pip:
-    - skan
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git
     - h5py==2.10

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - click
   - pymysql>=1.0.*
   - pip:
-    - h5py<3
+    - h5py
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git
     - pynwb

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: spyglass
 channels:
   - defaults
   - franklab
+  - conda-forge
   - edeno
 dependencies:
   - python>=3.8,<3.10
@@ -21,10 +22,10 @@ dependencies:
   - tqdm
   - nb_conda
   - skan
+  - h5py==2.10
   - pip:
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git
-    - h5py==2.10
     - pynwb
     - hdmf
     - datajoint>=0.13.6

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - tqdm
   - nb_conda
   - skan
-  - h5py==2.10
+  - h5py<=2.10
   - pip:
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - franklab
   - conda-forge
   - edeno
+  - anaconda
 dependencies:
   - python>=3.8,<3.10
   - jupyterlab>=3.*

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
-name: spyglass
+name: spyglass-test
 channels:
-  - conda-forge
   - defaults
   - franklab
   - edeno
@@ -17,17 +16,17 @@ dependencies:
   - trajectory_analysis_tools
   - matplotlib
   - seaborn
-  - skan
   - bottleneck
   - ipympl
   - tqdm
   - nb_conda
   - pip:
-    - pubnub<6.4.0
+    - skan
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git
-    - pynwb>=2.0.0,<3
-    - hdmf>=3.1.1,<=3.2.1
+    - h5py==2.10
+    - pynwb
+    - hdmf
     - datajoint>=0.13.6
     - ghostipy
     - pymysql>=1.0.*

--- a/environment.yml
+++ b/environment.yml
@@ -23,16 +23,16 @@ dependencies:
   - tqdm
   - nb_conda
   - skan
-  - h5py<3
+  - pyyaml
+  - click
+  - pymysql>=1.0.*
   - pip:
+    - h5py<3
     - mountainsort4
     - git+https://github.com/SpikeInterface/spikeinterface.git
     - pynwb
     - hdmf
     - datajoint>=0.13.6
     - ghostipy
-    - pymysql>=1.0.*
     - sortingview>=0.8
     - git+https://github.com/LorenFrankLab/ndx-franklab-novela.git
-    - pyyaml
-    - click


### PR DESCRIPTION
This gets rid of no-longer-needed restrictions and makes sure we're using h5py 2.10, as using v3.7 leads to large increases in memory usage and time during the save of recordings from spikeinterface. This has been reported to the pynwb team.