### PR TITLE
Merge table class 

### DIFF
--- a/docs/src/misc/merge_tables.md
+++ b/docs/src/misc/merge_tables.md
@@ -6,13 +6,15 @@ A pipeline may diverge when we want to process the same data in different ways.
 Merge Tables allow us to join divergent pipelines together, and unify
 downstream processing steps. For a more in depth discussion, please refer to
 [this notebook](https://github.com/ttngu207/db-programming-with-datajoint/blob/master/notebooks/pipelines_merging_design_master_part.ipynb)
-and related discussion [here](https://github.com/datajoint/datajoint-python/issues/151).
+and related discussions [here](https://github.com/datajoint/datajoint-python/issues/151)
+and [here](https://github.com/LorenFrankLab/spyglass/issues/469).
 
 **Note:** Deleting entries upstream of Merge Tables will throw errors related to
-deleteing a part entry before the master. To circumvent this, add
+deleteing a part entry before the master. To circumvent this, you can add
 `force_parts=True` to the
 [`delete` function](https://datajoint.com/docs/core/datajoint-python/0.14/api/datajoint/__init__/#datajoint.table.Table.delete)
-call.
+call, but this will leave and orphaned primary key in the master. Instead, use
+`spyglass.utils.dj_merge_tables.delete_downstream_merge` to delete master/part pairs.
 
 ## What
 

--- a/docs/src/misc/merge_tables.md
+++ b/docs/src/misc/merge_tables.md
@@ -21,7 +21,10 @@ call, but this will leave and orphaned primary key in the master. Instead, use
 A Merge Table is fundametally a master table with one part for each divergent
 pipeline. By convention...
 
-1. The master table has one primary key, `merge_id`, a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
+1. The master table has one primary key, `merge_id`, a 
+   [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier), and one
+   secondary attribute, `source`, which gives the part table name. Both are 
+   managed with the custom `insert` function of this class. 
 
 2. Each part table has inherits the final table in its respective pipeline, and
    shares the same name as this table.
@@ -33,6 +36,8 @@ from spyglass.utils.dj_merge_tables import Merge
 class MergeTable(Merge):
     definition = """
     merge_id: uuid
+    ---
+    source: varchar(32)
     """
 
     class One(dj.Part):
@@ -56,3 +61,92 @@ The Merge class in Spyglass's utils is a subclass of DataJoint's
 [Manual Table](https://datajoint.com/docs/core/design/tables/tiers/#data-entry-lookup-and-manual)
 and adds functions to make the awkwardness of part tables more manageable. These
 functions are described in the API section, under `utils.dj_merge_tables`.
+
+One quirk of these utilites is that they take restrictions as agruments, rather
+than with operators. So `Table & "field='value'"` becomes 
+`MergeTable.merge_view(restriction="field='value'"`)`. This is because 
+`merge_view` is a `Union` rather than a true Table.
+
+## Example 
+
+First, we'll import various items related to the LFP Merge Table...
+
+```python
+from spyglass.utils.dj_merge_tables import delete_downstream_merge, Merge
+from spyglass.common.common_ephys import LFP as CommonLFP  # Upstream 1
+from spyglass.lfp.lfp_merge import LFPOutput  # Merge Table
+from spyglass.lfp.v1.lfp import LFPV1  # Upstream 2
+```
+
+Merge Tables have multiple custom methods that begin with `merge`. `help` can 
+show us the docstring of each
+
+```python
+merge_methods=[d for d in dir(Merge) if d.startswith('merge')]
+help(getattr(Merge,merge_methods[-1]))
+```
+
+We'll use this example to explore populating both `LFPV1` and the `LFPOutput`
+Merge Table.
+
+```python
+nwb_file_dict = { # We'll use this later when fetching from the Merge Table
+    "nwb_file_name": "tonks20211103_.nwb",
+}
+lfpv1_key = {
+    **nwb_file_dict,
+    "lfp_electrode_group_name": "CA1_test",
+    "target_interval_list_name": "test interval2",
+    "filter_name": "LFP 0-400 Hz",
+    "filter_sampling_rate": 30000,
+}
+LFPV1.populate(lfpv1_key)  # Also populates LFPOutput
+```
+
+The Merge Table can also be populated with keys from `common_ephys.LFP`.
+
+```python
+common_keys = CommonLFP.fetch(limit=3, as_dict=True)
+LFPOutput.insert1(common_keys[0], skip_duplicates=True)
+LFPOutput.insert(common_keys[1:], skip_duplicates=True)
+```
+
+`merge_view` shows a union of the master and all part tables.
+
+```python
+LFPOutput.merge_view()
+LFPOutput.merge_view(restriction=lfpv1_key)
+```
+
+UUIDs help retain unique entries across all part tables. We can fetch NWB file
+by referencing this or other features.
+
+```python
+uuid_key = LFPOutput.fetch(limit=1, as_dict=True)[-1]
+restrict = LFPOutput & uuid_key
+result1 = restrict.fetch_nwb()
+
+nwb_key = LFPOutput.merge_restrict(nwb_file_dict).fetch(as_dict=True)[0]
+result2 = (LFPOutput & nwb_key).fetch_nwb()
+```
+
+When deleting from Merge Tables, we can either... 
+
+1. delete from the Merge Table itself with `merge_delete`_parent, deleting both
+   the master and part. 
+2. use `merge_delete_parent` to delete from the parent sources, getting rid of
+   the entries in the source table they came from.
+3. use `delete_downstream_merge` to find Merge Tables downstream and get rid 
+   full entries, avoiding orphaned master table entries. 
+
+The two latter cases can be destructive, so we include an extra layer of
+protection with `dry_run`. When true (by default), these functions return 
+a list of tables with the entries that would otherwise be deleted. 
+
+```python
+LFPOutput.merge_delete(common_keys[0])  # Delete from merge table
+LFPOutput.merge_delete_parent(restriction=nwb_file_dict, dry_run=True)
+delete_downstream_merge(
+    table=CommonLFP, restriction=common_keys[0], dry_run=True
+)
+```

--- a/docs/src/misc/merge_tables.md
+++ b/docs/src/misc/merge_tables.md
@@ -1,0 +1,56 @@
+# Merge Tables
+
+## Why
+
+A pipeline may diverge when we want to process the same data in different ways.
+Merge Tables allow us to join divergent pipelines together, and unify
+downstream processing steps. For a more in depth discussion, please refer to
+[this notebook](https://github.com/ttngu207/db-programming-with-datajoint/blob/master/notebooks/pipelines_merging_design_master_part.ipynb)
+and related discussion [here](https://github.com/datajoint/datajoint-python/issues/151).
+
+**Note:** Deleting entries upstream of Merge Tables will throw errors related to
+deleteing a part entry before the master. To circumvent this, add
+`force_parts=True` to the
+[`delete` function](https://datajoint.com/docs/core/datajoint-python/0.14/api/datajoint/__init__/#datajoint.table.Table.delete)
+call.
+
+## What
+
+A Merge Table is fundametally a master table with one part for each divergent
+pipeline. By convention...
+
+1. The master table has one primary key, `merge_id`, a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
+
+2. Each part table has inherits the final table in its respective pipeline, and
+   shares the same name as this table.
+
+```python
+from spyglass.utils.dj_merge_tables import Merge
+
+@schema
+class MergeTable(Merge):
+    definition = """
+    merge_id: uuid
+    """
+
+    class One(dj.Part):
+        definition = """
+        -> master
+        ---
+        -> One
+        """
+
+    class Two(dj.Part):
+        definition = """
+        -> master
+        ---
+        -> Two
+        """
+```
+
+## How
+
+The Merge class in Spyglass's utils is a subclass of DataJoint's
+[Manual Table](https://datajoint.com/docs/core/design/tables/tiers/#data-entry-lookup-and-manual)
+and adds functions to make the awkwardness of part tables more manageable. These
+functions are described in the API section, under `utils.dj_merge_tables`.

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -241,7 +241,8 @@ class Raw(dj.Imported):
             assert isinstance(rawdata, pynwb.ecephys.ElectricalSeries)
         except (ValueError, AssertionError):
             warnings.warn(
-                f"Unable to get acquisition object in: {nwb_file_abspath}"
+                f"Unable to get acquisition object in: {nwb_file_abspath}\n\t"
+                + f"Skipping entry in {self.full_table_name}"
             )
             return
         if rawdata.rate is not None:

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -7,29 +7,25 @@ from spyglass.common.common_interval import IntervalList  # noqa: F401
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.lfp.v1.lfp import LFPV1, ImportedLFPV1
 from spyglass.utils.dj_helper_fn import fetch_nwb
+from spyglass.utils.dj_merge_tables import Merge
 
 schema = dj.schema("lfp_merge")
 
 
 @schema
-class LFPOutput(dj.Manual):
+class LFPOutput(Merge):
     definition = """
-    lfp_id: uuid
-    ---
-    source: varchar(40)
-    version: int
-
+    merge_id: uuid
     """
 
     class LFPV1(dj.Part):
         definition = """
         -> master
-        -> LFPV1
         ---
-        -> AnalysisNwbfile
-        lfp_object_id: varchar(40)
+        -> LFPV1
         """
 
+        # TODO: modify to look upstream, make method of master
         def fetch_nwb(self, *attrs, **kwargs):
             return fetch_nwb(
                 self,

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -16,6 +16,8 @@ schema = dj.schema("lfp_merge")
 class LFPOutput(Merge):
     definition = """
     merge_id: uuid
+    ---
+    source: varchar(32)
     """
 
     class LFPV1(dj.Part):
@@ -80,7 +82,10 @@ class LFPOutput(Merge):
                 **kwargs,
             )
         else:
-            raise ValueError("Multiple sources found in Merge Table")
+            raise ValueError(
+                f"{len(part_parents)} possible sources found in Merge Table"
+                + part_parents
+            )
 
     def fetch1_dataframe(self, *attrs, **kwargs):
         nwb_lfp = self.fetch_nwb()[0]

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -68,18 +68,18 @@ class LFPOutput(Merge):
             return ImportedLFPV1 & (LFPOutput.ImportedLFP & key).fetch("KEY")
 
     def fetch_nwb(self, *attrs, **kwargs):
-        parts = self._merge_restrict_parts(
+        part_parents = self._merge_restrict_parents(
             restriction=self.restriction, return_empties=False
         )
 
-        if len(parts) == 1:
+        if len(part_parents) == 1:
             return fetch_nwb(
-                parts[0],
+                part_parents[0],
                 (AnalysisNwbfile, "analysis_file_abs_path"),
                 *attrs,
                 **kwargs,
             )
-        else:  # TODO: needs more testing!
+        else:
             raise ValueError("Multiple sources found in Merge Table")
 
     def fetch1_dataframe(self, *attrs, **kwargs):

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -32,7 +32,7 @@ class LFPOutput(Merge):
         -> ImportedLFPV1
         """
 
-    class CommonLFP(dj.Part):  # CB: Remove import above to reduce ambiguity?
+    class CommonLFP(dj.Part):
         """Table to pass-through legacy LFP"""
 
         definition = """
@@ -68,7 +68,10 @@ class LFPOutput(Merge):
             return ImportedLFPV1 & (LFPOutput.ImportedLFP & key).fetch("KEY")
 
     def fetch_nwb(self, *attrs, **kwargs):
-        parts = self._merge_restrict_parts()
+        parts = self._merge_restrict_parts(
+            restriction=self.restriction, return_empties=False
+        )
+
         if len(parts) == 1:
             return fetch_nwb(
                 parts[0],

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -28,16 +28,12 @@ class LFPOutput(Merge):
     class ImportedLFPV1(dj.Part):
         definition = """
         -> master
-        -> ImportedLFPV1
         ---
-        -> AnalysisNwbfile
-        lfp_object_id: varchar(40)
+        -> ImportedLFPV1
         """
 
-    class CommonLFP(dj.Part):
-        """
-        Table to pass-through legacy LFP
-        """
+    class CommonLFP(dj.Part):  # CB: Remove import above to reduce ambiguity?
+        """Table to pass-through legacy LFP"""
 
         definition = """
         -> master

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -196,7 +196,11 @@ class ImportedLFPV1(dj.Imported):
     lfp_sampling_rate: float        # the sampling rate, in samples/sec
     -> AnalysisNwbfile
     """
-    # TODO: add make func
+
+    def make(self, key):
+        raise NotImplementedError(
+            "For `insert`, use `allow_direct_insert=True`"
+        )
 
 
 @schema

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -140,16 +140,8 @@ class LFPV1(dj.Computed):
         # finally, we insert this into the LFP output table.
         from spyglass.lfp.lfp_merge import LFPOutput
 
-        # lfp_id = uuid.uuid1()
-        # lfp_o_key = {"lfp_id": lfp_id, "source": "LFP", "version": 1}
-        # LFPOutput.insert1(lfp_o_key)
-        #
-        # orig_key.update(lfp_o_key)
-        # del orig_key["source"]
-        # del orig_key["version"]
         orig_key["analysis_file_name"] = lfp_file_name
         orig_key["lfp_object_id"] = lfp_object_id
-        # LFPOutput.LFPV1.insert1(orig_key)
         LFPOutput.insert1(orig_key)
 
     def fetch_nwb(self, *attrs, **kwargs):

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -194,7 +194,9 @@ class ImportedLFPV1(dj.Imported):
     lfp_object_id: varchar(40)      # the NWB object ID for loading this object from the file
     ---
     lfp_sampling_rate: float        # the sampling rate, in samples/sec
+    -> AnalysisNwbfile
     """
+    # TODO: add make func
 
 
 @schema

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -22,27 +22,6 @@ MIN_LFP_INTERVAL_DURATION = 1.0  # 1 second minimum interval duration
 
 
 @schema
-class LFPSelection(dj.Manual):
-    """The user's selection of LFP data to be filtered
-
-    This table is used to select the LFP data to be filtered.  The user can select
-    the LFP data by specifying the electrode group and the interval list to be used.
-    The interval list is used to select the times from the raw data that will be
-    filtered.  The user can also specify the filter to be used.
-
-    The LFP data is filtered and downsampled to 1 KHz.  The filtered data is stored
-    in the AnalysisNwbfile table.  The valid times for the filtered data are stored
-    in the IntervalList table.
-    """
-
-    definition = """
-     -> LFPElectrodeGroup                                                  # the group of electrodes to be filtered
-     -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
-     -> FirFilterParameters                                                # the filter to be used
-     """
-
-
-@schema
 class LFPV1(dj.Computed):
     """The filtered LFP data"""
 
@@ -161,16 +140,17 @@ class LFPV1(dj.Computed):
         # finally, we insert this into the LFP output table.
         from spyglass.lfp.lfp_merge import LFPOutput
 
-        lfp_id = uuid.uuid1()
-        lfp_o_key = {"lfp_id": lfp_id, "source": "LFP", "version": 1}
-        LFPOutput.insert1(lfp_o_key)
-
-        orig_key.update(lfp_o_key)
-        del orig_key["source"]
-        del orig_key["version"]
+        # lfp_id = uuid.uuid1()
+        # lfp_o_key = {"lfp_id": lfp_id, "source": "LFP", "version": 1}
+        # LFPOutput.insert1(lfp_o_key)
+        #
+        # orig_key.update(lfp_o_key)
+        # del orig_key["source"]
+        # del orig_key["version"]
         orig_key["analysis_file_name"] = lfp_file_name
         orig_key["lfp_object_id"] = lfp_object_id
-        LFPOutput.LFPV1.insert1(orig_key)
+        # LFPOutput.LFPV1.insert1(orig_key)
+        LFPOutput.insert1(orig_key)
 
     def fetch_nwb(self, *attrs, **kwargs):
         return fetch_nwb(
@@ -182,24 +162,6 @@ class LFPV1(dj.Computed):
         return pd.DataFrame(
             nwb_lfp["lfp"].data,
             index=pd.Index(nwb_lfp["lfp"].timestamps, name="time"),
-        )
-
-
-@schema
-class ImportedLFPV1(dj.Imported):
-    definition = """
-    -> Session                      # the session to which this LFP belongs
-    -> LFPElectrodeGroup            # the group of electrodes to be filtered
-    -> IntervalList # the original set of times to be filtered
-    lfp_object_id: varchar(40)      # the NWB object ID for loading this object from the file
-    ---
-    lfp_sampling_rate: float        # the sampling rate, in samples/sec
-    -> AnalysisNwbfile
-    """
-
-    def make(self, key):
-        raise NotImplementedError(
-            "For `insert`, use `allow_direct_insert=True`"
         )
 
 
@@ -252,3 +214,42 @@ class LFPElectrodeGroup(dj.Manual):
                 LFPElectrodeGroup().LFPElectrode.insert1(
                     lfpelectdict, skip_duplicates=True
                 )
+
+
+@schema
+class LFPSelection(dj.Manual):
+    """The user's selection of LFP data to be filtered
+
+    This table is used to select the LFP data to be filtered.  The user can select
+    the LFP data by specifying the electrode group and the interval list to be used.
+    The interval list is used to select the times from the raw data that will be
+    filtered.  The user can also specify the filter to be used.
+
+    The LFP data is filtered and downsampled to 1 KHz.  The filtered data is stored
+    in the AnalysisNwbfile table.  The valid times for the filtered data are stored
+    in the IntervalList table.
+    """
+
+    definition = """
+     -> LFPElectrodeGroup                                                  # the group of electrodes to be filtered
+     -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
+     -> FirFilterParameters                                                # the filter to be used
+     """
+
+
+@schema
+class ImportedLFPV1(dj.Imported):
+    definition = """
+    -> Session                      # the session to which this LFP belongs
+    -> LFPElectrodeGroup            # the group of electrodes to be filtered
+    -> IntervalList # the original set of times to be filtered
+    lfp_object_id: varchar(40)      # the NWB object ID for loading this object from the file
+    ---
+    lfp_sampling_rate: float        # the sampling rate, in samples/sec
+    -> AnalysisNwbfile
+    """
+
+    def make(self, key):
+        raise NotImplementedError(
+            "For `insert`, use `allow_direct_insert=True`"
+        )

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -9,10 +9,11 @@ from .nwb_helper_fn import get_nwb_file
 
 
 def dj_replace(original_table, new_values, key_column, replace_column):
-    """Given the output of a fetch() call from a schema and a 2D array made up of (key_value, replace_value) tuples,
-    find each instance of key_value in the key_column of the original table and replace the specified replace_column
-    with the associated replace_value.
-    Key values must be unique.
+    """Given the output of a fetch() call from a schema and a 2D array made up
+    of (key_value, replace_value) tuples, find each instance of key_value in
+    the key_column of the original table and replace the specified
+    replace_column with the associated replace_value. Key values must be
+    unique.
 
     Parameters
     ----------

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -85,6 +85,7 @@ def fetch_nwb(query_expression, nwb_master, *attrs, **kwargs):
         else Nwbfile.get_abs_path
     )
 
+    # TODO: check that the query_expression restricts tbl - CBroz
     nwb_files = (
         query_expression * tbl.proj(nwb2load_filepath=attr_name)
     ).fetch(file_name_str)

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -1,4 +1,5 @@
 from itertools import chain as iter_chain
+from contextlib import nullcontext
 from pprint import pprint
 
 import datajoint as dj
@@ -136,7 +137,8 @@ class Merge(dj.Manual):
                     f"Non-existing entry in any of the parent tables - Entry: {row}"
                 )
 
-        with cls.connection.transaction:
+        # with cls.connection.transaction:
+        with nullcontext():  # This allows use within `make` but decreases reliability
             super().insert(cls(), master_entries, **kwargs)
             for part, part_entries in parts_entries.items():
                 part.insert(part_entries, **kwargs)

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -30,6 +30,21 @@ class Merge(dj.Manual):
                     )
 
     @classmethod
+    def _merge_restrict_parts(
+        cls, restriction: str = True, as_objects: bool = True
+    ) -> list:
+        """Returns a list of parts with restrictions applied."""
+        parts = []
+
+        for part in cls.parts(as_objects=as_objects):
+            try:
+                parts.append(part.restrict(restriction))
+            except DataJointError:  # If restriction not valid on given part
+                parts.append(part)
+
+        return parts
+
+    @classmethod
     def _merge_repr(
         cls, restriction: str = True, **kwargs
     ) -> dj.expression.Union:
@@ -44,12 +59,9 @@ class Merge(dj.Manual):
         ------
         datajoint.expression.Union
         """
-        parts = []
-        for part in cls.parts(as_objects=True):
-            try:
-                parts.append(part.restrict(restriction))
-            except DataJointError:  # If restriction not valid on given part
-                parts.append(part)
+
+        parts = cls._merge_restrict_parts(restriction=restriction)
+
         primary_attrs = list(
             dict.fromkeys(  # get all columns from parts
                 iter_chain.from_iterable([p.heading.names for p in parts])
@@ -151,31 +163,36 @@ class Merge(dj.Manual):
         return repr_html(cls._merge_repr())
 
     @classmethod
-    def merge_restrict(cls, restriction):
-        """Given a restriction string, return a merged view with the restrict'n applied.
+    def merge_restrict(cls, restriction: str) -> dj.U:
+        """Given a restriction string, return a merged view with restriction applied.
 
         Example
         -------
             >>> MergeTable.merge_restrict("field = 1")
+
+        Parameters
+        ----------
+        restriction: str
+            Restriction one would appy if `merge_view` was a real table.
+
+        Returns
+        -------
+        datajoint.Union
+            Merged view with restriction applied.
         """
         return cls._merge_repr(restriction=restriction)
 
     @classmethod
-    def merge_delete_parent(cls, **kwargs) -> None:
-        """Delete enties from merge master, part, and respective part parents"""
-        part_parents = [
-            parent
-            for part in cls().parts(as_objects=True)  # For each part table
-            for parent in part.parents(as_objects=True)  # ID respective parents
-            if cls().table_name not in parent.full_table_name  # Not merge table
-        ]
-        super().delete(cls(), **kwargs)
-        for part_parent in part_parents:
-            super().delete(part_parent, **kwargs)
-
-    @classmethod
     def merge_delete(cls, restriction: str = True, **kwargs):
         """Given a restriction string, delete corresponding entries.
+
+        Parameters
+        ----------
+        restriction: str
+            Optional restriction to apply before deletion from master/part
+            tables. If not provided, delete all entries.
+        kwargs: dict
+            Additional keyword arguments for DataJoint delete.
 
         Example
         -------
@@ -189,11 +206,62 @@ class Merge(dj.Manual):
         ]
         (cls() & uuids).delete(**kwargs)
 
+    @classmethod
+    def merge_delete_parent(
+        cls, restriction: str = True, dry_run=True, **kwargs
+    ) -> list:
+        """Delete enties from merge master, part, and respective part parents
+
+        Note: Clears merge entries from their respective parents.
+
+        Parameters
+        ----------
+        restriction: str
+            Optional restriction to apply before deletion from parents. If not
+            provided, delete all entries present in Merge Table.
+        dry_run: bool
+            Default True. If true, return list of tables with entries that would be
+            deleted. Otherwise, table entries.
+        kwargs: dict
+            Additional keyword arguments for DataJoint delete.
+        """
+        part_parents = [
+            parent.restrict(restriction)
+            for part in cls()._merge_restrict_parts(restriction=restriction)
+            for parent in part.parents(as_objects=True)  # ID respective parents
+            if cls().table_name not in parent.full_table_name  # Not merge table
+            and len(part)
+        ]
+
+        if dry_run:
+            return part_parents
+
+        super().delete(cls(), **kwargs)
+        for part_parent in part_parents:
+            super().delete(part_parent, **kwargs)
+
     # TODO: test fetch nwb
 
 
-def delete_downstream_merge(table: dj.Table, **kwargs) -> None:
-    """Given a table (or restriction), delete the relevant downstream merge entries"""
+def delete_downstream_merge(table: dj.Table, dry_run=True, **kwargs) -> list:
+    """Given a table (or restriction), id or delete relevant downstream merge entries
+
+    Parameters
+    ----------
+    table: dj.Table
+        DataJoint table or restriction thereof
+    dry_run: bool
+        Default True. If true, return list of tuples, merge/part tables downstream of
+        table input. Otherwise, delete merge/part table entries.
+    kwargs: dict
+        Additional keyword arguments for DataJoint delete.
+
+    Returns
+    -------
+    List[Tuple[dj.Table, dj.Table]]
+        Entries in merge/part tables downstream of table input.
+    """
+
     # Adapted from Spyglass PR 535
     merge_pairs = [
         (master, descendant)  # get each merge/part table
@@ -204,6 +272,9 @@ def delete_downstream_merge(table: dj.Table, **kwargs) -> None:
         # and it is not in not in direct descendants
         and master.full_table_name not in table.descendants(as_objects=False)
     ]
+
+    if dry_run:
+        return merge_pairs
 
     for merge_table, part_table in merge_pairs:
         keys = ((merge_table * part_table) & table.fetch()).fetch("KEY")

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -1,0 +1,211 @@
+from itertools import chain as iter_chain
+from pprint import pprint
+
+import datajoint as dj
+from datajoint.errors import DataJointError
+from datajoint.preview import repr_html
+
+
+class Merge(dj.Manual):
+    """Adds funcs to support insert/delete/view of Merge tables."""
+
+    def __init__(self):
+        super().__init__()
+        self._reserved_pk = "merge_id"  # reserved primary key
+        merge_def = f"\n    {self._reserved_pk}: uuid\n    "
+        # TODO: Change warnings to logger. Throw error?
+        if not self.is_declared:
+            if self.definition != merge_def:
+                print(
+                    "WARNING: merge table declared with non-default definition\n\t"
+                    + f"Expected: {merge_def.strip()}\n\t"
+                    + f"Actual  : {self.definition.strip()}"
+                )
+            for part in self.parts(as_objects=True):
+                if part.primary_key != self.primary_key:
+                    print(
+                        f"WARNING: unexpected primary key for {part.table_name}\n\t"
+                        + f"Expected: {self.primary_key}\n\t"
+                        + f"Actual  : {part.primary_key}"
+                    )
+
+    @classmethod
+    def _merge_repr(
+        cls, restriction: str = True, **kwargs
+    ) -> dj.expression.Union:
+        """Merged view, including null entries for columns unique to one part table.
+
+        Parameters
+        ---------
+        restriction: str, optional
+            Restriction to apply to the merged view
+
+        Returns
+        ------
+        datajoint.expression.Union
+        """
+        parts = []
+        for part in cls.parts(as_objects=True):
+            try:
+                parts.append(part.restrict(restriction))
+            except DataJointError:  # If restriction not valid on given part
+                parts.append(part)
+        primary_attrs = list(
+            dict.fromkeys(  # get all columns from parts
+                iter_chain.from_iterable([p.heading.names for p in parts])
+            )
+        )
+        query = dj.U(*primary_attrs) * parts[0].proj(  # declare query
+            ...,  # include all attributes from part 0
+            **{
+                a: "NULL"  # add null value where part has no column
+                for a in primary_attrs
+                if a not in parts[0].heading.names
+            },
+        )
+        for part in parts[1:]:  # add to declared query for each part
+            query += dj.U(*primary_attrs) * part.proj(
+                ...,
+                **{
+                    a: "NULL"
+                    for a in primary_attrs
+                    if a not in part.heading.names
+                },
+            )
+        return query
+
+    @classmethod
+    def _merge_insert(cls, rows: list, **kwargs) -> None:
+        """Insert rows into merge table, ensuring db integrity and mutual exclusivity
+
+        Parameters
+        ---------
+        rows: List[dict]
+            An iterable where an element is a dictionary.
+
+        Raises
+        ------
+        TypeError
+            If rows is not a list of dicts
+        ValueError
+            If entry already exists, mutual exclusivity errors
+            If data doesn't exist in part parents, integrity error
+        """
+
+        try:
+            for r in iter(rows):
+                assert isinstance(
+                    r, dict
+                ), 'Input "rows" must be a list of dictionaries'
+        except TypeError:
+            raise TypeError('Input "rows" must be a list of dictionaries')
+
+        parts = cls.parts(as_objects=True)
+        master_entries = []
+        parts_entries = {p: [] for p in parts}
+        for row in rows:
+            key = {}
+            for part in parts:
+                master = part.parents(as_objects=True)[-1]
+                if master & row:
+                    if not key:
+                        key = (master & row).fetch1("KEY")
+                        master_key = {cls.primary_key[0]: dj.hash.key_hash(key)}
+                        parts_entries[part].append({**master_key, **key})
+                        master_entries.append(master_key)
+                    else:
+                        raise ValueError(
+                            "Mutual Exclusivity Error! Entry exists in more than one "
+                            + f"table - Entry: {row}"
+                        )
+
+            if not key:
+                raise ValueError(
+                    f"Non-existing entry in any of the parent tables - Entry: {row}"
+                )
+
+        with cls.connection.transaction:
+            super().insert(cls(), master_entries, **kwargs)
+            for part, part_entries in parts_entries.items():
+                part.insert(part_entries, **kwargs)
+
+    @classmethod
+    def insert(cls, rows, **kwargs):
+        """Insert rows into merge table, ensuring db integrity and mutual exclusivity"""
+        cls._merge_insert(rows, **kwargs)
+
+    @classmethod
+    def merge_view(cls, limit=None, width=None):
+        """Merged view, including null entries for columns unique to one part table."""
+
+        # If we overwrite `preview`, we then encounter issues with operators
+        # getting passed a `Union`, which doesn't have a method we can
+        # intercept to manage master/parts
+
+        return pprint(cls._merge_repr())
+
+    @classmethod
+    def merge_html(cls):
+        """Returns HTML to display table in Jupyter notebook."""
+        print("WARNING: This method is untested")
+        return repr_html(cls._merge_repr())
+
+    @classmethod
+    def merge_restrict(cls, restriction):
+        """Given a restriction string, return a merged view with the restrict'n applied.
+
+        Example
+        -------
+            >>> MergeTable.merge_restrict("field = 1")
+        """
+        return cls._merge_repr(restriction=restriction)
+
+    @classmethod
+    def merge_delete_parent(cls, **kwargs) -> None:
+        """Delete enties from merge master, part, and respective part parents"""
+        part_parents = [
+            parent
+            for part in cls().parts(as_objects=True)  # For each part table
+            for parent in part.parents(as_objects=True)  # ID respective parents
+            if cls().table_name not in parent.full_table_name  # Not merge table
+        ]
+        super().delete(cls(), **kwargs)
+        for part_parent in part_parents:
+            super().delete(part_parent, **kwargs)
+
+    @classmethod
+    def merge_delete(cls, restriction: str = True, **kwargs):
+        """Given a restriction string, delete corresponding entries.
+
+        Example
+        -------
+            >>> MergeTable.merge_delete("field = 1")
+        """
+        uuids = [
+            {k: v}
+            for entry in cls.merge_restrict(restriction).fetch("KEY")
+            for k, v in entry.items()
+            if k == cls._reserved_pk
+        ]
+        (cls() & uuids).delete(**kwargs)
+
+    # TODO: test fetch nwb
+
+
+def delete_downstream_merge(table: dj.Table, **kwargs) -> None:
+    """Given a table (or restriction), delete the relevant downstream merge entries"""
+    # Adapted from Spyglass PR 535
+    merge_pairs = [
+        (master, descendant)  # get each merge/part table
+        for descendant in table.descendants(as_objects=True)  # given tbl desc
+        for master in descendant.parents(as_objects=True)  # and those parents
+        # if it is a part table (using a dunder not immediately after schema name)
+        if "__" in descendant.full_table_name.replace("`.`__", "")
+        # and it is not in not in direct descendants
+        and master.full_table_name not in table.descendants(as_objects=False)
+    ]
+
+    for merge_table, part_table in merge_pairs:
+        keys = ((merge_table * part_table) & table.fetch()).fetch("KEY")
+        for entry in keys:
+            (merge_table & entry).delete(**kwargs)


### PR DESCRIPTION
In this PR, I add a `Merge` class. This inherits from `dj.manual` and provides a series of methods for interacting with merge tables that adhere to a spec described in new documentation. This is not a new table type in the datajoint ontology, but a series of helper functions to support issues described [here](https://github.com/datajoint/datajoint-python/issues/151) and [here](https://github.com/LorenFrankLab/spyglass/issues/469). The only overwritten function is `insert` which supplies information in the master table. Others are prefixed with `merge_` to distinguish their use case. 

Additional minor changes...
- Rearrange tables in `lfp/v1/lfp.py` to ensure items are listed before foreign key references
- `common/common_ephys.py` adding warning specificity to notify an entry is skipped in `populate`