### PR TITLE
Fix common_filter.py little typo

### DIFF
--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -466,5 +466,5 @@ class FirFilter(dj.Manual):
             30000,
             "lowpass",
             [400, 425],
-            "standard LFP filter for 20 KHz data",
+            "standard LFP filter for 30 KHz data",
         )


### PR DESCRIPTION
Quick fix of 30 khz lfp filter description typo to say 30 khz instead of 20 khz.

Note if downstream things are using this table entry already then we might consider a manual update to the current entry within our existing FirFilter table rather than deleting and recreating standard filters.