### PR TITLE
Bump python version required

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - franklab
   - edeno
 dependencies:
-  - python>=3.8,<3.10
+  - python>=3.9,<3.10
   - jupyterlab>=3.*
   - pydotplus
   - dask

--- a/environment_position.yml
+++ b/environment_position.yml
@@ -15,7 +15,7 @@ channels:
   - franklab
   - edeno
 dependencies:
-  - python>=3.8, <3.10
+  - python>=3.9, <3.10
   - jupyterlab>=3.*
   - pydotplus>=2.0.*
   - libgcc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "spyglass-neuro"
 description = "Neuroscience data analysis framework for reproducible research"
 readme = "README.md"
-requires-python = ">=3.8,<3.10"
+requires-python = ">=3.9,<3.10"
 license = { file = "LICENSE" }
 authors = [
     { name = "Loren Frank", email = "loren.frank@ucsf.edu" },
@@ -78,7 +78,7 @@ test = [
     "kachery-cloud",
 ]
 docs = [
-    "hatch",                 # Get version from env 
+    "hatch",                 # Get version from env
     "mike",                  # Docs versioning
     "mkdocs",                # Docs core
     "mkdocs-exclude",        # Docs exclude files


### PR DESCRIPTION
In order to enable type hints with more modern syntax and also because earlier python version are being deprecated by other libraries.