### PR TITLE
Add codespell - config, workflow, fixed some typos and unified/removed a few imports

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,19 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v1

--- a/franklab_scripts/alter_tables.py
+++ b/franklab_scripts/alter_tables.py
@@ -35,7 +35,7 @@ def update_cls(cls):
             # some enum definitions will prompt alter() even when there has not been a change
             # NOTE: datajoint does not allow primary keys to be altered yet
             # this includes changing the length of a varchar primary key
-            # (other tables use this primary key, so constraints would probably have to be removed and readded)
+            # (other tables use this primary key, so constraints would probably have to be removed and re-added)
             cls.alter()
         except Exception as e:
             print("ERROR:", e)

--- a/franklab_scripts/nightly_cleanup.py
+++ b/franklab_scripts/nightly_cleanup.py
@@ -7,7 +7,6 @@ import warnings
 
 import numpy as np
 
-import spyglass as nd
 from spyglass.decoding.clusterless import MarkParameters, UnitMarkParameters, UnitMarks
 
 warnings.simplefilter("ignore", category=DeprecationWarning)

--- a/franklab_scripts/sort.py
+++ b/franklab_scripts/sort.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-import spyglass as nd
+import spyglass as sg
 
 
 def main():
@@ -14,10 +14,10 @@ def main():
     os.environ["SPIKE_SORTING_STORAGE_DIR"] = str(data_dir / "spikesorting")
 
     # session_id = 'jaq_01'
-    # nwb_file_name = (nd.common.Session() & {'session_id': session_id}).fetch1('nwb_file_name')
+    # nwb_file_name = (sg.common.Session() & {'session_id': session_id}).fetch1('nwb_file_name')
     nwb_file_name = "beans20190718-trim_.nwb"
 
-    nd.common.SpikeSorting().populate()
+    sg.common.SpikeSorting().populate()
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,8 @@ spyglass_cli = "spyglass.cli:cli"
 
 [tool.black]
 # line-length = 120
+
+[tool.codespell]
+skip = '.git,*.pdf,*.svg'
+#
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,5 @@ spyglass_cli = "spyglass.cli:cli"
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,*.ipynb'
-#
-# ignore-words-list = ''
+# Nevers - name in Citation
+ignore-words-list = 'nevers'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,6 @@ spyglass_cli = "spyglass.cli:cli"
 # line-length = 120
 
 [tool.codespell]
-skip = '.git,*.pdf,*.svg'
+skip = '.git,*.pdf,*.svg,*.ipynb'
 #
 # ignore-words-list = ''

--- a/src/spyglass/cli/cli.py
+++ b/src/spyglass/cli/cli.py
@@ -416,7 +416,7 @@ def run_spike_sorting(yaml_file_name: Union[str, None]):
     nds.SpikeSorting.populate([(nds.SpikeSortingSelection & sorting_key).proj()])
 
 
-@click.command(help="List spike sortings for a session.")
+@click.command(help="List spike sorting for a session.")
 @click.argument("nwb_file_name")
 def list_spike_sortings(nwb_file_name: str):
     import spyglass.spikesorting as nds

--- a/src/spyglass/cli/cli.py
+++ b/src/spyglass/cli/cli.py
@@ -14,9 +14,9 @@ def cli():
 )
 @click.argument("nwb_file_name")
 def insert_session(nwb_file_name: str):
-    import spyglass as nd
+    import spyglass as sg
 
-    nd.insert_sessions(nwb_file_name)
+    sg.insert_sessions(nwb_file_name)
 
 
 @click.command(help="List all sessions")

--- a/src/spyglass/common/common_lab.py
+++ b/src/spyglass/common/common_lab.py
@@ -106,7 +106,7 @@ class LabTeam(dj.Manual):
             if not len(query):
                 print(
                     f"Please add the Google user ID for {team_member} in the LabMember.LabMemberInfo table "
-                    "if you want to give them permission to manually curate sortings by this team."
+                    "if you want to give them permission to manually curate sorting by this team."
                 )
             labteammember_dict = dict()
             labteammember_dict["team_name"] = team_name

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -133,7 +133,7 @@ class AnalysisNwbfile(dj.Manual):
     -> Nwbfile                                     # name of the parent NWB file. Used for naming and metadata copy
     analysis_file_abs_path: filepath@analysis      # the full path to the file
     analysis_file_description = "": varchar(2000)  # an optional description of this analysis
