### PR TITLE
Add method to utils for deleting from merge tables

### DIFF
--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -9,6 +9,7 @@ from .nwb_helper_fn import get_nwb_file
 
 
 def _delete(tbl: dj.Table, **kwargs) -> None:
+    conn = dj.conn()
     descendants = tbl.descendants()
     rows = tbl.fetch()
     parents = []
@@ -29,7 +30,6 @@ def _delete(tbl: dj.Table, **kwargs) -> None:
         first_part, last_part = part.split(".")
         last_part = last_part.split("__")[0]
         table = f"{first_part}.{last_part}`"
-        conn = dj.conn()
         PartTable = dj.FreeTable(conn, part)
         ParentTable = dj.FreeTable(conn, table)
         keys = ((ParentTable * PartTable) & rows).fetch("KEY")

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -8,9 +8,9 @@ import numpy as np
 from .nwb_helper_fn import get_nwb_file
 
 
-def _delete(self: dj.Table, **kwargs) -> None:
-    descendants = self.descendants()
-    rows = self.fetch()
+def _delete(tbl: dj.Table, **kwargs) -> None:
+    descendants = tbl.descendants()
+    rows = tbl.fetch()
     parents = []
     parts = []
     for table in descendants:
@@ -26,9 +26,12 @@ def _delete(self: dj.Table, **kwargs) -> None:
         not in parents
     ]
     for part in parts_no_parents:
-        table = f"{part.split('.')[0]}.{part.split('.')[1].split('__')[0]}`"
-        PartTable = dj.FreeTable(dj.conn(), part)
-        ParentTable = dj.FreeTable(dj.conn(), table)
+        first_part, last_part = part.split(".")
+        last_part = last_part.split("__")[0]
+        table = f"{first_part}.{last_part}`"
+        conn = dj.conn()
+        PartTable = dj.FreeTable(conn, part)
+        ParentTable = dj.FreeTable(conn, table)
         keys = ((ParentTable * PartTable) & rows).fetch("KEY")
         for entry in keys:
             (ParentTable & entry).delete(**kwargs)


### PR DESCRIPTION
This pull request aims to address #469 I don't think this is by any means the ideal solution, but it would be good to have now that merge tables exist on the master branch and deleting will be a headache without some sort of temporary patch for this. 

I see this being used similarly to `fetch_nwb` where it is boilerplate on each table that is upstream of a merge table. 
Ideally, this would be a part of a mixin as @CBroz1 suggests in #530, and I'm open to waiting for that to happen, but figured it would be good to address this sooner rather than later.

- I have only tested this on a single table/class DLCPoseEstimation, but would be open to testing it on others with permission
- Black formatting has been applied
- I don't like the use of `self` here, and am open to naming suggestions in general, so please suggest other ideas
- I also am not a huge fan of string parsing being the base of this operation, so any other ideas are also welcome.