### PR TITLE
pyfftw and ghostipy versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - ipympl
   - tqdm
   - nb_conda
-  - pyfftw==0.12.0  # used by ghostipy. install from conda-forge so that it works on Mac ARM processors
+  - pyfftw<=0.12.0  # used by ghostipy. install from conda-forge so that it works on Mac ARM processors
   - pip:
     - pubnub<6.4.0
     - git+https://github.com/SpikeInterface/spikeinterface.git

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
     - pynwb>=2.2.0,<3
     - hdmf>=3.4.6
     - datajoint>=0.13.6
-    - ghostipy==0.2.1
+    - ghostipy
     - pymysql>=1.0.*
     - sortingview>=0.8
     - figurl-jupyter

--- a/environment.yml
+++ b/environment.yml
@@ -22,14 +22,14 @@ dependencies:
   - ipympl
   - tqdm
   - nb_conda
-  - pyfftw  # used by ghostipy. install from conda-forge so that it works on Mac ARM processors
+  - pyfftw==0.12.0  # used by ghostipy. install from conda-forge so that it works on Mac ARM processors
   - pip:
     - pubnub<6.4.0
     - git+https://github.com/SpikeInterface/spikeinterface.git
     - pynwb>=2.2.0,<3
     - hdmf>=3.4.6
     - datajoint>=0.13.6
-    - ghostipy
+    - ghostipy==0.2.1
     - pymysql>=1.0.*
     - sortingview>=0.8
     - figurl-jupyter


### PR DESCRIPTION
the most recent versions of pyfftw and ghostipy don't work. during LFP filtering they give an error about no specifying the number of threads. maybe this can be used in the future to parallelize lfp filtering.