### PR TITLE
Remove nb_conda from conda environment files to fix installation error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,6 @@ dependencies:
   - bottleneck
   - ipympl
   - tqdm
-  - nb_conda
   - pyfftw<=0.12.0  # used by ghostipy. install from conda-forge so that it works on Mac ARM processors
   - pip:
     - pubnub<6.4.0

--- a/environment_position.yml
+++ b/environment_position.yml
@@ -34,7 +34,6 @@ dependencies:
   - bottleneck
   - ipympl
   - tqdm
-  - nb_conda
   - ffmpeg
   - pytorch<1.12.0
   - torchvision


### PR DESCRIPTION
Fix #596. I also currently cannot install a clean spyglass environment on my Mac M1 for the same reason. 

As I understand it, [nb_conda](https://github.com/Anaconda-Platform/nb_conda) is a jupyter extension that adds components to the jupyter interface that allow you to list the available conda environments, list packages in the current environment, and modify the environment. This package has not been updated in three years and appears to be incompatible with recent updates to jupyter or jupyter lab. Since this package seems to be auxiliary to the function of spyglass, I recommend that we remove it from the environment files to fix the current installation issues.