### PR TITLE
Temporarily pin numpy < 1.24 to fix numba issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - dask
   - pip
   - position_tools
+  - numpy<1.24
   - track_linearization>=2.3
   - replay_trajectory_classification
   - ripple_detection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "seaborn",
     "skan",
     "bottleneck",
+    "numpy<1.24",
     "ipympl",
     "tqdm",
     "pubnub<6.4.0",

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -19,8 +19,6 @@ from position_tools import (
     interpolate_nan,
 )
 from position_tools.core import gaussian_smooth
-from skan import skeleton_to_csgraph
-from skan.draw import _clean_positions_dict
 from tqdm import tqdm_notebook as tqdm
 from track_linearization import (
     get_linearized_position,
@@ -30,7 +28,7 @@ from track_linearization import (
 )
 
 from .common_behav import RawPosition, VideoFile
-from .common_interval import IntervalList
+from .common_interval import IntervalList  # noqa
 from .common_nwbfile import AnalysisNwbfile
 from ..utils.dj_helper_fn import fetch_nwb
 
@@ -954,6 +952,9 @@ class SelectFromCollection:
         return is_in_polygon
 
     def get_graph(self):
+        from skan import skeleton_to_csgraph
+        from skan.draw import _clean_positions_dict
+
         mask = self.get_polygon_mask()
         skeleton = skimage.morphology.skeletonize(mask)
         csr_graph, coordinates, _ = skeleton_to_csgraph(skeleton)

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -19,6 +19,8 @@ from position_tools import (
     interpolate_nan,
 )
 from position_tools.core import gaussian_smooth
+from skan import skeleton_to_csgraph
+from skan.draw import _clean_positions_dict
 from tqdm import tqdm_notebook as tqdm
 from track_linearization import (
     get_linearized_position,
@@ -28,7 +30,7 @@ from track_linearization import (
 )
 
 from .common_behav import RawPosition, VideoFile
-from .common_interval import IntervalList  # noqa
+from .common_interval import IntervalList
 from .common_nwbfile import AnalysisNwbfile
 from ..utils.dj_helper_fn import fetch_nwb
 
@@ -952,9 +954,6 @@ class SelectFromCollection:
         return is_in_polygon
 
     def get_graph(self):
-        from skan import skeleton_to_csgraph
-        from skan.draw import _clean_positions_dict
-
         mask = self.get_polygon_mask()
         skeleton = skimage.morphology.skeletonize(mask)
         csr_graph, coordinates, _ = skeleton_to_csgraph(skeleton)


### PR DESCRIPTION
Numba can't handle the latest version of numpy (numpy version 1.24, see https://github.com/numba/numba/issues/8615) 

This fixes issue #461. Also may fix @MichaelCoulter's issue #455.