### PR TITLE
Fix formatting and dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ channels:
 dependencies:
   - python>=3.8,<3.10
   - jupyterlab>=3.*
-  - pydotplus>=2.0.*
-  - dask>=2.30
-  - pip>=20.2.*
+  - pydotplus
+  - dask
+  - pip
   - position_tools
   - track_linearization>=2.3
   - replay_trajectory_classification
@@ -30,7 +30,7 @@ dependencies:
     - hdmf>=3.4.6
     - datajoint>=0.13.6
     - ghostipy
-    - pymysql>=1.0.*
+    - pymysql
     - sortingview>=0.11
     - figurl-jupyter
     - git+https://github.com/LorenFrankLab/ndx-franklab-novela.git

--- a/franklab_scripts/nightly_cleanup.py
+++ b/franklab_scripts/nightly_cleanup.py
@@ -6,6 +6,7 @@ import os
 import warnings
 
 import numpy as np
+
 import spyglass as nd
 from spyglass.decoding.clusterless import MarkParameters, UnitMarkParameters, UnitMarks
 
@@ -15,16 +16,11 @@ os.environ["SPIKE_SORTING_STORAGE_DIR"] = "/stelmo/nwb/spikesorting"
 
 
 # import tables so that we can call them easily
-from spyglass.common import (
-    AnalysisNwbfile,
-)
-from spyglass.spikesorting import (
-    SpikeSorting,
-)
+from spyglass.common import AnalysisNwbfile
+from spyglass.spikesorting import SpikeSorting
 
 
 def main():
-
     AnalysisNwbfile().nightly_cleanup()
     SpikeSorting().nightly_cleanup()
 

--- a/franklab_scripts/sort.py
+++ b/franklab_scripts/sort.py
@@ -5,7 +5,6 @@ import spyglass as nd
 
 
 def main():
-
     data_dir = Path(
         "/stelmo/nwb"
     )  # CHANGE ME TO THE BASE DIRECTORY FOR DATA STORAGE ON YOUR SYSTEM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ keywords = [
     "sortingview",
 ]
 dependencies = [
-    "pydotplus>=2.0.*",
-    "dask>=2.30",
+    "pydotplus",
+    "dask",
     "position_tools",
     "track_linearization>=2.3",
     "replay_trajectory_classification",
@@ -51,7 +51,7 @@ dependencies = [
     "pynwb>=2.2.0,<3",
     "hdmf>=3.4.6",
     "datajoint>=0.13.6",
-    "pymysql>=1.0.*",
+    "pymysql",
     "sortingview>=0.11",
     "pyyaml",
     "click",

--- a/src/spyglass/cli/cli.py
+++ b/src/spyglass/cli/cli.py
@@ -360,7 +360,7 @@ def list_spike_sorter_parameters():
 
 sample_spike_sorting_key = dict(
     sample_spike_sorting_recording_selection_key,
-    **{"artifact_params_name": "default", "sorter_params_name": "default"}
+    **{"artifact_params_name": "default", "sorter_params_name": "default"},
 )
 
 
@@ -388,7 +388,7 @@ def run_spike_sorting(yaml_file_name: Union[str, None]):
 
     artifact_key = dict(
         spike_sorting_recording_key,
-        **{"artifact_params_name": x["artifact_params_name"]}
+        **{"artifact_params_name": x["artifact_params_name"]},
     )
     nds.ArtifactDetectionSelection.insert1(artifact_key, skip_duplicates=True)
     nds.ArtifactDetection.populate(
@@ -409,7 +409,7 @@ def run_spike_sorting(yaml_file_name: Union[str, None]):
             "sorter": sorter,
             "sorter_params_name": sorter_params_name,
             "artifact_removed_interval_list_name": artifact_removed_interval_list_name,
-        }
+        },
     )
 
     nds.SpikeSortingSelection.insert1(sorting_key, skip_duplicates=True)

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -187,7 +187,6 @@ class IntervalPositionInfo(dj.Computed):
         upsampling_sampling_rate,
         upsampling_interpolation_method,
     ):
-
         CM_TO_METERS = 100
 
         # Get spatial series properties

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -142,7 +142,7 @@ class SessionGroup(dj.Manual):
         session_group_name: str,
         session_group_description: str,
         *,