-    analysis_parameters = NULL: blob               # additional relevant parmeters. Currently used only for analyses
+    analysis_parameters = NULL: blob               # additional relevant parameters. Currently used only for analyses
                                                    # that span multiple NWB files
     INDEX (analysis_file_abs_path)
     """

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -647,7 +647,7 @@ class NodePicker:
 @schema
 class PositionVideo(dj.Computed):
     """Creates a video of the computed head position and orientation as well as
-    the original LED positions overlayed on the video of the animal.
+    the original LED positions overlaid on the video of the animal.
 
     Use for debugging the effect of position extraction parameters."""
 

--- a/src/spyglass/figurl_views/SpikeSortingView.py
+++ b/src/spyglass/figurl_views/SpikeSortingView.py
@@ -12,7 +12,7 @@ schema = dj.schema("figurl_view_spike_sorting_recording")
 @schema
 class SpikeSortingView(dj.Computed):
     definition = """
-    # Schema for storing figurl views of spike sortings
+    # Schema for storing figurl views of spike sorting
     -> SpikeSorting
     ---
     figurl: varchar(10000)

--- a/src/spyglass/spikesorting/curation_figurl.py
+++ b/src/spyglass/spikesorting/curation_figurl.py
@@ -121,7 +121,7 @@ def _generate_the_figurl(
         max_num_snippets_per_segment=100,
         channel_neighborhood_size=7,
     )
-    # create a fake unit similiarity matrix (for future reference)
+    # create a fake unit similarity matrix (for future reference)
     # similarity_scores = []
     # for u1 in X.unit_ids:
     #     for u2 in X.unit_ids:

--- a/src/spyglass/spikesorting/sortingview_helper_fn.py
+++ b/src/spyglass/spikesorting/sortingview_helper_fn.py
@@ -80,7 +80,7 @@ def _generate_url(
         channel_neighborhood_size=7,
     )
 
-    # create a fake unit similiarity matrix
+    # create a fake unit similarity matrix
     # similarity_scores = []
     # for u1 in X.unit_ids:
     #     for u2 in X.unit_ids:

--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -39,7 +39,7 @@ def apply_merge_groups_to_sorting(
 class Curation(dj.Manual):
     definition = """
     # Stores each spike sorting; similar to IntervalList
-    curation_id: int # a number correponding to the index of this curation
+    curation_id: int # a number corresponding to the index of this curation
     -> SpikeSorting
     ---
     parent_curation_id=-1: int
@@ -994,7 +994,7 @@ class UnitInclusionParameters(dj.Manual):
         Parameters
         ----------
         curated_sorting_key : dict
-            key to select a set of curated sortings
+            key to select a set of curated sorting
         unit_inclusion_param_name : str
             name of a unit inclusion parameter entry
 

--- a/src/spyglass/spikesorting/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/spikesorting_recording.py
@@ -140,7 +140,7 @@ class SortGroup(dj.Manual):
                 ]
                 if (
                     omit_unitrode and len(shank_elect) == 1
-                ):  # ommit unitrodes if indicated
+                ):  # omit unitrodes if indicated
                     print(
                         f"Omitting electrode group {e_group}, shank {shank} from sort groups because unitrode."
                     )
@@ -288,7 +288,7 @@ class SortGroup(dj.Manual):
                     n_found += 1
                 else:
                     Warning(
-                        "Relative electrode locations have three coordinates; only two are currenlty supported"
+                        "Relative electrode locations have three coordinates; only two are currently supported"
                     )
         return np.ndarray.tolist(geometry)
 

--- a/src/spyglass/spikesorting/spikesorting_sorting.py
+++ b/src/spyglass/spikesorting/spikesorting_sorting.py
@@ -288,7 +288,7 @@ class SpikeSorting(dj.Computed):
         sorting_name = recording_name + "_" + str(uuid.uuid4())[0:8] + "_spikesorting"
         return sorting_name
 
-    # TODO: write a function to import sortings done outside of dj
+    # TODO: write a function to import sorting done outside of dj
 
     def _import_sorting(self, key):
         raise NotImplementedError

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -117,7 +117,7 @@ def fetch_nwb(query_expression, nwb_master, *attrs, **kwargs):
 
 
 def _get_nwb_object(objects, object_id):
-    """Retreive NWB object and try to convert to dataframe if possible"""
+    """Retrieve NWB object and try to convert to dataframe if possible"""
     try:
         return objects[object_id].to_dataframe()
     except AttributeError:


### PR DESCRIPTION
There is still `import spyglass as nd` used in .ipynb which I decided to skip for this step.   But I did "fix" it to be `import spyglass as sg` in few .py files (and removed in one where unused).

With codespell then you would guarantee to not have typos sneaked into your codebase