### PR TITLE
Update version and changelog for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.4.0 (May 22, 2023)
+- Updated call to `spikeinterface.preprocessing.whiten` to use dtype np.float16. #446,
+- Updated default spike sorting metric parameters. #447
+- Updated whitening to be compatible with recent changes in spikeinterface when using mountainsort. #449
+- Moved LFP pipeline to `src/spyglass/lfp/v1` and addressed related usability issues. #468, #478, #482, #484, #504
+- Removed whiten parameter for clusterless thresholder. #454
+- Added plot to plot all DIO events in a session. #457
+- Added file sharing functionality through kachery_cloud. #458, #460
+- Pinned numpy version to `numpy<1.24`
+- Added scripts to add guests and collaborators as users. #463
+- Cleaned up installation instructions in repo README. #467
+- Added checks in decoding visualization to ensure time dimensions are the correct length.
+- Fixed artifact removed valid times. #472
+- Added codespell workflow for spell checking and fixed typos. #471
+- Updated LFP code to save LFP as `pynwb.ecephys.LFP` type. #475
+- Added artifact detection to LFP pipeline. #473
+- Replaced calls to `spikeinterface.sorters.get_default_params` with `spikeinterface.sorters.get_default_sorter_params`. #486
+- Updated position pipeline and added functionality to handle pose estimation through DeepLabCut. #367, #505
+- Updated `environment_position.yml`. #502
+- Renamed `FirFilter` class to `FirFilterParameters`. #512
+
 # 0.3.4 (March 30, 2023)
 - Fixed error in spike sorting pipeline referencing the "probe_type" column which is no longer accessible from the `Electrode` table. #437
 - Fixed error when inserting an NWB file that does not have a probe manufacturer. #433, #436

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,6 @@ authors:
 - family-names: "Frank"
   given-names: "Loren"
 title: "spyglass"
-version: 0.3.4
-date-released: 2023-03-30
+version: 0.4.0
+date-released: 2023-05-22
 url: "https://github.com/LorenFrankLab/spyglass"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spyglass-neuro"
-version = "0.3.4"
+version = "0.4.0"
 authors = [
     { name = "Loren Frank", email = "loren.frank@ucsf.edu" },
     { name = "Kyu Hyun Lee", email = "kyuhyun.lee@ucsf.edu" },
@@ -69,11 +69,7 @@ spyglass_cli = "spyglass.cli:cli"
 "Bug Tracker" = "https://github.com/LorenFrankLab/spyglass/issues"
 
 [project.optional-dependencies]
-position = [
-    "ffmpeg",
-    "numba>=0.54",
-    "deeplabcut<2.3.0",
-]
+position = ["ffmpeg", "numba>=0.54", "deeplabcut<2.3.0"]
 [tool.black]
 # line-length = 120
 


### PR DESCRIPTION
The breaking change to the name of the `FirFilter` table in #512 means that users using an older version of spyglass will be accessing a newer, partially incompatible version of the production database. To help users using pip-installed older versions of spyglass update, we should release a new version of spyglass.