### PR TITLE
Use hatch, eliminate setup.py, use dynamic versioning

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+.git_archival.txt export-subst

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Test conda env and run tests
 
 on:
   push:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -76,9 +76,9 @@ jobs:
         if: matrix.package == 'archive'
         run: pip install archive/archive.tgz
       - name: Install test extras
-        run: pip install spyglass-neuro[test]
+        run: pip install spyglass[test]
       - name: Run tests
-        run: pytest --doctest-modules -v --pyargs spyglass-neuro
+        run: pytest --doctest-modules -v --pyargs spyglass
   publish:
     runs-on: ubuntu-latest
     needs: [test-package]

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.package == 'archive'
         run: pip install archive/archive.tgz
       - name: Install test extras
-        run: pip install .[test]
+        run: pip install spyglass[test]
       - name: Run tests
         run: pytest --doctest-modules -v --pyargs spyglass
   publish:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.package == 'archive'
         run: pip install archive/archive.tgz
       - name: Install test extras
-        run: pip install project-name[test]
+        run: pip install spyglass[test]
       - name: Run tests
         run: pytest --doctest-modules -v --pyargs project_name
   publish:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -1,3 +1,5 @@
+name: Test package building
+
 on:
   push:
     branches:
@@ -21,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3
+          python-version: 3.9
       - run: pip install --upgrade build twine
       - name: Build sdist and wheel
         run: python -m build
@@ -59,7 +61,7 @@ jobs:
           path: archive/
       - uses: actions/setup-python@v4
         with:
-          python-version: 3
+          python-version: 3.9
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Update pip

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -75,10 +75,10 @@ jobs:
       - name: Install archive
         if: matrix.package == 'archive'
         run: pip install archive/archive.tgz
-      - name: Install test extras
-        run: pip install spyglass[test]
-      - name: Run tests
-        run: pytest --doctest-modules -v --pyargs spyglass
+      # - name: Install test extras
+      #   run: pip install spyglass[test]
+      # - name: Run tests
+      #   run: pytest --doctest-modules -v --pyargs spyglass
   publish:
     runs-on: ubuntu-latest
     needs: [test-package]

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.package == 'archive'
         run: pip install archive/archive.tgz
       - name: Install test extras
