### PR TITLE
Fix artifact removed valid times

### DIFF
--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -441,6 +441,7 @@ def interval_from_inds(list_frames):
         interval_list.append([group[0][1], group[-1][1]])
     return np.asarray(interval_list)
 
+
 def interval_set_difference_inds(intervals1, intervals2):
     """
     e.g.

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -440,3 +440,42 @@ def interval_from_inds(list_frames):
         group = list(group)
         interval_list.append([group[0][1], group[-1][1]])
     return np.asarray(interval_list)
+
+def interval_set_difference_inds(intervals1, intervals2):
+    """
+    e.g.
+    intervals1 = [(0, 5), (8, 10)]
+    intervals2 = [(1, 2), (3, 4), (6, 9)]
+
+    result = [(0, 1), (4, 5), (9, 10)]
+
+    Parameters
+    ----------
+    intervals1 : _type_
+        _description_
+    intervals2 : _type_
+        _description_
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
+    result = []
+    i = j = 0
+    while i < len(intervals1) and j < len(intervals2):
+        if intervals1[i][1] <= intervals2[j][0]:
+            result.append(intervals1[i])
+            i += 1
+        elif intervals2[j][1] <= intervals1[i][0]:
+            j += 1
+        else:
+            if intervals1[i][0] < intervals2[j][0]:
+                result.append((intervals1[i][0], intervals2[j][0]))
+            if intervals1[i][1] > intervals2[j][1]:
+                intervals1[i] = (intervals2[j][1], intervals1[i][1])
+                j += 1
+            else:
+                i += 1
+    result += intervals1[i:]
+    return result

--- a/src/spyglass/spikesorting/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/spikesorting_artifact.py
@@ -12,7 +12,7 @@ from ..common.common_interval import (
     IntervalList,
     _union_concat,
     interval_from_inds,
-    interval_list_intersect,
+    interval_set_difference_inds,
 )
 from ..utils.nwb_helper_fn import get_valid_intervals
 from .spikesorting_recording import SpikeSortingRecording
@@ -255,12 +255,17 @@ def _get_artifact_times(
         ]
     artifact_intervals_s = reduce(_union_concat, artifact_intervals_s)
 
