### PR TITLE
Rename FirFilter to FirFilterParameters

### DIFF
--- a/notebooks/02_curation.ipynb
+++ b/notebooks/02_curation.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -105,7 +106,7 @@
     "    LFP,\n",
     "    LFPBandSelection,\n",
     "    LFPBand,\n",
-    "    FirFilter,\n",
+    "    FirFilterParameters,\n",
     "    IntervalList,\n",
     "    Lab,\n",
     "    LabMember,\n",
@@ -168,6 +169,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -409,6 +411,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -416,6 +419,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -433,6 +437,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/notebooks/03_lfp.ipynb
+++ b/notebooks/03_lfp.ipynb
@@ -35,7 +35,7 @@
     "    Electrode,\n",
     "    Raw,\n",
     "    SampleCount,\n",
-    "    FirFilter,\n",
+    "    FirFilterParameters,\n",
     "    IntervalList,\n",
     "    Lab,\n",
     "    LabMember,\n",
@@ -115,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FirFilter().create_standard_filters()\n"
+    "FirFilterParameters().create_standard_filters()\n"
    ]
   },
   {
@@ -181,7 +181,7 @@
     "You might need to run<br>\n",
     "(IntervalList & {\"nwb_file_name\": nwb_file_name}) <br>\n",
     "    to see the list of intervals and similarly<br>\n",
-    "FIRFilter() <br>\n",
+    "FirFilterParameters() <br>\n",
     "    to see the list of defined filters"
    ]
   },
@@ -264,7 +264,7 @@
     "    \"lfp_sampling_rate\"\n",
     ")\n",
     "filter_name = \"Theta 5-11 Hz\"\n",
-    "FirFilter().add_filter(\n",
+    "FirFilterParameters().add_filter(\n",
     "    filter_name,\n",
     "    lfp_sampling_rate,\n",
     "    \"bandpass\",\n",

--- a/src/spyglass/common/__init__.py
+++ b/src/spyglass/common/__init__.py
@@ -22,7 +22,7 @@ from .common_ephys import (
     Raw,
     SampleCount,
 )
