### PR TITLE
Move LFPElectrodeGroup to lfp_electrode.py

### DIFF
--- a/src/spyglass/lfp/__init__.py
+++ b/src/spyglass/lfp/__init__.py
@@ -1,2 +1,3 @@
 from spyglass.lfp.lfp_merge import LFPOutput
 from spyglass.lfp.lfp_electrode import LFPElectrodeGroup
+from spyglass.lfp.lfp_imported import ImportedLFP

--- a/src/spyglass/lfp/__init__.py
+++ b/src/spyglass/lfp/__init__.py
@@ -1,1 +1,2 @@
 from spyglass.lfp.lfp_merge import LFPOutput
+from spyglass.lfp.lfp_electrode import LFPElectrodeGroup

--- a/src/spyglass/lfp/lfp_electrode.py
+++ b/src/spyglass/lfp/lfp_electrode.py
@@ -1,0 +1,57 @@
+import datajoint as dj
+
+from spyglass.common.common_ephys import Electrode
+from spyglass.common.common_session import Session
+
+schema = dj.schema("lfp_electrode")
+
+
+@schema
+class LFPElectrodeGroup(dj.Manual):
+    definition = """
+     -> Session                             # the session to which this LFP belongs
+     lfp_electrode_group_name: varchar(200) # the name of this group of electrodes
+     """
+
+    class LFPElectrode(dj.Part):
+        definition = """
+        -> LFPElectrodeGroup # the group of electrodes to be filtered
+        -> Electrode        # the electrode to be filtered
+        """
+
+    @staticmethod
+    def create_lfp_electrode_group(
+        nwb_file_name: str, group_name: str, electrode_list: list[int]
+    ):
+        """Adds an LFPElectrodeGroup and the individual electrodes
+
+        Parameters
+        ----------
+        nwb_file_name : str
+            The name of the nwb file (e.g. the session)
+        group_name : str
+            The name of this group (< 200 char)
+        electrode_list : list
+            A list of the electrode ids to include in this group.
+        """
+        # remove the session and then recreate the session and Electrode list
+        # check to see if the user allowed the deletion
+        key = {
+            "nwb_file_name": nwb_file_name,
+            "lfp_electrode_group_name": group_name,
+        }
+        LFPElectrodeGroup().insert1(key, skip_duplicates=True)
+
+        # TODO: do this in a better way
+        all_electrodes = (Electrode() & {"nwb_file_name": nwb_file_name}).fetch(
+            as_dict=True
+        )
+        primary_key = Electrode.primary_key
+        for e in all_electrodes:
+            # create a dictionary so we can insert the electrodes
+            if e["electrode_id"] in electrode_list:
+                lfpelectdict = {k: v for k, v in e.items() if k in primary_key}
+                lfpelectdict["lfp_electrode_group_name"] = group_name
+                LFPElectrodeGroup().LFPElectrode.insert1(
+                    lfpelectdict, skip_duplicates=True
+                )

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -2,14 +2,14 @@ import datajoint as dj
 
 from spyglass.common.common_interval import IntervalList
 from spyglass.common.common_nwbfile import AnalysisNwbfile
-from spyglass.common.common_session import SessionGroup
+from spyglass.common.common_session import Session
 from spyglass.lfp.lfp_electrode import LFPElectrodeGroup
 
 schema = dj.schema("lfp_imported")
 
 
 @schema
-class ImportedLFPV1(dj.Imported):
+class ImportedLFP(dj.Imported):
     definition = """
     -> Session                      # the session to which this LFP belongs
     -> LFPElectrodeGroup            # the group of electrodes to be filtered

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -1,0 +1,26 @@
+import datajoint as dj
+
+from spyglass.common.common_interval import IntervalList
+from spyglass.common.common_nwbfile import AnalysisNwbfile
+from spyglass.common.common_session import SessionGroup
+from spyglass.lfp.lfp_electrode import LFPElectrodeGroup
+
+schema = dj.schema("lfp_imported")
+
+
+@schema
+class ImportedLFPV1(dj.Imported):
+    definition = """
+    -> Session                      # the session to which this LFP belongs
+    -> LFPElectrodeGroup            # the group of electrodes to be filtered
+    -> IntervalList # the original set of times to be filtered
+    lfp_object_id: varchar(40)      # the NWB object ID for loading this object from the file
+    ---
+    lfp_sampling_rate: float        # the sampling rate, in samples/sec
+    -> AnalysisNwbfile
+    """
+
+    def make(self, key):
+        raise NotImplementedError(
+            "For `insert`, use `allow_direct_insert=True`"
+        )

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -5,7 +5,7 @@ from spyglass.common.common_ephys import LFP as CommonLFP  # noqa: F401
 from spyglass.common.common_filter import FirFilterParameters  # noqa: F401
 from spyglass.common.common_interval import IntervalList  # noqa: F401
 from spyglass.lfp.v1.lfp import LFPV1  # noqa: F401
-from spyglass.lfp.lfp_imported import ImportedLFPV1  # noqa: F401
+from spyglass.lfp.lfp_imported import ImportedLFP  # noqa: F401
 from spyglass.utils.dj_merge_tables import _Merge
 
 schema = dj.schema("lfp_merge")
@@ -26,11 +26,11 @@ class LFPOutput(_Merge):
         -> LFPV1
         """
 