-        skip_duplicates: bool = False
+        skip_duplicates: bool = False,
     ):
         SessionGroup.insert1(
             {

--- a/src/spyglass/common/nwb_helper_fn.py
+++ b/src/spyglass/common/nwb_helper_fn.py
@@ -295,7 +295,6 @@ def get_all_spatial_series(nwbf, verbose=False):
     pos_data_dict = dict()
 
     for index, orig_epoch in enumerate(sorted_order):
-
         spatial_series = list(position.spatial_series.values())[orig_epoch]
         pos_data_dict[index] = dict()
         # get the valid intervals for the position data

--- a/src/spyglass/decoding/clusterless.py
+++ b/src/spyglass/decoding/clusterless.py
@@ -448,7 +448,6 @@ class UnitMarksIndicator(dj.Computed):
 
 
 def make_default_decoding_parameters_cpu():
-
     classifier_parameters = dict(
         environments=[_DEFAULT_ENVIRONMENT],
         observation_models=None,
@@ -558,7 +557,6 @@ class MultiunitFiringRate(dj.Computed):
     """
 
     def make(self, key):
-
         marks = (UnitMarksIndicator & key).fetch_xarray()
         multiunit_spikes = (np.any(~np.isnan(marks.values), axis=1)).astype(float)
         multiunit_firing_rate = pd.DataFrame(
@@ -637,7 +635,6 @@ class MultiunitHighSynchronyEvents(dj.Computed):
     """
 
     def make(self, key):
-
         marks = (UnitMarksIndicator & key).fetch_xarray()
         multiunit_spikes = (np.any(~np.isnan(marks.values), axis=1)).astype(float)
         position_info = (IntervalPositionInfo() & key).fetch1_dataframe()
@@ -717,7 +714,6 @@ def get_data_for_multiple_epochs(
     position_info_param_name="default_decoding",
     additional_mark_keys={},
 ):
-
     data = []
     environment_labels = []
 
@@ -773,7 +769,6 @@ def populate_mark_indicators(
     mark_param_name="default",
     position_info_param_name="default_decoding",
 ):
-
     spikesorting_selection_keys = deepcopy(spikesorting_selection_keys)
     # Populate spike sorting
     SpikeSortingSelection().insert(

--- a/src/spyglass/decoding/core.py
+++ b/src/spyglass/decoding/core.py
@@ -5,7 +5,6 @@ from spyglass.common.common_interval import IntervalList, interval_list_intersec
 
 
 def get_valid_ephys_position_times_from_interval(interval_list_name, nwb_file_name):
-
     interval_valid_times = (
         IntervalList
         & {"nwb_file_name": nwb_file_name, "interval_list_name": interval_list_name}

--- a/src/spyglass/decoding/sorted_spikes.py
+++ b/src/spyglass/decoding/sorted_spikes.py
@@ -151,7 +151,6 @@ class SortedSpikesIndicator(dj.Computed):
 
 
 def make_default_decoding_parameters_cpu():
-
     classifier_parameters = dict(
         environments=[_DEFAULT_ENVIRONMENT],
         observation_models=None,

--- a/src/spyglass/decoding/visualization.py
+++ b/src/spyglass/decoding/visualization.py
@@ -283,7 +283,6 @@ def make_multi_environment_movie(
     direction_name="head_orientation",
     vmax=0.07,
 ):
-
     # Set up formatting for the movie files
     Writer = animation.writers["ffmpeg"]
     fps = sampling_frequency // video_slowdown
@@ -539,7 +538,6 @@ def create_interactive_2D_decoding_figurl(
     sampling_frequency=500,
     view_height=800,
 ):
-
     decode_view = create_2D_decode_view(
         position_time=position_info.index,
         position=position_info[position_name],

--- a/src/spyglass/decoding/visualization_1D_view.py
+++ b/src/spyglass/decoding/visualization_1D_view.py
@@ -12,7 +12,6 @@ def discretize_and_trim(series: xr.DataArray) -> xr.DataArray:
 def get_observations_per_time(
     trimmed_posterior: xr.DataArray, base_data: xr.Dataset
 ) -> np.ndarray:
-
     times, counts = np.unique(trimmed_posterior.time.values, return_counts=True)
     indexed_counts = xr.DataArray(counts, coords={"time": times})
     _, good_counts = xr.align(base_data.time, indexed_counts, join="left", fill_value=0)  # type: ignore

--- a/src/spyglass/decoding/visualization_2D_view.py
+++ b/src/spyglass/decoding/visualization_2D_view.py
@@ -90,7 +90,6 @@ def generate_linearization_function(
     y_min: float,
     y_width: float,
 ):
-
     args = {
         "location_lookup": location_lookup,
         "x_count": x_count,

--- a/src/spyglass/spikesorting/merged_sorting_extractor.py
+++ b/src/spyglass/spikesorting/merged_sorting_extractor.py
@@ -13,7 +13,6 @@ class MergedSortingExtractor(si.BaseSorting):
     def __init__(
         self, *, parent_sorting: si.BaseSorting, merge_groups: List[List[int]]
     ):
-
         # Loop through the sorting segments in the original sorting
         # and add merged versions to the new sorting
         sorting_segment_list = []

--- a/src/spyglass/spikesorting/sortingview_helper_fn.py
+++ b/src/spyglass/spikesorting/sortingview_helper_fn.py
@@ -82,7 +82,6 @@ def _create_spikesortingview_workspace(
     raster_plot_subsample_max_firing_rate=50,
     spike_amplitudes_subsample_max_firing_rate=50,
 ):
-
     workspace = sv.create_workspace(label=workspace_label)
 
     recording = si.load_extractor(recording_path)


### PR DESCRIPTION
- Black updated to a new stable version causing our linting checks to fail. This fixes the linting.
- There were invalid restrictions in the pyproject.toml on version numbers. Thanks to @dpeg22 for pointing out which ones. I removed the restrictions on the two offending dependencies: pydotplus, pymysql
- I also removed the restrictions on pip and dask. Both because I didn't see the reason for them. Hopefully will not fail in the future.