-        run: pip install spyglass[test]
+        run: pip install .[test]
       - name: Run tests
         run: pytest --doctest-modules -v --pyargs spyglass
   publish:

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -1,0 +1,92 @@
+on:
+  push:
+    branches:
+      - main
+      - maint/*
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - main
+      - maint/*
+defaults:
+  run:
+    shell: bash
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3
+      - run: pip install --upgrade build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - run: twine check dist/*
+      - name: Upload sdist and wheel artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - name: Build git archive
+        run: mkdir archive && git archive -v -o archive/archive.tgz HEAD
+      - name: Upload git archive artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: archive
+          path: archive/
+  test-package:
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      matrix:
+        package: ['wheel', 'sdist', 'archive']
+    steps:
+      - name: Download sdist and wheel artifacts
+        if: matrix.package != 'archive'
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - name: Download git archive artifact
+        if: matrix.package == 'archive'
+        uses: actions/download-artifact@v3
+        with:
+          name: archive
+          path: archive/
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Update pip
+        run: pip install --upgrade pip
+      - name: Install wheel
+        if: matrix.package == 'wheel'
+        run: pip install dist/*.whl
+      - name: Install sdist
+        if: matrix.package == 'sdist'
+        run: pip install dist/*.tar.gz
+      - name: Install archive
+        if: matrix.package == 'archive'
+        run: pip install archive/archive.tgz
+      - name: Install test extras
+        run: pip install project-name[test]
+      - name: Run tests
+        run: pytest --doctest-modules -v --pyargs project_name
+  publish:
+    runs-on: ubuntu-latest
+    needs: [test-package]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -76,9 +76,9 @@ jobs:
         if: matrix.package == 'archive'
         run: pip install archive/archive.tgz
       - name: Install test extras
-        run: pip install spyglass[test]
+        run: pip install spyglass-neuro[test]
       - name: Run tests
-        run: pytest --doctest-modules -v --pyargs project_name
+        run: pytest --doctest-modules -v --pyargs spyglass-neuro
   publish:
     runs-on: ubuntu-latest
     needs: [test-package]

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -1,13 +1,13 @@
 on:
   push:
     branches:
-      - main
+      - master
       - maint/*
     tags:
       - "*"
   pull_request:
     branches:
-      - main
+      - master
       - maint/*
 defaults:
   run:

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ docs/src/LICENSE.md
 docs/src/notebooks/
 !docs/src/images/*png
 temp*
+
+# Version
+_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ docs = [
 source = "vcs"
 
 [tool.hatch.build.hooks.vcs]
+# this file is created/updated when the package is installed and used in
+# src/spyglass/__init__.py to set `spyglass.__version__`
 version-file = "src/spyglass/_version.py"
 
 [tool.hatch.build.targets.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,13 @@
-
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "spyglass-neuro"
-version = "0.4.0"
+description = "Neuroscience data analysis framework for reproducible research"
+readme = "README.md"
+requires-python = ">=3.8,<3.10"
+license = { file = "LICENSE" }
 authors = [
     { name = "Loren Frank", email = "loren.frank@ucsf.edu" },
     { name = "Kyu Hyun Lee", email = "kyuhyun.lee@ucsf.edu" },
@@ -10,10 +15,6 @@ authors = [
     { name = "Ryan Ly", email = "rly@lbl.gov" },
     { name = "Daniel Gramling", email = "daniel.gramling@ucsf.edu" },
 ]
-description = "Neuroscience data analysis framework for reproducible research"
-readme = "README.md"
-license = { file = "LICENSE" }
-requires-python = ">=3.8,<3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -58,13 +59,7 @@ dependencies = [
     "spikeinterface",
     "ndx_franklab_novela>=0.1.0",
 ]
-
-[build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools.packages.find]
-where = ["src"]
+dynamic = ["version"]
 
 [project.scripts]
 spyglass_cli = "spyglass.cli:cli"
@@ -75,6 +70,37 @@ spyglass_cli = "spyglass.cli:cli"
 
 [project.optional-dependencies]
 position = ["ffmpeg", "numba>=0.54", "deeplabcut<2.3.0"]
+test = [
+    "pytest",         # unit testing
+    "pytest-cov",     # code coverage
+    "kachery",        # database access
+    "kachery-client",
+    "kachery-cloud",
+]
+docs = [
+    "mike",                  # Docs versioning
+    "mkdocs",                # Docs core
+    "mkdocs-exclude",        # Docs exclude files
+    "mkdocs-exclude-search", # Docs exclude files in search
+    "mkdocs-gen-files",      # Docs API generator
+    "mkdocs-jupyter",        # Docs render notebooks
+    "mkdocs-literate-nav",   # Dynamic page list for API docs
+    "mkdocs-material",       # Docs theme
+    "mkdocstrings[python]",  # Docs API docstrings
+]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/spyglass/_version.py"
+
+[tool.hatch.build.targets.sdist]
+exclude = [".git_archival.txt"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/spyglass"]
+exclude = []
 
 [tool.black]
 line-length = 80

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup()

--- a/src/spyglass/__init__.py
+++ b/src/spyglass/__init__.py
@@ -6,9 +6,15 @@
 
 # Important to do this so that we add the franklab namespace for pynwb
 # Note: This is franklab-specific
-import ndx_franklab_novela
+try:
+    import ndx_franklab_novela
+except ImportError:
+    pass
 
-import importlib.metadata
+
 from .settings import config
 
-__version__ = importlib.metadata.version("spyglass-neuro")
+try:
+    from ._version import __version__
+except ImportError:
+    pass


### PR DESCRIPTION
This PR allows us to use dynamic versioning that relies on git tags (for example, we claim to be on version 4.0 but we have not made a tagged release for it).

It also eliminates the use of setuptools and setup.py which the python community is moving away from.

See: https://effigies.gitlab.io/posts/python-packaging-2023/