### PR TITLE
Make fixes to spyglass-position env creation and catch centroid cases

### DIFF
--- a/environment_position.yml
+++ b/environment_position.yml
@@ -44,6 +44,7 @@ dependencies:
   - tensorflow>=2.0
   - numba>=0.48.0
   - pyfftw<=0.12.0  # used by ghostipy. install from conda-forge so that it works on Mac ARM processors
+  - pybind11 #To avoid isosplit5 build error
   - pip:
     - pubnub<6.4.0
     - mountainsort4
@@ -53,7 +54,7 @@ dependencies:
     - datajoint>=0.13.6
     - ghostipy
     - pymysql>=1.0.*
-    - sortingview>=0.8
+    - sortingview>=0.11
     - figurl-jupyter
     - git+https://github.com/LorenFrankLab/ndx-franklab-novela.git
     - pyyaml

--- a/src/spyglass/position/v1/position_dlc_centroid.py
+++ b/src/spyglass/position/v1/position_dlc_centroid.py
@@ -330,7 +330,9 @@ class DLCCentroid(dj.Computed):
                         **params["smoothing_params"],
                     )
                 else:
-                    raise KeyError("smoothing_duration needs to be passed within smoothing_params")
+                    raise KeyError(
+                        "smoothing_duration needs to be passed within smoothing_params"
+                    )
             else:
                 final_df = interp_df.copy()
             logger.logger.info("getting velocity")

--- a/src/spyglass/position/v1/position_dlc_centroid.py
+++ b/src/spyglass/position/v1/position_dlc_centroid.py
@@ -303,6 +303,9 @@ class DLCCentroid(dj.Computed):
                     interp_df = interp_pos(
                         centroid_df.copy(), nan_spans, **params["interp_params"]
                     )
+                else:
+                    logger.logger.info("no NaNs to interpolate over")
+                    interp_df = centroid_df.copy()
             else:
                 interp_df = centroid_df.copy()
             if params["smooth"]:
@@ -326,6 +329,8 @@ class DLCCentroid(dj.Computed):
                         sampling_rate=sampling_rate,
                         **params["smoothing_params"],
                     )
+                else:
+                    raise KeyError("smoothing_duration needs to be passed within smoothing_params")
             else:
                 final_df = interp_df.copy()
             logger.logger.info("getting velocity")


### PR DESCRIPTION
This PR adds PyBind11 to the list of packages installed by conda during spyglass-position environment creation. There was an error being thrown do to pybind11 not being found during isosplit5 build. This fix seems to prevent that error and allow for a clean install. It also updates the version of sortingview required to match the current spyglass environment requirements.

It also catches two cases during centroid determination in position_dlc_centroid.py where an `if` was used with no `else`.
