### PR TITLE
Allow for multiple camera recordings within single epoch

### DIFF
--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -219,10 +219,10 @@ class VideoFile(dj.Imported):
         ).fetch1("valid_times")
 
         is_found = False
-        for video in videos.values():
+        for ind, video in enumerate(videos.values()):
             if isinstance(video, pynwb.image.ImageSeries):
                 video = [video]
-            for ind, video_obj in enumerate(video):
+            for video_obj in video:
                 # check to see if the times for this video_object are largely overlapping with the task epoch times
                 if len(
                     interval_list_contains(valid_times, video_obj.timestamps)

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1,22 +1,24 @@
 import os
+import pathlib
+from typing import Dict
+
 import datajoint as dj
 import ndx_franklab_novela
 import pandas as pd
 import pynwb
-import pathlib
-from typing import Dict
 
-from .common_ephys import Raw  # noqa: F401
-from .common_interval import IntervalList, interval_list_contains
-from .common_nwbfile import Nwbfile
-from .common_session import Session  # noqa: F401
-from .common_task import TaskEpoch
 from ..utils.dj_helper_fn import fetch_nwb
 from ..utils.nwb_helper_fn import (
     get_all_spatial_series,
     get_data_interface,
     get_nwb_file,
 )
+from .common_device import CameraDevice
+from .common_ephys import Raw  # noqa: F401
+from .common_interval import IntervalList, interval_list_contains
+from .common_nwbfile import Nwbfile
+from .common_session import Session  # noqa: F401
+from .common_task import TaskEpoch
 
 schema = dj.schema("common_behav")
 
@@ -188,6 +190,7 @@ class VideoFile(dj.Imported):
     -> TaskEpoch
     video_file_num = 0: int
     ---
+    -> CameraDevice
     video_file_object_id: varchar(40)  # the object id of the file object
     """
 
@@ -195,13 +198,15 @@ class VideoFile(dj.Imported):
         nwb_file_name = key["nwb_file_name"]
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         nwbf = get_nwb_file(nwb_file_abspath)
-        video = get_data_interface(
+        videos = get_data_interface(
             nwbf, "video", pynwb.behavior.BehavioralEvents
         )
 
-        if video is None:
+        if videos is None:
             print(f"No video data interface found in {nwb_file_name}\n")
             return
+        else:
+            videos = videos.time_series
 
         # get the interval for the current TaskEpoch
         interval_list_name = (TaskEpoch() & key).fetch1("interval_list_name")
@@ -214,15 +219,26 @@ class VideoFile(dj.Imported):
         ).fetch1("valid_times")
 
         is_found = False
-        for video_obj in video.time_series.values():
-            # check to see if the times for this video_object are largely overlapping with the task epoch times
-            if len(
-                interval_list_contains(valid_times, video_obj.timestamps)
-                > 0.9 * len(video_obj.timestamps)
-            ):
-                key["video_file_object_id"] = video_obj.object_id
-                self.insert1(key)
-                is_found = True
+        for video in videos.values():
+            if isinstance(video, pynwb.image.ImageSeries):
+                video = [video]
+            for ind, video_obj in enumerate(video):
+                # check to see if the times for this video_object are largely overlapping with the task epoch times
+                if len(
+                    interval_list_contains(valid_times, video_obj.timestamps)
+                    > 0.9 * len(video_obj.timestamps)
+                ):
+                    key["video_file_num"] = ind
+                    camera_name = video_obj.device.camera_name
+                    if CameraDevice & {"camera_name": camera_name}:
+                        key["camera_name"] = video_obj.device.camera_name
+                    else:
+                        raise KeyError(
+                            f"No camera with camera_name: {camera_name} found in CameraDevice table."
+                        )
+                    key["video_file_object_id"] = video_obj.object_id
+                    self.insert1(key)
+                    is_found = True
 
         if not is_found:
             print(f"No video found corresponding to epoch {interval_list_name}")

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -190,7 +190,7 @@ class VideoFile(dj.Imported):
     -> TaskEpoch
     video_file_num = 0: int
     ---
-    -> CameraDevice
+    camera_name: varchar(80)
     video_file_object_id: varchar(40)  # the object id of the file object
     """
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -247,6 +247,20 @@ class VideoFile(dj.Imported):
         return fetch_nwb(self, (Nwbfile, "nwb_file_abs_path"), *attrs, **kwargs)
 
     @classmethod
+    def update_entries(cls, restrict={}):
+        existing_entries = (cls & restrict).fetch("KEY")
+        for row in existing_entries:
+            if (cls & row).fetch1("camera_name"):
+                continue
+            video_nwb = (cls & row).fetch_nwb()[0]
+            if len(video_nwb) != 1:
+                raise ValueError(
+                    f"expecting 1 video file per entry, but {len(video_nwb)} files found"
+                )
+            row["camera_name"] = video_nwb[0]["video_file"].device.camera_name
+            cls.update1(row=row)
+
+    @classmethod
     def get_abs_path(cls, key: Dict):
         """Return the absolute path for a stored video file given a key with the nwb_file_name and epoch number
 

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -162,6 +162,17 @@ class TaskEpoch(dj.Imported):
                     self.insert1(key)
 
     @classmethod
+    def update_entries(cls, restrict={}):
+        existing_entries = (cls & restrict).fetch("KEY")
+        for row in existing_entries:
+            if (cls & row).fetch1("camera_names"):
+                continue
+            row["camera_names"] = [
+                {"camera_name": (cls & row).fetch1("camera_name")}
+            ]
+            cls.update1(row=row)
+
+    @classmethod
     def check_task_table(cls, task_table):
         """Check whether the pynwb DynamicTable containing task metadata conforms to the expected format.
 

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -92,6 +92,7 @@ class TaskEpoch(dj.Imported):
      -> [nullable] CameraDevice
      -> IntervalList
      task_environment = NULL: varchar(200)  # the environment the animal was in
+     camera_names : blob # list of keys corresponding to entry in CameraDevice
      """
 
     def make(self, key):
@@ -123,14 +124,21 @@ class TaskEpoch(dj.Imported):
 
                 # get the CameraDevice used for this task (primary key is camera name so we need
                 # to map from ID to name)
-                camera_id = int(task.camera_id[0])
-                if camera_id in camera_names:
-                    key["camera_name"] = camera_names[camera_id]
+                camera_ids = task.camera_id[0]
+                valid_camera_ids = [
+                    camera_id
+                    for camera_id in camera_ids
+                    if camera_id in camera_names.keys()
+                ]
+                if valid_camera_ids:
+                    key["camera_names"] = [
+                        {"camera_name": camera_names[camera_id]}
+                        for camera_id in valid_camera_ids
+                    ]
                 else:
                     print(
-                        f"No camera device found with ID {camera_id} in NWB file {nwbf}\n"
+                        f"No camera device found with ID {camera_ids} in NWB file {nwbf}\n"
                     )
-
                 # Add task environment
                 if hasattr(task, "task_environment"):
                     key["task_environment"] = task.task_environment[0]


### PR DESCRIPTION
### Description
This pull request will allow users to use Spyglass with recordings that made use of >1 camera within a single epoch. Two main changes need to be made to the 1) `TaskEpoch` and 2) `VideoFile` tables.

1. My plan is to use `alter` to add a `camera_names` secondary key to `TaskEpoch`, which would be a list where each element is a dictionary of form `{"camera_name": camera_name}` and corresponds to a single entry in the `CameraDevice` table.
This would mean the nullable dependence on `CameraDevice` would be taken advantage of and all future entries would not be strictly dependent on `CameraDevice`.

2. For `VideoFile` I will again use `alter` to add `CameraDevice` as a nullable foreign key. In this case, `video_file_num` will only increment if there are multiple videos for an individual camera.

I have tested these changes outside of Spyglass, but will need to alter the tables to test within Spyglass.

### To-do:
- [x] Run `alter` to make changes to tables in database
- [x] Test code within Spyglass

### Further Considerations
Since we're only adding information, I don't think downstream tables will be directly effected. Changes will have to be made to the position pipeline to handle multiple cameras, but I'll address that in a separate PR. 