### PR TITLE
Need to use `spyglass-neuro` for package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,9 @@
    ```bash
    pip install -e .
    ```
-### Installing from pip or conda
+### Installing from pip
 ```bash
 pip install spyglass-neuro
-pip install git+https://github.com/SpikeInterface/spikeinterface.git
-```
-
-```bash
-conda install -c franklab spyglass-neuro
 pip install git+https://github.com/SpikeInterface/spikeinterface.git
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@
    ```bash
    pip install -e .
    ```
+### Installing from pip or conda
+```bash
+pip install spyglass-neuro
+pip install git+https://github.com/SpikeInterface/spikeinterface.git
+```
+
+```bash
+conda install -c franklab spyglass-neuro
+pip install git+https://github.com/SpikeInterface/spikeinterface.git
+```
+
 
 ### Setting up Frank lab database access
 
@@ -47,7 +58,7 @@ Step 1 below only applies if you are a member of Frank lab at UCSF. If you're no
      export DJ_SUPPORT_FILEPATH_MANAGEMENT="TRUE"
      ```
      Note that a local SPYGLASS_TEMP_DIR (e.g. one on your machine) will speed up spike sorting, but make sure it has enough free space (ideally at least 500GB)
- 
+
 3. Configure `DataJoint`. To connect to the database, you need to specify information such as the hostname and the port. You should also change your password from the temporary one you were given. Go to the config directory, and run [`dj_config.py`](https://github.com/LorenFrankLab/spyglass/blob/master/config/dj_config.py) in the terminal with your username:
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -7,11 +7,16 @@
 
 Documentation can be found at - [https://lorenfranklab.github.io/spyglass/](https://lorenfranklab.github.io/spyglass/)
 
+### Installing from pip
+```bash
+pip install spyglass-neuro
+pip install git+https://github.com/SpikeInterface/spikeinterface.git
+```
+
 ## Setup
 See the documentation for setup instructions - [https://lorenfranklab.github.io/spyglass/type/html/installation.html](https://lorenfranklab.github.io/spyglass/type/html/installation.html)
 
 ## Tutorials
-
 The tutorials for `spyglass` is currently in the form of Jupyter Notebooks and can be found in the [notebooks](https://github.com/LorenFrankLab/spyglass/tree/master/notebooks) directory. We strongly recommend opening them in the context of `jupyterlab`.
 
 ## Contributing
@@ -20,6 +25,6 @@ See the [Developer's Note](https://lorenfranklab.github.io/spyglass/type/html/de
 ## License/Copyright
 License and Copyright notice can be found at [https://lorenfranklab.github.io/spyglass/type/html/copyright.html](https://lorenfranklab.github.io/spyglass/type/html/copyright.html)
 
-## Citing
+## Citation
 
 Kyu Hyun Lee, Eric Denovellis, Ryan Ly, Jeremy Magland, Jeff Soules, Alison Comrie, Jennifer Guidera, Rhino Nevers, Daniel Gramling, Philip Adenekan, Ji Hyun Bak, Emily Monroe, Andrew Tritt, Oliver Rübel, Thinh Nguyen, Dimitri Yatsenko, Joshua Chu, Caleb Kemere, Samuel Garcia, Alessio Buccino, Emily Aery Jones, Lisa Giocomo, and Loren Frank. Spyglass: A Data Analysis Framework for Reproducible and Shareable Neuroscience Research. Neuroscience Meeting Planner. San Diego, CA: Society for Neuroscience, 2022.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "spyglass"
+name = "spyglass-neuro"
 version = "0.1.0"
 authors = [
   { name="Loren Frank", email="loren.frank@ucsf.edu" },
@@ -23,7 +23,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-keywords = ["neuroscience", "research", "electrophysiology", "reproducible", "data analysis", 
+keywords = ["neuroscience", "research", "electrophysiology", "reproducible", "data analysis",
             "spike sorting", "spikeinterface","datajoint", "nwb", "kachery", "sortingview"]
 dependencies = [
     "jupyterlab>=3.*",


### PR DESCRIPTION
Even though the person who previously had the spyglass name removed it from pypi, the rules for taking over that namespace are rather strict and cumbersome for security reasons. See [PEP-541](https://peps.python.org/pep-0541/#how-to-request-a-name-transfer)

I have changed the package name to `spyglass-neuro` for pip and conda and added the instructions. @khl02007 and I have tested the installs under this name and importing spyglass still works.