-    class ImportedLFPV1(dj.Part):
+    class ImportedLFP(dj.Part):
         definition = """
         -> master
         ---
-        -> ImportedLFPV1
+        -> ImportedLFP
         """
 
     class CommonLFP(dj.Part):

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -4,7 +4,8 @@ import pandas as pd
 from spyglass.common.common_ephys import LFP as CommonLFP  # noqa: F401
 from spyglass.common.common_filter import FirFilterParameters  # noqa: F401
 from spyglass.common.common_interval import IntervalList  # noqa: F401
-from spyglass.lfp.v1.lfp import LFPV1, ImportedLFPV1  # noqa: F401
+from spyglass.lfp.v1.lfp import LFPV1  # noqa: F401
+from spyglass.lfp.lfp_imported import ImportedLFPV1  # noqa: F401
 from spyglass.utils.dj_merge_tables import _Merge
 
 schema = dj.schema("lfp_merge")

--- a/src/spyglass/lfp/v1/__init__.py
+++ b/src/spyglass/lfp/v1/__init__.py
@@ -1,7 +1,6 @@
 # flake8: noqa
 from spyglass.lfp.v1.lfp import (
     LFPV1,
-    ImportedLFPV1,
     LFPElectrodeGroup,
     LFPSelection,
 )

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -176,21 +176,3 @@ class LFPV1(dj.Computed):
             nwb_lfp["lfp"].data,
             index=pd.Index(nwb_lfp["lfp"].timestamps, name="time"),
         )
-
-
-@schema
-class ImportedLFPV1(dj.Imported):
-    definition = """
-    -> Session                      # the session to which this LFP belongs
-    -> LFPElectrodeGroup            # the group of electrodes to be filtered
-    -> IntervalList # the original set of times to be filtered
-    lfp_object_id: varchar(40)      # the NWB object ID for loading this object from the file
-    ---
-    lfp_sampling_rate: float        # the sampling rate, in samples/sec
-    -> AnalysisNwbfile
-    """
-
-    def make(self, key):
-        raise NotImplementedError(
-            "For `insert`, use `allow_direct_insert=True`"
-        )

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -4,7 +4,8 @@ import datajoint as dj
 import numpy as np
 import pandas as pd
 
-from spyglass.common.common_ephys import Electrode, Raw
+from spyglass.common.common_ephys import Raw
+from spyglass.lfp.lfp_electrode import LFPElectrodeGroup
 from spyglass.common.common_filter import FirFilterParameters
 from spyglass.common.common_interval import (
     IntervalList,
@@ -18,57 +19,6 @@ from spyglass.utils.dj_helper_fn import fetch_nwb  # dj_replace
 schema = dj.schema("lfp_v1")
 
 MIN_LFP_INTERVAL_DURATION = 1.0  # 1 second minimum interval duration
-
-
-@schema
-class LFPElectrodeGroup(dj.Manual):
-    definition = """
-     -> Session                             # the session to which this LFP belongs
-     lfp_electrode_group_name: varchar(200) # the name of this group of electrodes
-     """
-
-    class LFPElectrode(dj.Part):
-        definition = """
-        -> LFPElectrodeGroup # the group of electrodes to be filtered
-        -> Electrode        # the electrode to be filtered
-        """
-
-    @staticmethod
-    def create_lfp_electrode_group(
-        nwb_file_name: str, group_name: str, electrode_list: list[int]
-    ):
-        """Adds an LFPElectrodeGroup and the individual electrodes
-
-        Parameters
-        ----------
-        nwb_file_name : str
-            The name of the nwb file (e.g. the session)
-        group_name : str
-            The name of this group (< 200 char)
-        electrode_list : list
-            A list of the electrode ids to include in this group.
-        """
-        # remove the session and then recreate the session and Electrode list
-        # check to see if the user allowed the deletion
-        key = {
-            "nwb_file_name": nwb_file_name,
-            "lfp_electrode_group_name": group_name,
-        }
-        LFPElectrodeGroup().insert1(key, skip_duplicates=True)
-
-        # TODO: do this in a better way
-        all_electrodes = (Electrode() & {"nwb_file_name": nwb_file_name}).fetch(
-            as_dict=True
-        )
-        primary_key = Electrode.primary_key
-        for e in all_electrodes:
-            # create a dictionary so we can insert the electrodes
-            if e["electrode_id"] in electrode_list:
-                lfpelectdict = {k: v for k, v in e.items() if k in primary_key}
-                lfpelectdict["lfp_electrode_group_name"] = group_name
-                LFPElectrodeGroup().LFPElectrode.insert1(
-                    lfpelectdict, skip_duplicates=True
-                )
 
 
 @schema

--- a/src/spyglass/lfp_band/lfp_band_merge.py
+++ b/src/spyglass/lfp_band/lfp_band_merge.py
@@ -2,13 +2,13 @@ import datajoint as dj
 import pandas as pd
 
 from spyglass.lfp_band.v1.lfp_band import LFPBandV1  # noqa F401
-from spyglass.utils.dj_merge_tables import Merge
+from spyglass.utils.dj_merge_tables import _Merge
 
 schema = dj.schema("lfp_band_merge")
 
 
 @schema
-class LFPBandOutput(Merge):
+class LFPBandOutput(_Merge):
     definition = """
     merge_id: uuid
     ---


### PR DESCRIPTION
This pull request moves `LFPElectrodeGroup` from `spyglass/lfp/v1/lfp.py` to `spyglass/lfp/lfp_electrode.py` and also changes the schema under which the table lives from `lfp_v1` to `lfp_electrode`. This will allow for use of the table by all LFP pipelines (except for `common_ephys.LFP`). 