### PR TITLE
dj_config handle second argument (one-line fix)

### DIFF
--- a/config/dj_config.py
+++ b/config/dj_config.py
@@ -95,4 +95,4 @@ def set_configuration(user_name: str, file_name: str = None):
 
 
 if __name__ == "__main__":
-    set_configuration(sys.argv[1])
+    set_configuration(sys.argv[1], sys.argv[2])

--- a/config/dj_config.py
+++ b/config/dj_config.py
@@ -95,4 +95,4 @@ def set_configuration(user_name: str, file_name: str = None):
 
 
 if __name__ == "__main__":
-    set_configuration(sys.argv[1], sys.argv[2])
+    set_configuration(*sys.argv[1:])


### PR DESCRIPTION
In dj_config.py, the second argument should be the datajoint_config.yml file, but that doesn't get passed through.

This is a one-line modification to fix that.