-    valid_intervals = get_valid_intervals(
-        valid_timestamps, recording.get_sampling_frequency(), 1.5, 0.000001
+    artifact_intervals_new = []
+    for artifact_interval_s in artifact_intervals_s:
+        artifact_intervals_new.append((np.searchsorted(valid_timestamps, artifact_interval_s[0]),np.searchsorted(valid_timestamps, artifact_interval_s[1])))
+
+    artifact_removed_valid_times_ind = interval_set_difference_inds(
+        np.array((0, len(valid_timestamps))), artifact_intervals_new
     )
-    artifact_removed_valid_times = interval_list_intersect(
-        valid_intervals, artifact_intervals_s
-    )
+
+    artifact_removed_valid_times = []
+    for i in artifact_removed_valid_times_ind:
+        artifact_removed_valid_times.append((valid_timestamps[i[0]], valid_timestamps[i[1]]))
 
     return artifact_removed_valid_times, artifact_intervals_s
 

--- a/src/spyglass/spikesorting/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/spikesorting_artifact.py
@@ -257,15 +257,22 @@ def _get_artifact_times(
 
     artifact_intervals_new = []
     for artifact_interval_s in artifact_intervals_s:
-        artifact_intervals_new.append((np.searchsorted(valid_timestamps, artifact_interval_s[0]),np.searchsorted(valid_timestamps, artifact_interval_s[1])))
+        artifact_intervals_new.append(
+            (
+                np.searchsorted(valid_timestamps, artifact_interval_s[0]),
+                np.searchsorted(valid_timestamps, artifact_interval_s[1]),
+            )
+        )
 
     artifact_removed_valid_times_ind = interval_set_difference_inds(
-        np.array((0, len(valid_timestamps))), artifact_intervals_new
+        [(0, len(valid_timestamps))], artifact_intervals_new
     )
 
     artifact_removed_valid_times = []
     for i in artifact_removed_valid_times_ind:
-        artifact_removed_valid_times.append((valid_timestamps[i[0]], valid_timestamps[i[1]]))
+        artifact_removed_valid_times.append(
+            (valid_timestamps[i[0]], valid_timestamps[i[1]])
+        )
 
     return artifact_removed_valid_times, artifact_intervals_s
 

--- a/src/spyglass/spikesorting/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/spikesorting_artifact.py
@@ -262,12 +262,12 @@ def _get_artifact_times(
     artifact_intervals_new = []
     for artifact_interval_s in artifact_intervals_s:
         artifact_intervals_new.append(
-                np.searchsorted(valid_timestamps, artifact_interval_s)
+            np.searchsorted(valid_timestamps, artifact_interval_s)
         )
 
     # compute set difference between intervals (of indices)
     artifact_removed_valid_times_ind = interval_set_difference_inds(
-        [(0, len(valid_timestamps)-1)], artifact_intervals_new
+        [(0, len(valid_timestamps) - 1)], artifact_intervals_new
     )
 
     # convert back to seconds

--- a/tests/common/test_common_interval.py
+++ b/tests/common/test_common_interval.py
@@ -31,7 +31,7 @@ def test_interval_set_difference_inds_overlap():
     intervals1 = [(0, 5), (8, 10)]
     intervals2 = [(1, 2), (3, 4), (6, 9)]
     result = interval_set_difference_inds(intervals1, intervals2)
-    assert result == [(0, 1), (4, 5), (9, 10)]
+    assert result == [(0, 1), (2, 3), (4, 5), (9, 10)]
 
 
 def test_interval_set_difference_inds_empty_intervals1():

--- a/tests/common/test_common_interval.py
+++ b/tests/common/test_common_interval.py
@@ -1,5 +1,8 @@
 import numpy as np
-from spyglass.common.common_interval import interval_list_intersect
+from spyglass.common.common_interval import (
+    interval_list_intersect,
+    interval_set_difference_inds,
+)
 
 
 def test_interval_list_intersect1():
@@ -15,3 +18,58 @@ def test_interval_list_intersect2():
     interval_list2 = np.array([[11, 14]])
     intersection_list = interval_list_intersect(interval_list1, interval_list2)
     assert len(intersection_list) == 0
+
+
+def test_interval_set_difference_inds_no_overlap():
+    intervals1 = [(0, 5), (8, 10)]
+    intervals2 = [(5, 8)]
+    result = interval_set_difference_inds(intervals1, intervals2)
+    assert result == [(0, 5), (8, 10)]
+
+
+def test_interval_set_difference_inds_overlap():
+    intervals1 = [(0, 5), (8, 10)]
+    intervals2 = [(1, 2), (3, 4), (6, 9)]
+    result = interval_set_difference_inds(intervals1, intervals2)
+    assert result == [(0, 1), (4, 5), (9, 10)]
+
+
+def test_interval_set_difference_inds_empty_intervals1():
+    intervals1 = []
+    intervals2 = [(1, 2), (3, 4), (6, 9)]
+    result = interval_set_difference_inds(intervals1, intervals2)
+    assert result == []
+
+
+def test_interval_set_difference_inds_empty_intervals2():
+    intervals1 = [(0, 5), (8, 10)]
+    intervals2 = []
+    result = interval_set_difference_inds(intervals1, intervals2)
+    assert result == [(0, 5), (8, 10)]
+
+
+def test_interval_set_difference_inds_equal_intervals():
+    intervals1 = [(0, 5), (8, 10)]
+    intervals2 = [(0, 5), (8, 10)]
+    result = interval_set_difference_inds(intervals1, intervals2)
+    assert result == []
+
+
+def test_interval_set_difference_inds_multiple_overlaps():
+    intervals1 = [(0, 10)]
+    intervals2 = [(1, 3), (4, 6), (7, 9)]
+    result = interval_set_difference_inds(intervals1, intervals2)
+    assert result == [(0, 1), (3, 4), (6, 7), (9, 10)]
+
+
+# @pytest.mark.parametrize(
+#     "intervals1, intervals2, expected",
+#     [
+#         ([(0, 10)], [(0, 10)], []),
+#         ([(0, 5)], [(3, 7)], [(0, 3)]),
+#         ([(2, 8)], [(0, 4), (6, 10)], [(4, 6)]),
+#     ],
+# )
+# def test_interval_set_difference_inds_parametrized(intervals1, intervals2, expected):
+#     result = interval_set_difference_inds(intervals1, intervals2)
+#     assert result == expected

--- a/tests/common/test_common_interval.py
+++ b/tests/common/test_common_interval.py
@@ -60,16 +60,3 @@ def test_interval_set_difference_inds_multiple_overlaps():
     intervals2 = [(1, 3), (4, 6), (7, 9)]
     result = interval_set_difference_inds(intervals1, intervals2)
     assert result == [(0, 1), (3, 4), (6, 7), (9, 10)]
-
-
-# @pytest.mark.parametrize(
-#     "intervals1, intervals2, expected",
-#     [
-#         ([(0, 10)], [(0, 10)], []),
-#         ([(0, 5)], [(3, 7)], [(0, 3)]),
-#         ([(2, 8)], [(0, 4), (6, 10)], [(4, 6)]),
-#     ],
-# )
-# def test_interval_set_difference_inds_parametrized(intervals1, intervals2, expected):
-#     result = interval_set_difference_inds(intervals1, intervals2)
-#     assert result == expected


### PR DESCRIPTION
Previously `artifact_removed_valid_times` was the same as `artifact_times` because the code was taking the intersection between the timestamps and `artifact_times` instead of set-theoretic difference. This PR fixes that.