-from .common_filter import FirFilter
+from .common_filter import FirFilterParameters
 from .common_interval import (
     IntervalList,
     interval_list_censor,

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pynwb
 
 from .common_device import Probe  # noqa: F401
-from .common_filter import FirFilter
+from .common_filter import FirFilterParameters
 from .common_interval import (
     IntervalList,
     interval_list_censor,  # noqa: F401
@@ -362,7 +362,7 @@ class LFP(dj.Imported):
     -> LFPSelection
     ---
     -> IntervalList             # the valid intervals for the data
-    -> FirFilter                # the filter used for the data
+    -> FirFilterParameters                # the filter used for the data
     -> AnalysisNwbfile          # the name of the nwb file with the lfp data
     lfp_object_id: varchar(40)  # the NWB object ID for loading this object from the file
     lfp_sampling_rate: float    # the sampling rate, in HZ
@@ -399,7 +399,7 @@ class LFP(dj.Imported):
 
         # get the LFP filter that matches the raw data
         filter = (
-            FirFilter()
+            FirFilterParameters()
             & {"filter_name": "LFP 0-400 Hz"}
             & {"filter_sampling_rate": sampling_rate}
         ).fetch(as_dict=True)
@@ -422,7 +422,7 @@ class LFP(dj.Imported):
         lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
 
         lfp_file_abspath = AnalysisNwbfile().get_abs_path(lfp_file_name)
-        lfp_object_id, timestamp_interval = FirFilter().filter_data_nwb(
+        lfp_object_id, timestamp_interval = FirFilterParameters().filter_data_nwb(
             lfp_file_abspath,
             rawdata,
             filter_coeff,
@@ -481,7 +481,7 @@ class LFP(dj.Imported):
 class LFPBandSelection(dj.Manual):
     definition = """
     -> LFP
-    -> FirFilter                   # the filter to use for the data
+    -> FirFilterParameters                   # the filter to use for the data
     -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
     lfp_band_sampling_rate: int    # the sampling rate for this band
     ---
@@ -512,7 +512,7 @@ class LFPBandSelection(dj.Manual):
         in the electrode_list.
         :param nwb_file_name: string - the name of the nwb file for the desired session
         :param electrode_list: list of LFP electrodes to be filtered
-        :param filter_name: the name of the filter (from the FirFilter schema)
+        :param filter_name: the name of the filter (from the FirFilterParameters schema)
         :param interval_name: the name of the interval list (from the IntervalList schema)
         :param reference_electrode_list: A single electrode id corresponding to the reference to use for all
         electrodes or a list with one element per entry in the electrode_list
@@ -539,13 +539,13 @@ class LFPBandSelection(dj.Manual):
                 f"samping rate {lfp_sampling_rate}"
             )
         # filter
-        query = FirFilter() & {
+        query = FirFilterParameters() & {
             "filter_name": filter_name,
             "filter_sampling_rate": lfp_sampling_rate,
         }
         if not query:
             raise ValueError(
-                f"filter {filter_name}, sampling rate {lfp_sampling_rate} is not in the FirFilter table"
+                f"filter {filter_name}, sampling rate {lfp_sampling_rate} is not in the FirFilterParameters table"
             )
         # interval_list
         query = IntervalList() & {
@@ -699,14 +699,14 @@ class LFPBand(dj.Computed):
 
         # get the LFP filter that matches the raw data
         filter = (
-            FirFilter()
+            FirFilterParameters()
             & {"filter_name": filter_name}
             & {"filter_sampling_rate": filter_sampling_rate}
         ).fetch(as_dict=True)
         if len(filter) == 0:
             raise ValueError(
                 f"Filter {filter_name} and sampling_rate {lfp_band_sampling_rate} does not exit in the "
-                "FirFilter table"
+                "FirFilterParameters table"
             )
 
         filter_coeff = filter[0]["filter_coeff"]
@@ -720,7 +720,7 @@ class LFPBand(dj.Computed):
         lfp_band_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
         lfp_band_file_abspath = AnalysisNwbfile().get_abs_path(lfp_band_file_name)
         # filter the data and write to an the nwb file
-        filtered_data, new_timestamps = FirFilter().filter_data(
+        filtered_data, new_timestamps = FirFilterParameters().filter_data(
             timestamps,
             lfp_data,
             filter_coeff,

--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -27,7 +27,7 @@ def _import_ghostipy():
 
 
 @schema
-class FirFilter(dj.Manual):
+class FirFilterParameters(dj.Manual):
     definition = """
     filter_name: varchar(80)           # descriptive name of this filter
     filter_sampling_rate: int          # sampling rate for this filter

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -10,7 +10,7 @@ import pynwb
 import scipy.stats as stats
 
 from spyglass.common.common_ephys import Electrode, Raw
-from spyglass.common.common_filter import FirFilter
+from spyglass.common.common_filter import FirFilterParameters
 from spyglass.common.common_interval import interval_list_censor  # noqa: F401
 from spyglass.common.common_interval import (
     IntervalList,
@@ -80,7 +80,7 @@ class LFPSelection(dj.Manual):
     definition = """
      -> LFPElectrodeGroup
      -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
-     -> FirFilter
+     -> FirFilterParameters
      """
 
 
@@ -131,7 +131,7 @@ class LFP(dj.Computed):
 
         # get the LFP filter that matches the raw data
         filter = (
-            FirFilter()
+            FirFilterParameters()
             & {"filter_name": key["filter_name"]}
             & {"filter_sampling_rate": sampling_rate}
         ).fetch(as_dict=True)
@@ -154,7 +154,7 @@ class LFP(dj.Computed):
         lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
 
         lfp_file_abspath = AnalysisNwbfile().get_abs_path(lfp_file_name)
-        lfp_object_id, timestamp_interval = FirFilter().filter_data_nwb(
+        lfp_object_id, timestamp_interval = FirFilterParameters().filter_data_nwb(
             lfp_file_abspath,
             rawdata,
             filter_coeff,
@@ -615,7 +615,7 @@ def _check_artifact_thresholds(
 class LFPBandSelection(dj.Manual):
     definition = """
     -> LFPOutput
-    -> FirFilter                   # the filter to use for the data
+    -> FirFilterParameters                   # the filter to use for the data
     -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
     lfp_band_sampling_rate: int    # the sampling rate for this band
     ---
@@ -647,7 +647,7 @@ class LFPBandSelection(dj.Manual):
         :param nwb_file_name: string - the name of the nwb file for the desired session
         :param lfp_id: uuid - the uuid for the LFPOutput to use
         :param electrode_list: list of LFP electrodes (electrode ids) to be filtered
-        :param filter_name: the name of the filter (from the FirFilter schema)
+        :param filter_name: the name of the filter (from the FirFilterParameters schema)
         :param interval_name: the name of the interval list (from the IntervalList schema)
         :param reference_electrode_list: A single electrode id corresponding to the reference to use for all
         electrodes or a list with one element per entry in the electrode_list
@@ -676,13 +676,13 @@ class LFPBandSelection(dj.Manual):
                 f"samping rate {lfp_sampling_rate}"
             )
         # filter
-        query = FirFilter() & {
+        query = FirFilterParameters() & {
             "filter_name": filter_name,
             "filter_sampling_rate": lfp_sampling_rate,
         }
         if not query:
             raise ValueError(
-                f"filter {filter_name}, sampling rate {lfp_sampling_rate} is not in the FirFilter table"
+                f"filter {filter_name}, sampling rate {lfp_sampling_rate} is not in the FirFilterParameters table"
             )
         # interval_list
         query = IntervalList() & {
@@ -840,14 +840,14 @@ class LFPBand(dj.Computed):
 
         # get the LFP filter that matches the raw data
         filter = (
-            FirFilter()
+            FirFilterParameters()
             & {"filter_name": filter_name}
             & {"filter_sampling_rate": filter_sampling_rate}
         ).fetch(as_dict=True)
         if len(filter) == 0:
             raise ValueError(
                 f"Filter {filter_name} and sampling_rate {lfp_band_sampling_rate} does not exit in the "
-                "FirFilter table"
+                "FirFilterParameters table"
             )
 
         filter_coeff = filter[0]["filter_coeff"]
@@ -861,7 +861,7 @@ class LFPBand(dj.Computed):
         lfp_band_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
         lfp_band_file_abspath = AnalysisNwbfile().get_abs_path(lfp_band_file_name)
         # filter the data and write to an the nwb file
-        filtered_data, new_timestamps = FirFilter().filter_data(
+        filtered_data, new_timestamps = FirFilterParameters().filter_data(
             timestamps,
             lfp_data,
             filter_coeff,


### PR DESCRIPTION
See discussion in https://github.com/LorenFrankLab/spyglass/issues/488

I have renamed the FirFilter table to FirFilterParameters in the MySQL database a few minutes ago. This PR updates the spyglass code to use the new table name. Running the old code may create a new FirFilter table (old name), but it should not get populated. I will keep an eye on the database to see if one gets created and drop the table to avoid future confusion.