### PR TITLE
modify datatype of filter_coeff to longblob

### DIFF
--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -26,7 +26,7 @@ class FirFilter(dj.Manual):
     filter_high_stop = 0: float        # highest frequency for stop band of high frequency side of filter
     filter_comments: varchar(2000)     # comments about the filter
     filter_band_edges: blob            # numpy array containing the filter bands (redundant with individual parameters)
-    filter_coeff: longblob                 # numpy array containing the filter coefficients
+    filter_coeff: longblob             # numpy array containing the filter coefficients
     """
 
     def add_filter(self, filter_name, fs, filter_type, band_edges, comments=''):


### PR DESCRIPTION
Datatype of `filter_coeff` is currently `blob`, which caps out at 64KiB. Filter coefficients can be an array upwards of 100KiB, so datatype is changed to `longblob` here to address this need.