### PR TITLE
Change to recording whitenening dtype

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -10,7 +10,7 @@ from typing import List
 import datajoint as dj
 import numpy as np
 import spikeinterface as si
-import spikeinterface.preprocessing as sp
+import spikeinterface.preprocessing as sip
 import spikeinterface.qualitymetrics as sq
 
 from ..common.common_interval import IntervalList
@@ -322,7 +322,7 @@ class Waveforms(dj.Computed):
         waveform_params = (WaveformParameters & key).fetch1("waveform_params")
         if "whiten" in waveform_params:
             if waveform_params.pop("whiten"):
-                recording = sp.whiten(recording, dtype=np.float16)
+                recording = sip.whiten(recording, dtype="float32")
 
         waveform_extractor_name = self._get_waveform_extractor_name(key)
         key["waveform_extractor_path"] = str(

--- a/src/spyglass/spikesorting/spikesorting_sorting.py
+++ b/src/spyglass/spikesorting/spikesorting_sorting.py
@@ -210,13 +210,12 @@ class SpikeSorting(dj.Computed):
                 sampling_frequency=recording.get_sampling_frequency(),
             )
         else:
-            # whiten recording here if indicated, so can make sure dtype is float16
             if "whiten" in sorter_params.keys():
                 if sorter_params["whiten"]:
                     sorter_params["whiten"] = False  # set whiten to False
             # whiten recording separately; make sure dtype is float32
             # to avoid downstream error with svd
-            recording = sip.whiten(recording, dtype=np.float32)
+            recording = sip.whiten(recording, dtype="float32")
             sorting = sis.run_sorter(
                 sorter,
                 recording,


### PR DESCRIPTION
Similar to #465 this PR addresses #559 by changing the dtype passed to `sip.whiten` 

The bug #559 describes is handled here by changing `np.float32` to `"float32"` in `spikesorting_sorting.SpikeSorting`.
The bug #555 describes and #465 handles exists in `spikesorting_curation.Waveform` and is fixed here by changing `np.float16` to `"float32"` to reflect #559. 