### PR TITLE
Address issue #359 add filter_type to filterdict

### DIFF
--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -109,7 +109,7 @@ class FirFilter(dj.Manual):
             filterdict["filter_low_pass"] = band_edges[1]
             filterdict["filter_high_pass"] = band_edges[2]
             filterdict["filter_high_stop"] = band_edges[3]
-        filterdict['filter_type'] = filter_type
+        filterdict["filter_type"] = filter_type
         filterdict["filter_band_edges"] = np.asarray(band_edges)
         # create 1d array for coefficients
         filterdict["filter_coeff"] = np.array(

--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -109,7 +109,7 @@ class FirFilter(dj.Manual):
             filterdict["filter_low_pass"] = band_edges[1]
             filterdict["filter_high_pass"] = band_edges[2]
             filterdict["filter_high_stop"] = band_edges[3]
-
+        filterdict['filter_type'] = filter_type
         filterdict["filter_band_edges"] = np.asarray(band_edges)
         # create 1d array for coefficients
         filterdict["filter_coeff"] = np.array(


### PR DESCRIPTION
This PR addresses iss #359, which, in short, identified a bug in `common_ephys.FirFilter` where `filter_type` was not properly inserted into the table. This PR adds `filter_type` as an entry to the `filterdict` dictionary, which is eventually inserted into the FirFilter table on line 119. This was tested once (see `FirFilter` entry LFP 300-600 Hz with `filter_type` 'bandpass'). 