### PR TITLE
Handle Intan capitalization specially

### DIFF
--- a/src/spyglass/common/common_device.py
+++ b/src/spyglass/common/common_device.py
@@ -67,10 +67,14 @@ class DataAcquisitionDevice(dj.Manual):
             # transform amplifier value. check if value is in DB. if not, prompt user to add an entry or cancel.
             amplifier = cls._add_amplifier(nwb_device_obj.amplifier)
 
+            # standardize how Intan is represented in the database
+            if adc_circuit.title() == "Intan":
+                adc_circuit = "Intan"
+
             new_device_dict["data_acquisition_device_name"] = name
             new_device_dict["data_acquisition_device_system"] = system
-            new_device_dict["data_acquisition_device_amplifier"] = amplifier.title()
-            new_device_dict["adc_circuit"] = adc_circuit.title()
+            new_device_dict["data_acquisition_device_amplifier"] = amplifier
+            new_device_dict["adc_circuit"] = adc_circuit
 
             cls._add_device(new_device_dict)
 
@@ -239,6 +243,10 @@ class DataAcquisitionDevice(dj.Manual):
         amplifier : str
             The amplifier value that was added to the database.
         """
+        # standardize how Intan is represented in the database
+        if amplifier.title() == "Intan":
+            amplifier = "Intan"
+
         all_values = DataAcquisitionDeviceAmplifier.fetch(
             "data_acquisition_device_amplifier"
         ).tolist()


### PR DESCRIPTION
Update on #430. Based on discussion on Slack, @khl02007 and I think it would be best not to auto-capitalize every amplifier and adc_circuit. This changes the code so that "intan" vs "Intan" is handled specially given that Frank Lab NWB files have both. 