### PR TITLE
Add method to VideoFile to return absolute path based on environment variable

### DIFF
--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -242,8 +242,8 @@ class VideoFile(dj.Imported):
         nwb_video = nwbf.objects[video_info["video_file_object_id"]]
         video_filename = nwb_video.name
         # see if the file exists and is stored in the base analysis dir
-        nwb_video_file_abspath = pathlib.PurePath(
-            video_dir, pathlib.Path(video_filename)
+        nwb_video_file_abspath = pathlib.Path(
+            f"{video_dir}/{pathlib.Path(video_filename)}"
         )
         if nwb_video_file_abspath.exists():
             return nwb_video_file_abspath.as_posix()

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -249,5 +249,6 @@ class VideoFile(dj.Imported):
             return nwb_video_file_abspath.as_posix()
         else:
             raise FileNotFoundError(
-                f"video file with filename: {video_filename} does not exist in {video_dir}/"
+                f"video file with filename: {video_filename} "
+                f"does not exist in {video_dir}/"
             )

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -236,6 +236,8 @@ class VideoFile(dj.Imported):
         """
         video_dir = pathlib.Path(os.getenv("SPYGLASS_VIDEO_DIR", None))
         assert video_dir is not None, "You must set SPYGLASS_VIDEO_DIR"
+        if not video_dir.exists():
+            raise OSError("SPYGLASS_VIDEO_DIR does not exist")
         video_info = (cls & key).fetch1()
         nwb_path = Nwbfile.get_abs_path(key["nwb_file_name"])
         nwbf = get_nwb_file(nwb_path)


### PR DESCRIPTION
Currently, we get the path to the video file associated with an nwb file and epoch using the external_file field of the video object in the NWB file. This breaks when a user moves a video file from it's original location when the NWB file was created. This method on the `VideoFile` table uses the `SPYGLASS_BASE_DIR` environment variable and the name of the video file, as listed in the NWB file, to look for the video file in a video folder (in our case `/stelmo/nwb/video/`). It returns a FIleNotFound error if the video file is not in the directory specified by `SPYGLASS_BASE_DIR/video`. 

Open to any feedback others may have. @acomrie may have further rationale for why this is necessary.