### PR TITLE
Rename final position tables and add common_position to PosMerge table

### DIFF
--- a/src/spyglass/position/__init__.py
+++ b/src/spyglass/position/__init__.py
@@ -39,9 +39,7 @@ from .position_trodes_position import (
     TrodesPosVideo,
 )
 from .position_position import (
-    PosSource,
-    IntervalPositionInfo,
-    IntervalPositionInfoSelection,
+    FinalPosition,
     PositionVideoSelection,
     PositionVideo,
 )

--- a/src/spyglass/position/position_dlc_selection.py
+++ b/src/spyglass/position/position_dlc_selection.py
@@ -123,18 +123,18 @@ class DLCPos(dj.Computed):
         )
 
         self.insert1(key)
-        from .position_position import PosSource
+        from .position_position import PosMerge
 
         key["source"] = "DLC"
         dlc_key = key.copy()
         del dlc_key["pose_eval_result"]
         key["interval_list_name"] = f"pos {key['epoch']-1} valid times"
-        valid_fields = PosSource().fetch().dtype.fields.keys()
+        valid_fields = PosMerge().fetch().dtype.fields.keys()
         entries_to_delete = [entry for entry in key.keys() if entry not in valid_fields]
         for entry in entries_to_delete:
             del key[entry]
 
-        PosSource().insert1(key=key, params=dlc_key, skip_duplicates=True)
+        PosMerge().insert1(key=key, params=dlc_key, skip_duplicates=True)
 
     def fetch_nwb(self, *attrs, **kwargs):
         return fetch_nwb(

--- a/src/spyglass/position/position_dlc_selection.py
+++ b/src/spyglass/position/position_dlc_selection.py
@@ -123,18 +123,18 @@ class DLCPos(dj.Computed):
         )
 
         self.insert1(key)
-        from .position_position import PosMerge
+        from .position_position import FinalPosition
 
         key["source"] = "DLC"
         dlc_key = key.copy()
         del dlc_key["pose_eval_result"]
         key["interval_list_name"] = f"pos {key['epoch']-1} valid times"
-        valid_fields = PosMerge().fetch().dtype.fields.keys()
+        valid_fields = FinalPosition().fetch().dtype.fields.keys()
         entries_to_delete = [entry for entry in key.keys() if entry not in valid_fields]
         for entry in entries_to_delete:
             del key[entry]
 
-        PosMerge().insert1(key=key, params=dlc_key, skip_duplicates=True)
+        FinalPosition().insert1(key=key, params=dlc_key, skip_duplicates=True)
 
     def fetch_nwb(self, *attrs, **kwargs):
         return fetch_nwb(

--- a/src/spyglass/position/position_position.py
+++ b/src/spyglass/position/position_position.py
@@ -180,7 +180,6 @@ class FinalPosition(dj.Manual):
         )
 
     def fetch1_dataframe(self):
-
         source = self.fetch1("source")
         part_table = getattr(self, f"{source}Pos") & self
         nwb_data = part_table.fetch_nwb()[0]
@@ -190,7 +189,6 @@ class FinalPosition(dj.Manual):
             name="time",
         )
         if "video_frame_ind" in nwb_data["velocity"].fields["time_series"].keys():
-
             COLUMNS = [
                 "video_frame_ind",
                 "position_x",

--- a/src/spyglass/position/position_trodes_position.py
+++ b/src/spyglass/position/position_trodes_position.py
@@ -194,15 +194,15 @@ class TrodesPos(dj.Computed):
         AnalysisNwbfile().add(key["nwb_file_name"], key["analysis_file_name"])
 
         self.insert1(key)
-        from .position_position import PosSource
+        from .position_position import PosMerge
 
         key["source"] = "Trodes"
         trodes_key = key.copy()
-        valid_fields = PosSource().fetch().dtype.fields.keys()
+        valid_fields = PosMerge().fetch().dtype.fields.keys()
         entries_to_delete = [entry for entry in key.keys() if entry not in valid_fields]
         for entry in entries_to_delete:
             del key[entry]
-        PosSource().insert1(key=key, params=trodes_key, skip_duplicates=True)
+        PosMerge().insert1(key=key, params=trodes_key, skip_duplicates=True)
 
     @staticmethod
     def calculate_position_info_from_spatial_series(

--- a/src/spyglass/position/position_trodes_position.py
+++ b/src/spyglass/position/position_trodes_position.py
@@ -194,15 +194,15 @@ class TrodesPos(dj.Computed):
         AnalysisNwbfile().add(key["nwb_file_name"], key["analysis_file_name"])
 
         self.insert1(key)
-        from .position_position import PosMerge
+        from .position_position import FinalPosition
 
         key["source"] = "Trodes"
         trodes_key = key.copy()
-        valid_fields = PosMerge().fetch().dtype.fields.keys()
+        valid_fields = FinalPosition().fetch().dtype.fields.keys()
         entries_to_delete = [entry for entry in key.keys() if entry not in valid_fields]
         for entry in entries_to_delete:
             del key[entry]
-        PosMerge().insert1(key=key, params=trodes_key, skip_duplicates=True)
+        FinalPosition().insert1(key=key, params=trodes_key, skip_duplicates=True)
 
     @staticmethod
     def calculate_position_info_from_spatial_series(


### PR DESCRIPTION
This is an option for modifying the table names in order to reduce confusion.
Addresses: https://github.com/LorenFrankLab/spyglass/pull/367#discussion_r1105259668

It changes
```python
position.IntervalPositionInfoSelection -> position.PositionOutputSelection
position.IntervalPositionInfo -> position.PositionOutput
position.PosSource -> position.PosMerge
```

It also adds an import for IntervalPositionInfo from the common_position schema
```python
from ..common.common_position import IntervalPositionInfo as CommonIntervalPositionInfo
```