### PR TITLE
Add notebook demonstrating some approaches to alter tables manually

### DIFF
--- a/examples/db_alter.ipynb
+++ b/examples/db_alter.ipynb
@@ -1,0 +1,1628 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b275c085-5542-445e-9f42-b4f2773adad2",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Altering a Spyglass DataJoint table "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "944d8595-62e5-4fb2-acfd-bbeee3d017f1",
+   "metadata": {},
+   "source": [
+    "This notebook was used to do the following modifications to Loren Frank Lab's Spyglass database:\n",
+    "1. Move table LFPElectrodeGroup from lfp_v1 schema to new schema called lfp_electrode\n",
+    "2. Move table ImportedLFPV1 from lfp_v1 schema to new schema called lfp_imported\n",
+    "3. Remove empty tables in the lfp-related schema that are not associated with any code and create issues when plotting ERDs\n",
+    "\n",
+    "See https://github.com/LorenFrankLab/spyglass/pull/594"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ccd0dd5-9190-429a-afa5-d8ad0b8ba8c9",
+   "metadata": {},
+   "source": [
+    "# Prepare local test database using backup of production database\n",
+    "```\n",
+    "# ssh into a frank lab machine\n",
+    "ssh rly@typhoon.cin.ucsf.edu -p 7777\n",
+    "\n",
+    "# zip up the latest database backup and place in your home directory on the frank lab remote storage\n",
+    "# change the dates in the file names as appropriate\n",
+    "tar -cvf lmf-db-20230722.tar.gz /stelmo/mysql-backup/lmf-db-20230722/\n",
+    "\n",
+    "# NOTE: we may only really need the mysql-all.sql file but it's good to have a full backup handy\n",
+    "\n",
+    "# copy the zipped up database backup to your local machine\n",
+    "# NOTE: this is a large file >11 GB\n",
+    "scp -P 7777 rly@typhoon.cin.ucsf.edu:lmf-db-20230722.tar.gz ~/Downloads/\n",
+    "cd ~/Downloads\n",
+    "tar -xzvf lmf-db-20230720.tar.gz\n",
+    "# this will unzip into a stelmo folder in ~/Downloads\n",
+    "\n",
+    "# start a clean datajoint mysql database in docker locally\n",
+    "# on Ryan's laptop, that involves:\n",
+    "cd ~/Documents/NWB/datajoint-mysql-docker\n",
+    "docker-compose up -d\n",
+    "\n",
+    "# load the database backup into the local empty database\n",
+    "# this will take ~20 minutes depending on the size of the backup and speed of the computer...\n",
+    "cat ~/Downloads/stelmo/mysql-backup/lmf-db-20230722/mysql-all.sql | docker exec -i dj mysql -u root --password=tutorial -h 127.0.0.1\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfdd35de-5592-4116-95e3-c1dc900a085d",
+   "metadata": {},
+   "source": [
+    "# Examine the backup file for references to the tables being altered\n",
+    "\n",
+    "For LFPElectrodeGroup (encoded as l_f_p_electrode_group in mysql tables):\n",
+    "\n",
+    "Search for all instances of the table name being altered in mysql-all.sql\n",
+    "```\n",
+    "grep l_f_p_electrode_group ~/Downloads/stelmo/mysql-backup/lmf-db-20230722/mysql-all.sql > out.txt\n",
+    "```\n",
+    "\n",
+    "take note of which tables these are in. for example:\n",
+    "- l_f_p_band_selection__l_f_p_band_electrode_ibfk_2 is a foreign key from LFPBandSelection._LFPBandElectrode that references\n",
+    "`` `lfp_v1`.`l_f_p_electrode_group__l_f_p_electrode` ``\n",
+    "- similarly for _imported_l_f_p_ibfk_2 and _imported_l_f_p_v1_ibfk_2\n",
+    "- l_f_p_band_selection__l_f_p_band_electrode_ibfk_2 is a foreign key from LFPBandSelection._LFPBandElectrode that references\n",
+    "`l_f_p_electrode_group__l_f_p_electrode`\n",
+    "- l_f_p_selection_ibfk_1 is a foreign key from LFPSelection that references `l_f_p_electrode_group`\n",
+    "\n",
+    "ignore all logs and innodb_table_stats.\n",
+    "\n",
+    "use `grep -A 20 -B 20` to get context around each match\n",
+    "\n",
+    "also search the spyglass codebase for references to this table\n",
+    "- imported in `lfp/v1/__init__.py`\n",
+    "- defined in `lfp/v1/lfp.py`\n",
+    "- has a part table\n",
+    "- used as primary key in LFPSelection in `lfp/v1/lfp.py`\n",
+    "- used in make function of LFPV1\n",
+    "- used as primary key in ImportedLFPV1 in `lfp/v1/lfp.py`\n",
+    "- used as primary key in LFPBandSelection.LFPBandElectrode in `lfp_band/v1/lfp_band.py` and in code\n",
+    "\n",
+    "- the `lfp/v1/lfp.py::ImportedLFP` table is not in the codebase and therefore should not exist in the database. It is empty and seems to be causing issues with plotting ERDs. It must have been created once from a local or temporary version of the codebase and then the code was updated.\n",
+    "- LFPOutput.ImportedLFP still has a foreign key to ImportedLFP. This should be a foreign key to ImportedLFPV1.\n",
+    "\n",
+    "The ImportedLFPV1 table is being moved and renamed. LFPOutput.ImportedLFPV1 is also being renamed.\n",
+    "- it is currently empty.\n",
+    "- ImportedLFP is also empty.\n",
+    "- LFPOutput.ImportedLFP is also empty.\n",
+    "\n",
+    "Drop all these tables and re-initialize with the PR.\n",
+    "\n",
+    "Need to find all the foreign keys to these tables and drop those keys (or tables) before dropping the above tables.\n",
+    "In this order:\n",
+    "- Drop empty LFPMerge.ImportedLFPV1\n",
+    "- Drop empty LFPOutput.ImportedLFP\n",
+    "- Drop empty ImportedLFPV1\n",
+    "- Drop empty ImportedLFP\n",
+    "...\n",
+    "\n",
+    "Delete the local docker volume and reload the backup database as needed to nail down the sequence of steps that you will perform on the production database."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8153d27e-0aff-43f5-a695-be7036945e1c",
+   "metadata": {},
+   "source": [
+    "# Make sure your repo is on the master branch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9610c0f7-d830-4d81-b539-813485ccece6",
+   "metadata": {},
+   "source": [
+    "# Configure a connection to the local database for a dry run - skip this cell if running on frank lab servers on the production database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d8f3047-349a-4830-8bfd-911b0df5bb47",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import datajoint as dj\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# set dirs\n",
+    "base_dir = Path('/Users/rly/Documents/NWB/spyglass-workspace') # change this to your desired directory\n",
+    "raw_dir = base_dir / 'raw'\n",
+    "analysis_dir = base_dir / 'analysis'\n",
+    "recording_dir = base_dir / 'recording'\n",
+    "sorting_dir = base_dir / 'sorting'\n",
+    "waveforms_dir = base_dir / 'waveforms'\n",
+    "tmp_dir = base_dir / 'tmp'\n",
+    "kachery_cloud_dir = base_dir / '.kachery_cloud'\n",
+    "\n",
+    "os.makedirs(raw_dir, exist_ok=True)\n",
+    "os.makedirs(analysis_dir, exist_ok=True)\n",
+    "os.makedirs(recording_dir, exist_ok=True)\n",
+    "os.makedirs(sorting_dir, exist_ok=True)\n",
+    "os.makedirs(waveforms_dir, exist_ok=True)\n",
+    "os.makedirs(tmp_dir, exist_ok=True)\n",
+    "os.makedirs(kachery_cloud_dir, exist_ok=True)\n",
+    "\n",
+    "# set dj config\n",
+    "dj.config['database.host'] = 'localhost'\n",
+    "dj.config['database.user'] = 'root'\n",
+    "dj.config['database.password'] = 'tutorial'\n",
+    "dj.config['database.port'] = 3306\n",
+    "dj.config['stores'] = {\n",
+    "  'raw': {\n",
+    "    'protocol': 'file',\n",
+    "    'location': str(raw_dir),\n",
+    "    'stage': str(raw_dir)\n",
+    "  },\n",
+    "  'analysis': {\n",
+    "    'protocol': 'file',\n",
+    "    'location': str(analysis_dir),\n",
+    "    'stage': str(analysis_dir)\n",
+    "  }\n",
+    "}\n",
+    "dj.config[\"enable_python_native_blobs\"] = True\n",
+    "\n",
+    "# set env vars\n",
+    "os.environ['SPYGLASS_BASE_DIR'] = str(base_dir)\n",
+    "os.environ['SPYGLASS_RECORDING_DIR'] = str(recording_dir)\n",
+    "os.environ['SPYGLASS_SORTING_DIR'] = str(sorting_dir)\n",
+    "os.environ['SPYGLASS_WAVEFORMS_DIR'] = str(waveforms_dir)\n",
+    "os.environ['SPYGLASS_TEMP_DIR'] = str(tmp_dir)\n",
+    "os.environ['KACHERY_CLOUD_DIR'] = str(kachery_cloud_dir)\n",
+    "os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = 'TRUE'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e2f53b3-8e47-4542-88db-61c5865214a2",
+   "metadata": {},
+   "source": [
+    "# Start here instead of above if running on the Frank Lab servers on the production database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ee60967-f5b2-4654-a939-fd519b512c62",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import datajoint as dj\n",
+    "import spyglass as sg\n",
+    "\n",
+    "sg.config[\"prepopulate\"] = False\n",
+    "\n",
+    "import spyglass.common as sgc\n",
+    "import spyglass.data_import as sgdi\n",
+    "import spyglass.lfp as lfp\n",
+    "import spyglass.lfp.v1 as lfp_v1\n",
+    "import spyglass.lfp_band as lfp_band\n",
+    "import spyglass.lfp_band.lfp_band_merge as lfp_band_merge"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "681d51ca-cf1b-4b9c-b4d1-4cbb94506195",
+   "metadata": {},
+   "source": [
+    "# Plot ERDs of the tables being altered to see what tables depend on these tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35d789b7-b72d-474b-b17d-672d98149511",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dj.ERD(lfp_v1.LFPElectrodeGroup) + 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb7cfe57-9641-4be0-88ad-b666732ca7a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dj.ERD(lfp_v1.ImportedLFP) + 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "922847bc-a820-4327-9927-1dd27febe482",
+   "metadata": {},
+   "source": [
+    "# Start with tasks #2 and #3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82b66064-f9e6-4cd0-acfd-5eb5feb3b1e2",
+   "metadata": {},
+   "source": [
+    "# Confirm that the tables being dropped are empty\n",
+    "- If the table exists, just print the contents, e.g., `lfp.LFPOutput.ImportedLFPV1`\n",
+    "- If the table does not exist, use a MySQL database browser, like TablePlus for macOS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcd619e9-fa99-4baa-97ca-48a08bd10c86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lfp.LFPOutput.ImportedLFPV1()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "437dabfa-e7cc-4094-acb3-3242200df9c7",
+   "metadata": {},
+   "source": [
+    "The `lfp_v1.l_f_p_output` table shouldn't even exist anymore. There are no references in the codebase to it anymore. It should have been replaced with the `lfp_merge.l_f_p_output` table. But the data in the two tables differ... Probably `lfp_v1.l_f_p_output` is old. It has only 80 rows. Ignore this for now."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd0dce66-6373-4ece-a4ba-8becef0bba31",
+   "metadata": {},
+   "source": [
+    "# Drop tables starting with those that no other tables depend upon\n",
+    "Carefully, one at a time...\n",
+    "\n",
+    "The expected output if the command passes is `<pymysql.cursors.Cursor at ...>`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d8e2279-ee93-4a93-847f-9c228566528f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `lfp_merge`\")\n",
+    "conn.query(\"DROP TABLE `lfp_merge`.`l_f_p_output__imported_l_f_p_v1`\")  # can't use datajoint to drop this because it's a part table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39560434-f383-474c-94cd-5ffdaba8dc4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `lfp_v1`\")\n",
+    "conn.query(\"DROP TABLE `lfp_v1`.`l_f_p_output__imported_l_f_p`\")  # can't use datajoint to drop this because it's a part table and also doesn't exist in the code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c6ff6fc-2c88-4956-a379-d35a931984c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `lfp_v1`\")\n",
+    "conn.query(\"DROP TABLE `lfp_v1`.`_imported_l_f_p_v1`\")  # can't use datajoint to drop this because it doesn't exist in the code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d87ffa17-a776-4171-bf51-4295dea9f9d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `lfp_v1`\")\n",
+    "conn.query(\"DROP TABLE `lfp_v1`.`_imported_l_f_p`\")  # can't use datajoint to drop this because it doesn't exist in the code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd8fc6c0-6364-427d-8026-4bc11f676eb2",
+   "metadata": {},
+   "source": [
+    "# Task 1. Rename the tables while maintaining foreign key references from other tables to these tables "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "202ab4d7-0e81-4655-903e-07bb5582d349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dj.schema(\"lfp_electrode\")  # create a new database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e68349f-db92-483e-82b0-161b2cccac98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `lfp_v1`\")\n",
+    "conn.query(\"ALTER TABLE `lfp_v1`.`l_f_p_electrode_group` RENAME `lfp_electrode`.`l_f_p_electrode_group`\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26d054c6-189f-479f-873f-2a76c0397365",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `lfp_v1`\")\n",
+    "conn.query(\"ALTER TABLE `lfp_v1`.`l_f_p_electrode_group__l_f_p_electrode` RENAME `lfp_electrode`.`l_f_p_electrode_group__l_f_p_electrode`\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d12ce2-0ea6-4475-82a1-fb924d333047",
+   "metadata": {},
+   "source": [
+    "# Verify the changes\n",
+    "Dump individual databases to a file and search for lingering references to `lfp_v1.l_f_p_electrode_group` or `lfp_v1.l_f_p_electrode_group__l_f_p_electrode`. Make sure they have been updated.\n",
+    "```\n",
+    "docker exec -i dj mysqldump -u root --password=tutorial -h 127.0.0.1 --databases lfp_v1 > dump_lfp_v1.sql\n",
+    "docker exec -i dj mysqldump -u root --password=tutorial -h 127.0.0.1 --databases lfp_band_v1 > dump_lfp_band_v1.sql\n",
+    "```\n",
+    "\n",
+    "You might also just be able to run:\n",
+    "```\n",
+    "SELECT * FROM information_schema.KEY_COLUMN_USAGE WHERE REFERENCED_TABLE_NAME = 'l_f_p_electrode_group'\n",
+    "SELECT * FROM information_schema.KEY_COLUMN_USAGE WHERE REFERENCED_TABLE_NAME = 'l_f_p_electrode_group__l_f_p_electrode'\n",
+    "```\n",
+    "\n",
+    "If time permits, run through the steps of this notebook again to make sure it is smooth and foolproof before running this on the production database."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f1cfdd0-202e-4a15-b6f9-0af768bb5a61",
+   "metadata": {},
+   "source": [
+    "# Then switch git branches to the PR with the new changes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8288acea-e97c-4a34-bb83-c89c49102b37",
+   "metadata": {},
+   "source": [
+    "# Restart the Jupyter kernel. Confirm things work. Connect to the local database again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "14e33ff2-fd02-4a8f-8275-988a17a0aadf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datajoint as dj\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# set dirs\n",
+    "base_dir = Path('/Users/rly/Documents/NWB/spyglass-workspace') # change this to your desired directory\n",
+    "raw_dir = base_dir / 'raw'\n",
+    "analysis_dir = base_dir / 'analysis'\n",
+    "recording_dir = base_dir / 'recording'\n",
+    "sorting_dir = base_dir / 'sorting'\n",
+    "waveforms_dir = base_dir / 'waveforms'\n",
+    "tmp_dir = base_dir / 'tmp'\n",
+    "kachery_cloud_dir = base_dir / '.kachery_cloud'\n",
+    "\n",
+    "os.makedirs(raw_dir, exist_ok=True)\n",
+    "os.makedirs(analysis_dir, exist_ok=True)\n",
+    "os.makedirs(recording_dir, exist_ok=True)\n",
+    "os.makedirs(sorting_dir, exist_ok=True)\n",
+    "os.makedirs(waveforms_dir, exist_ok=True)\n",
+    "os.makedirs(tmp_dir, exist_ok=True)\n",
+    "os.makedirs(kachery_cloud_dir, exist_ok=True)\n",
+    "\n",
+    "# set dj config\n",
+    "dj.config['database.host'] = 'localhost'\n",
+    "dj.config['database.user'] = 'root'\n",
+    "dj.config['database.password'] = 'tutorial'\n",
+    "dj.config['database.port'] = 3306\n",
+    "dj.config['stores'] = {\n",
+    "  'raw': {\n",
+    "    'protocol': 'file',\n",
+    "    'location': str(raw_dir),\n",
+    "    'stage': str(raw_dir)\n",
+    "  },\n",
+    "  'analysis': {\n",
+    "    'protocol': 'file',\n",
+    "    'location': str(analysis_dir),\n",
+    "    'stage': str(analysis_dir)\n",
+    "  }\n",
+    "}\n",
+    "dj.config[\"enable_python_native_blobs\"] = True\n",
+    "\n",
+    "# set env vars\n",
+    "os.environ['SPYGLASS_BASE_DIR'] = str(base_dir)\n",
+    "os.environ['SPYGLASS_RECORDING_DIR'] = str(recording_dir)\n",
+    "os.environ['SPYGLASS_SORTING_DIR'] = str(sorting_dir)\n",
+    "os.environ['SPYGLASS_WAVEFORMS_DIR'] = str(waveforms_dir)\n",
+    "os.environ['SPYGLASS_TEMP_DIR'] = str(tmp_dir)\n",
+    "os.environ['KACHERY_CLOUD_DIR'] = str(kachery_cloud_dir)\n",
+    "os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = 'TRUE'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "72254c87-1833-44b7-8ab7-47edffb467f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2023-07-23 23:56:50,225][INFO]: Connecting root@localhost:3306\n",
+      "[2023-07-23 23:56:50,363][INFO]: Connected root@localhost:3306\n"
+     ]
+    }
+   ],
+   "source": [
+    "import spyglass as sg\n",
+    "\n",
+    "sg.config[\"prepopulate\"] = False\n",
+    "\n",
+    "import spyglass.common as sgc\n",
+    "import spyglass.data_import as sgdi\n",
+    "import spyglass.lfp as lfp\n",
+    "import spyglass.lfp.v1 as lfp_v1\n",
+    "import spyglass.lfp_band as lfp_band\n",
+    "import spyglass.lfp_band.lfp_band_merge as lfp_band_merge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "428ef635-259d-4f7b-aa57-a48ff3af721f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    \n",
+       "    <style type=\"text/css\">\n",
+       "        .Table{\n",
+       "            border-collapse:collapse;\n",
+       "        }\n",
+       "        .Table th{\n",
+       "            background: #A0A0A0; color: #ffffff; padding:4px; border:#f0e0e0 1px solid;\n",
+       "            font-weight: normal; font-family: monospace; font-size: 100%;\n",
+       "        }\n",
+       "        .Table td{\n",
+       "            padding:4px; border:#f0e0e0 1px solid; font-size:100%;\n",
+       "        }\n",
+       "        .Table tr:nth-child(odd){\n",
+       "            background: #ffffff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        .Table tr:nth-child(even){\n",
+       "            background: #f3f1ff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        /* Tooltip container */\n",
+       "        .djtooltip {\n",
+       "        }\n",
+       "        /* Tooltip text */\n",
+       "        .djtooltip .djtooltiptext {\n",
+       "            visibility: hidden;\n",
+       "            width: 120px;\n",
+       "            background-color: black;\n",
+       "            color: #fff;\n",
+       "            text-align: center;\n",
+       "            padding: 5px 0;\n",
+       "            border-radius: 6px;\n",
+       "            /* Position the tooltip text - see examples below! */\n",
+       "            position: absolute;\n",
+       "            z-index: 1;\n",
+       "        }\n",
+       "        #primary {\n",
+       "            font-weight: bold;\n",
+       "            color: black;\n",
+       "        }\n",
+       "        #nonprimary {\n",
+       "            font-weight: normal;\n",
+       "            color: white;\n",
+       "        }\n",
+       "\n",
+       "        /* Show the tooltip text when you mouse over the tooltip container */\n",
+       "        .djtooltip:hover .djtooltiptext {\n",
+       "            visibility: visible;\n",
+       "        }\n",
+       "    </style>\n",
+       "    \n",
+       "    <b></b>\n",
+       "        <div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "        <table border=\"1\" class=\"Table\">\n",
+       "            <thead> <tr style=\"text-align: right;\"> <th> <div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">nwb_file_name</p>\n",
+       "                            <span class=\"djtooltiptext\">name of the NWB file</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">lfp_electrode_group_name</p>\n",
+       "                            <span class=\"djtooltiptext\">the name of this group of electrodes</span>\n",
+       "                        </div> </th> </tr> </thead>\n",
+       "            <tbody> <tr> <td>arthur20220315_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220316_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220317_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220318_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220319_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220320_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220321_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220322_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220323_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220324_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220325_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220326_.nwb</td>\n",
+       "<td>all_tets_arthur</td> </tr> </tbody>\n",
+       "        </table>\n",
+       "        <p>...</p>\n",
+       "        <p>Total: 333</p></div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "*nwb_file_name *lfp_electrode\n",
+       "+------------+ +------------+\n",
+       "arthur20220315 all_tets_arthu\n",
+       "arthur20220316 all_tets_arthu\n",
+       "arthur20220317 all_tets_arthu\n",
+       "arthur20220318 all_tets_arthu\n",
+       "arthur20220319 all_tets_arthu\n",
+       "arthur20220320 all_tets_arthu\n",
+       "arthur20220321 all_tets_arthu\n",
+       "arthur20220322 all_tets_arthu\n",
+       "arthur20220323 all_tets_arthu\n",
+       "arthur20220324 all_tets_arthu\n",
+       "arthur20220325 all_tets_arthu\n",
+       "arthur20220326 all_tets_arthu\n",
+       "   ...\n",
+       " (Total: 333)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lfp.LFPElectrodeGroup()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "78598711-6fa7-4c54-84f0-3c3ec3e36324",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    \n",
+       "    <style type=\"text/css\">\n",
+       "        .Table{\n",
+       "            border-collapse:collapse;\n",
+       "        }\n",
+       "        .Table th{\n",
+       "            background: #A0A0A0; color: #ffffff; padding:4px; border:#f0e0e0 1px solid;\n",
+       "            font-weight: normal; font-family: monospace; font-size: 100%;\n",
+       "        }\n",
+       "        .Table td{\n",
+       "            padding:4px; border:#f0e0e0 1px solid; font-size:100%;\n",
+       "        }\n",
+       "        .Table tr:nth-child(odd){\n",
+       "            background: #ffffff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        .Table tr:nth-child(even){\n",
+       "            background: #f3f1ff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        /* Tooltip container */\n",
+       "        .djtooltip {\n",
+       "        }\n",
+       "        /* Tooltip text */\n",
+       "        .djtooltip .djtooltiptext {\n",
+       "            visibility: hidden;\n",
+       "            width: 120px;\n",
+       "            background-color: black;\n",
+       "            color: #fff;\n",
+       "            text-align: center;\n",
+       "            padding: 5px 0;\n",
+       "            border-radius: 6px;\n",
+       "            /* Position the tooltip text - see examples below! */\n",
+       "            position: absolute;\n",
+       "            z-index: 1;\n",
+       "        }\n",
+       "        #primary {\n",
+       "            font-weight: bold;\n",
+       "            color: black;\n",
+       "        }\n",
+       "        #nonprimary {\n",
+       "            font-weight: normal;\n",
+       "            color: white;\n",
+       "        }\n",
+       "\n",
+       "        /* Show the tooltip text when you mouse over the tooltip container */\n",
+       "        .djtooltip:hover .djtooltiptext {\n",
+       "            visibility: visible;\n",
+       "        }\n",
+       "    </style>\n",
+       "    \n",
+       "    <b></b>\n",
+       "        <div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "        <table border=\"1\" class=\"Table\">\n",
+       "            <thead> <tr style=\"text-align: right;\"> <th> <div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">nwb_file_name</p>\n",
+       "                            <span class=\"djtooltiptext\">name of the NWB file</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">lfp_electrode_group_name</p>\n",
+       "                            <span class=\"djtooltiptext\">the name of this group of electrodes</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">target_interval_list_name</p>\n",
+       "                            <span class=\"djtooltiptext\">descriptive name of this interval list</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">filter_name</p>\n",
+       "                            <span class=\"djtooltiptext\">descriptive name of this filter</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">filter_sampling_rate</p>\n",
+       "                            <span class=\"djtooltiptext\">sampling rate for this filter</span>\n",
+       "                        </div> </th> </tr> </thead>\n",
+       "            <tbody> <tr> <td>arthur20220315_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r1_r2</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220315_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r2_r3</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220316_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r1_r2</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220316_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r2_r3</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220317_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r1_r2</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220317_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r2_r3</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220318_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r1_r2</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220318_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r2_r3</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220319_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r2_r2</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220319_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r2_r3</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220320_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r1_r2</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td></tr><tr><td>arthur20220320_.nwb</td>\n",
+       "<td>all_tets_arthur</td>\n",
+       "<td>r2_r3</td>\n",
+       "<td>LFP 0-400 Hz</td>\n",
+       "<td>30000</td> </tr> </tbody>\n",
+       "        </table>\n",
+       "        <p>...</p>\n",
+       "        <p>Total: 1102</p></div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "*nwb_file_name *lfp_electrode *target_interv *filter_name   *filter_sampli\n",
+       "+------------+ +------------+ +------------+ +------------+ +------------+\n",
+       "arthur20220315 all_tets_arthu r1_r2          LFP 0-400 Hz   30000         \n",
+       "arthur20220315 all_tets_arthu r2_r3          LFP 0-400 Hz   30000         \n",
+       "arthur20220316 all_tets_arthu r1_r2          LFP 0-400 Hz   30000         \n",
+       "arthur20220316 all_tets_arthu r2_r3          LFP 0-400 Hz   30000         \n",
+       "arthur20220317 all_tets_arthu r1_r2          LFP 0-400 Hz   30000         \n",
+       "arthur20220317 all_tets_arthu r2_r3          LFP 0-400 Hz   30000         \n",
+       "arthur20220318 all_tets_arthu r1_r2          LFP 0-400 Hz   30000         \n",
+       "arthur20220318 all_tets_arthu r2_r3          LFP 0-400 Hz   30000         \n",
+       "arthur20220319 all_tets_arthu r2_r2          LFP 0-400 Hz   30000         \n",
+       "arthur20220319 all_tets_arthu r2_r3          LFP 0-400 Hz   30000         \n",
+       "arthur20220320 all_tets_arthu r1_r2          LFP 0-400 Hz   30000         \n",
+       "arthur20220320 all_tets_arthu r2_r3          LFP 0-400 Hz   30000         \n",
+       "   ...\n",
+       " (Total: 1102)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lfp_v1.LFPSelection()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "261bf6cf-ba4b-48f0-84f7-11a52626c40b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    \n",
+       "    <style type=\"text/css\">\n",
+       "        .Table{\n",
+       "            border-collapse:collapse;\n",
+       "        }\n",
+       "        .Table th{\n",
+       "            background: #A0A0A0; color: #ffffff; padding:4px; border:#f0e0e0 1px solid;\n",
+       "            font-weight: normal; font-family: monospace; font-size: 100%;\n",
+       "        }\n",
+       "        .Table td{\n",
+       "            padding:4px; border:#f0e0e0 1px solid; font-size:100%;\n",
+       "        }\n",
+       "        .Table tr:nth-child(odd){\n",
+       "            background: #ffffff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        .Table tr:nth-child(even){\n",
+       "            background: #f3f1ff;\n",
+       "            color: #000000;\n",
+       "        }\n",
+       "        /* Tooltip container */\n",
+       "        .djtooltip {\n",
+       "        }\n",
+       "        /* Tooltip text */\n",
+       "        .djtooltip .djtooltiptext {\n",
+       "            visibility: hidden;\n",
+       "            width: 120px;\n",
+       "            background-color: black;\n",
+       "            color: #fff;\n",
+       "            text-align: center;\n",
+       "            padding: 5px 0;\n",
+       "            border-radius: 6px;\n",
+       "            /* Position the tooltip text - see examples below! */\n",
+       "            position: absolute;\n",
+       "            z-index: 1;\n",
+       "        }\n",
+       "        #primary {\n",
+       "            font-weight: bold;\n",
+       "            color: black;\n",
+       "        }\n",
+       "        #nonprimary {\n",
+       "            font-weight: normal;\n",
+       "            color: white;\n",
+       "        }\n",
+       "\n",
+       "        /* Show the tooltip text when you mouse over the tooltip container */\n",
+       "        .djtooltip:hover .djtooltiptext {\n",
+       "            visibility: visible;\n",
+       "        }\n",
+       "    </style>\n",
+       "    \n",
+       "    <b></b>\n",
+       "        <div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "        <table border=\"1\" class=\"Table\">\n",
+       "            <thead> <tr style=\"text-align: right;\"> <th> <div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">nwb_file_name</p>\n",
+       "                            <span class=\"djtooltiptext\">name of the NWB file</span>\n",
+       "                        </div></th><th><div class=\"djtooltip\">\n",
+       "                            <p id=\"primary\">lfp_electrode_group_name</p>\n",
+       "                            <span class=\"djtooltiptext\">the name of this group of electrodes</span>\n",
+       "                        </div> </th> </tr> </thead>\n",
+       "            <tbody> <tr> <td>arthur20220315_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220316_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220317_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220318_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220319_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220320_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220321_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220322_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220323_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220324_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220325_.nwb</td>\n",
+       "<td>all_tets_arthur</td></tr><tr><td>arthur20220326_.nwb</td>\n",
+       "<td>all_tets_arthur</td> </tr> </tbody>\n",
+       "        </table>\n",
+       "        <p>...</p>\n",
+       "        <p>Total: 333</p></div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "*nwb_file_name *lfp_electrode\n",
+       "+------------+ +------------+\n",
+       "arthur20220315 all_tets_arthu\n",
+       "arthur20220316 all_tets_arthu\n",
+       "arthur20220317 all_tets_arthu\n",
+       "arthur20220318 all_tets_arthu\n",
+       "arthur20220319 all_tets_arthu\n",
+       "arthur20220320 all_tets_arthu\n",
+       "arthur20220321 all_tets_arthu\n",
+       "arthur20220322 all_tets_arthu\n",
+       "arthur20220323 all_tets_arthu\n",
+       "arthur20220324 all_tets_arthu\n",
+       "arthur20220325 all_tets_arthu\n",
+       "arthur20220326 all_tets_arthu\n",
+       "   ...\n",
+       " (Total: 333)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from spyglass.lfp.lfp_electrode import LFPElectrodeGroup\n",
+    "LFPElectrodeGroup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "719ca00f-e106-4434-ac61-d17b3a9d4cae",
+   "metadata": {},
+   "source": [
+    "# Run this on the production database on the frank lab servers\n",
+    "- Log in to the frank lab server\n",
+    "- Reinstall the master branch of spyglass\n",
+    "```\n",
+    "ssh rly@typhoon.cin.ucsf.edu -p 7777\n",
+    "cd spyglass\n",
+    "# remove the existing spyglass repo if it exists\n",
+    "mamba remove --name spyglass --all --yes\n",
+    "git status\n",
+    "# make sure i am on the master branch\n",
+    "git pull\n",
+    "mamba env create -f environment.yml --verbose  # this can take like 30 minutes\n",
+    "mamba activate spyglass\n",
+    "pip install -e .\n",
+    "```\n",
+    "- Copy this notebook there\n",
+    "- Start jupyter\n",
+    "- Run through all the above steps EXCEPT do not configure datajoint to connect to a local database. Datajoint is already configured to connect to the Frank Lab spyglass production database (at least on Ryan's account) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e19074ce-2502-43bd-b29e-aef38d4a8564",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c97a6dc6-ad40-4899-9983-e09bd59f1b79",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46741e20-f97b-41a5-95a4-fe0e78ed6709",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2074c54e-4640-4ad0-ba3c-84947f3bad20",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a53e-3b27-41b7-8a4e-462bf7217e1c",
+   "metadata": {},
+   "source": [
+    "# A scrapped idea - changing a primary key of a table that is used by lots of downstream tables\n",
+    "\n",
+    "2. Copy all entries from common_ephys.LFPSelection to new lfp_electrode.LFPElectrodeGroup and set the \"lfp_electrode_group_name\" values to \"full_session_full_channel_set\"\n",
+    "3. Add a column in common_ephys.LFP that is a foreign key to new lfp_electrode.LFPElectrodeGroup with the values equal to the new entries in lfp_electrode.LFPElectrodeGroup\n",
+    "4. Change the primary key of common_ephys.LFP to new lfp_electrode.LFPElectrodeGroup (this might involve adding a new primary key and then removing the old one).\n",
+    "- If changing the primary key requires manually adding the new \"lfp_electrode_group_name\" to every table downstream of common_ephys.LFP, then abort mission.\n",
+    "- To add a new primary key, we would need to drop the foreign key to the primary key of common_ephys.LFP (recursively) on every downstream table, some of which may be primary keys themselves. This would require dropping basically reference to common_ephys.LFP and every reference to a table that references that, etc.\n",
+    "\n",
+    "### ChatGPT says:\n",
+    "If you encounter the \"Foreign key constraint is incorrectly formed\" error when trying to drop the primary key, it might be because there are foreign key constraints referencing the primary key you're attempting to drop.\n",
+    "\n",
+    "To add a new column to an existing primary key without encountering this issue, you can follow these steps:\n",
+    "\n",
+    "1. **Drop Foreign Key Constraints**:\n",
+    "   You need to drop any foreign key constraints that reference the existing primary key before modifying it. Identify the foreign key constraints that are using the primary key you want to modify, and drop them using the `ALTER TABLE` statement. For example:\n",
+    "\n",
+    "   ```sql\n",
+    "   -- Drop foreign key constraints that reference the primary key\n",
+    "   ALTER TABLE referencing_table1 DROP FOREIGN KEY constraint_name1;\n",
+    "   ALTER TABLE referencing_table2 DROP FOREIGN KEY constraint_name2;\n",
+    "   -- ... (repeat for each referencing table)\n",
+    "   ```\n",
+    "\n",
+    "   Replace `referencing_table1`, `referencing_table2`, etc., with the names of the tables that have foreign key constraints, and `constraint_name1`, `constraint_name2`, etc., with the actual names of the foreign key constraints.\n",
+    "\n",
+    "2. **Drop Primary Key Constraint**:\n",
+    "   Once all foreign key constraints have been dropped, you can drop the existing primary key constraint:\n",
+    "\n",
+    "   ```sql\n",
+    "   ALTER TABLE users DROP PRIMARY KEY;\n",
+    "   ```\n",
+    "\n",
+    "   Replace `users` with the name of your table.\n",
+    "\n",
+    "3. **Add the New Column and Primary Key**:\n",
+    "   Now that the primary key constraint is removed, you can add the new column and designate it as the primary key:\n",
+    "\n",
+    "   ```sql\n",
+    "   ALTER TABLE users\n",
+    "   ADD COLUMN new_id INT AUTO_INCREMENT PRIMARY KEY;\n",
+    "   ```\n",
+    "\n",
+    "   Replace `users` with the name of your table and `new_id` with the name of the new column.\n",
+    "\n",
+    "4. **Recreate Foreign Key Constraints**:\n",
+    "   After successfully adding the new primary key column, you can re-create the foreign key constraints that were previously dropped:\n",
+    "\n",
+    "   ```sql\n",
+    "   ALTER TABLE referencing_table1\n",
+    "   ADD CONSTRAINT constraint_name1 FOREIGN KEY (foreign_key_column1) REFERENCES users(new_id);\n",
+    "\n",
+    "   ALTER TABLE referencing_table2\n",
+    "   ADD CONSTRAINT constraint_name2 FOREIGN KEY (foreign_key_column2) REFERENCES users(new_id);\n",
+    "\n",
+    "   -- ... (repeat for each referencing table)\n",
+    "   ```\n",
+    "\n",
+    "   Replace `referencing_table1`, `referencing_table2`, etc., with the names of the tables that have foreign key constraints, `constraint_name1`, `constraint_name2`, etc., with the desired names of the foreign key constraints, and `foreign_key_column1`, `foreign_key_column2`, etc., with the columns in the referencing tables that reference the new primary key column.\n",
+    "\n",
+    "Please be cautious when modifying primary keys and foreign key constraints, as they are critical to maintaining data integrity. Always have proper backups and thoroughly test any changes in a safe environment before applying them to production data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c9ba764-69a9-40ec-8794-6039cb836f83",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14e670e7-d50b-46b2-b9a4-06c97332dc63",
+   "metadata": {},
+   "source": [
+    "# Old cells from previous database surgery"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a3ed9e2-dda3-4c6f-8ae8-e4adf1f5f69f",
+   "metadata": {},
+   "source": [
+    "# Alter DataAcquisitionDevice and create DataAcquisitionDeviceSystem and DataAcquisitionDeviceAmplifier tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "557e792a-476d-44bd-8a19-f98fb73473ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# inspect values\n",
+    "sgc.DataAcquisitionDevice()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c5941ed-0a06-4581-94a7-bafe31cf16e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# store the values in memory\n",
+    "res = sgc.DataAcquisitionDevice.fetch()\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6829902b-b6ff-44aa-be65-be094cab153b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rename the fields\n",
+    "res.dtype.names=[\"data_acquisition_device_name\", \"data_acquisition_device_system\", \"data_acquisition_device_amplifier\", \"adc_circuit\"]\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60b0d8cf-6cb4-4c71-ada4-533d5d44f4f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop DataAcquisitionDevice\n",
+    "# this will also drop sgc.SessionDataAcquisitionDevice() but this should not exist anyway (it may have been created during testing)\n",
+    "sgc.DataAcquisitionDevice().drop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63a383f7-69c6-4519-94f2-f40c3175d1a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# these new tables may already exist and have dummy data from testing\n",
+    "# temporarily make a class for them and then drop the tables\n",
+    "schema = dj.schema(\"common_device\")\n",
+    "@schema\n",
+    "class DataAcquisitionDeviceSystem(dj.Manual):\n",
+    "    pass\n",
+    "\n",
+    "@schema\n",
+    "class DataAcquisitionDeviceAmplifier(dj.Manual):\n",
+    "    pass\n",
+    "\n",
+    "DataAcquisitionDeviceSystem.drop()\n",
+    "DataAcquisitionDeviceAmplifier.drop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc1d0241-641c-4c0c-b9e9-f0937e539314",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load new class definitions\n",
+    "schema = dj.schema(\"common_device\")\n",
+    "\n",
+    "@schema\n",
+    "class DataAcquisitionDeviceSystem(dj.Manual):\n",
+    "    definition = \"\"\"\n",
+    "    # Known data acquisition device system names.\n",
+    "    data_acquisition_device_system: varchar(80)\n",
+    "    ---\n",
+    "    \"\"\"\n",
+    "\n",
+    "\n",
+    "@schema\n",
+    "class DataAcquisitionDeviceAmplifier(dj.Manual):\n",
+    "    definition = \"\"\"\n",
+    "    # Known data acquisition device amplifier names.\n",
+    "    data_acquisition_device_amplifier: varchar(80)\n",
+    "    ---\n",
+    "    \"\"\"\n",
+    "\n",
+    "\n",
+    "@schema\n",
+    "class DataAcquisitionDevice(dj.Manual):\n",
+    "    definition = \"\"\"\n",
+    "    data_acquisition_device_name: varchar(80)\n",
+    "    ---\n",
+    "    -> DataAcquisitionDeviceSystem\n",
+    "    -> DataAcquisitionDeviceAmplifier\n",
+    "    adc_circuit = NULL: varchar(2000)\n",
+    "    \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecfd069d-112d-42ea-9cff-d4c9175c670d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# populate DataAcquisitionDeviceSystem\n",
+    "for name in res[\"data_acquisition_device_system\"]:\n",
+    "    DataAcquisitionDeviceSystem.insert1({\"data_acquisition_device_system\": name}, skip_duplicates=True)\n",
+    "DataAcquisitionDeviceSystem()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a165c177-57f0-48c0-9e53-dcf04fcade0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# populate DataAcquisitionDeviceAmplifier\n",
+    "for name in res[\"data_acquisition_device_amplifier\"]:\n",
+    "    DataAcquisitionDeviceAmplifier.insert1({\"data_acquisition_device_amplifier\": name}, skip_duplicates=True)\n",
+    "DataAcquisitionDeviceAmplifier()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7a9aa1f-cc74-417c-bf88-189d1b2290c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# populate DataAcquisitionDevice\n",
+    "DataAcquisitionDevice.insert(res)\n",
+    "DataAcquisitionDevice()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9310d24d-6f11-4dcb-a399-767d026dc59b",
+   "metadata": {},
+   "source": [
+    "# Create new ProbeType table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a480d357-ef2f-4684-bd21-1dfe2a036995",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# these new tables may already exist and have dummy data from testing\n",
+    "# temporarily make a class for them and then drop the tables\n",
+    "schema = dj.schema(\"common_device\")\n",
+    "@schema\n",
+    "class ProbeType(dj.Manual):\n",
+    "    definition = \"\"\"\n",
+    "    # Type/category of probe, e.g., Neuropixels 1.0 or NeuroNexus X-Y-Z, regardless of configuration.\n",
+    "    # This is a controlled vocabulary of probe type names.\n",
+    "    # This is separated from Probe because probes like the Neuropixels 1.0 can have different dynamic configurations,\n",
+    "    # e.g. channel maps.\n",
+    "    probe_type: varchar(80)\n",
+    "    ---\n",
+    "    probe_description: varchar(2000)               # description of this probe\n",
+    "    manufacturer = \"\": varchar(200)                # manufacturer of this probe\n",
+    "    num_shanks: int                                # number of shanks on this probe\n",
+    "    \"\"\"\n",
+    "\n",
+    "ProbeType.drop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bbe3d7a-c29f-4fd7-92da-74c4789b996b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load new class definition\n",
+    "schema = dj.schema(\"common_device\")\n",
+    "\n",
+    "@schema\n",
+    "class ProbeType(dj.Manual):\n",
+    "    definition = \"\"\"\n",
+    "    # Type/category of probe, e.g., Neuropixels 1.0 or NeuroNexus X-Y-Z, regardless of configuration.\n",
+    "    # This is a controlled vocabulary of probe type names.\n",
+    "    # This is separated from Probe because probes like the Neuropixels 1.0 can have different dynamic configurations,\n",
+    "    # e.g. channel maps.\n",
+    "    probe_type: varchar(80)\n",
+    "    ---\n",
+    "    probe_description: varchar(2000)               # description of this probe\n",
+    "    manufacturer = \"\": varchar(200)                # manufacturer of this probe\n",
+    "    num_shanks: int                                # number of shanks on this probe\n",
+    "    \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0089ad9-3438-4292-b15a-e0411b99cfa9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# populate ProbeType from Probe\n",
+    "res = sgc.Probe.fetch()\n",
+    "for row in res:\n",
+    "    ProbeType.insert1({\n",
+    "        \"probe_type\": row[\"probe_type\"],\n",
+    "        \"probe_description\": row[\"probe_description\"],\n",
+    "        \"num_shanks\": row[\"num_shanks\"]\n",
+    "    })\n",
+    "ProbeType()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28f93788-27d6-408e-a26b-e8ec445cac03",
+   "metadata": {},
+   "source": [
+    "# Alter primary key of Probe table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "caecd02c-442e-4677-b986-c011e3225138",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# confirm that only a few tables are affected by these changes\n",
+    "# only Probe.Shank and ElectrodeGroup should use Probe\n",
+    "dj.ERD(sgc.Probe) + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a453fec-9556-4bec-ac70-d1cc6406fb08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# only Probe.Electrode should use Probe.Shank\n",
+    "dj.ERD(sgc.Probe.Shank) + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "048fe4ab-a842-4b69-af31-e3b3c717b1ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# only Electrode should use Probe.Electrode\n",
+    "dj.ERD(sgc.Probe.Electrode) + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93c1bc8b-a8d9-40b4-bd1e-5b580596e5eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `common_device`\")\n",
+    "conn.query(\"ALTER TABLE `probe` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\")\n",
+    "conn.query(\"ALTER TABLE `probe__shank` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\")\n",
+    "conn.query(\"ALTER TABLE `probe__electrode` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\")\n",
+    "conn.query(\"USE `common_ephys`\")\n",
+    "conn.query(\"ALTER TABLE `_electrode_group` CHANGE `probe_type` `probe_id` varchar(80) DEFAULT NULL\")\n",
+    "conn.query(\"ALTER TABLE `_electrode_group` DROP KEY `probe_type`, ADD KEY `probe_id` (`probe_id`)\")\n",
+    "conn.query(\"ALTER TABLE `_electrode` CHANGE `probe_type` `probe_id` varchar(80) DEFAULT NULL\")\n",
+    "conn.query(\"ALTER TABLE `_electrode` DROP KEY `probe_type`, ADD KEY `probe_id` (`probe_id`,`probe_shank`,`probe_electrode`)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a4c54c1-3333-4ce4-a85b-8a370d5478cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stop\n",
+    "# then update spyglass code to reflect the name change (`git checkout file_based_mods`)\n",
+    "# restart kernel\n",
+    "# dump databases common_device and common_ephys to file to make sure the name change cascaded correctly\n",
+    "# `docker exec -i dj mysqldump -u root --password=tutorial -h 127.0.0.1 --databases common_device common_ephys > dump.sql`\n",
+    "# run first cell\n",
+    "# print tables in spyglass to make sure the name change worked"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01d68e4d-fef5-42d6-9103-d341e59057c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# verify the change\n",
+    "sgc.Probe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82b00b2b-48a7-47cc-80e0-3d02d862a64a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgc.Probe.Shank()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3cf2fcb-bf93-41e6-b833-499e2f32d12d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgc.Probe.Electrode()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8ee9b62-cf4c-4c85-9473-8fc186d90ed5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgc.ElectrodeGroup()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "165cb9b4-d9fc-478a-ab45-b45c4eace08d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgc.Electrode()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27cbf2c9-9fa4-499f-bb30-2e0c08652945",
+   "metadata": {},
+   "source": [
+    "# Alter columns of Probe table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b84b1735-6077-44b2-8f6a-4981a18ca626",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load new class definition\n",
+    "schema = dj.schema(\"common_device\")\n",
+    "from spyglass.common import DataAcquisitionDevice \n",
+    "\n",
+    "@schema\n",
+    "class Probe(dj.Manual):\n",
+    "    definition = \"\"\"\n",
+    "    # A configuration of a ProbeType. For most probe types, there is only one configuration, and that configuration\n",
+    "    # should always be used. For Neuropixels probes, the specific channel map (which electrodes are used,\n",
+    "    # where are they, and in what order) can differ between users and sessions, and each configuration should have a\n",
+    "    # different ProbeType.\n",
+    "    probe_id: varchar(80)     # a unique ID for this probe and dynamic configuration\n",
+    "    ---\n",
+    "    -> ProbeType              # the type of probe, selected from a controlled list of probe types\n",
+    "    -> [nullable] DataAcquisitionDevice  # the data acquisition device used with this Probe\n",
+    "    contact_side_numbering: enum(\"True\", \"False\")  # if True, then electrode contacts are facing you when numbering them\n",
+    "    \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fdc8f9f-5b32-4f9d-bdbd-d3c4bd0b59a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `common_device`\")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `probe` \"\n",
+    "    \"DROP `probe_description`, \"\n",
+    "    \"DROP `num_shanks`, \"\n",
+    "    \"ADD `probe_type` varchar(80) NOT NULL DEFAULT '' COMMENT '' AFTER `probe_id`, \"\n",
+    "    \"ADD `data_acquisition_device_name` varchar(80) COMMENT '' AFTER `probe_type`\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "232df23f-83c6-4f69-9eb6-1ce7b7126ecb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `common_device`\")\n",
+    "conn.query(\n",
+    "    \"UPDATE `probe` SET `probe_type` = `probe_id` where `probe_type` = ''\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc1f42dc-a5a7-4422-8552-e7e7c4a9905d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn = dj.conn()\n",
+    "conn.query(\"USE `common_device`\")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `probe` \"\n",
+    "    \"ADD FOREIGN KEY (`probe_type`) REFERENCES `common_device`.`probe_type` (`probe_type`) ON UPDATE CASCADE ON DELETE RESTRICT, \"\n",
+    "    \"ADD FOREIGN KEY (`data_acquisition_device_name`) REFERENCES `common_device`.`data_acquisition_device` (`data_acquisition_device_name`) ON UPDATE CASCADE ON DELETE RESTRICT\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90110b79-97b3-4f66-a0c6-5c31b3cfcdbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stop\n",
+    "# restart kernel\n",
+    "# dump databases common_device and common_ephys to file to make sure the name change cascaded correctly\n",
+    "# `docker exec -i dj mysqldump -u root --password=tutorial -h 127.0.0.1 --databases common_device > dump.sql`\n",
+    "# run cell 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5941880a-b34b-460e-a603-8395727eabae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# verify this is correct\n",
+    "sgc.Probe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0069c9f6-d7fb-4c83-bb76-2bc884469bef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# verify the join works\n",
+    "sgc.Probe() * sgc.ProbeType()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8cbc1eb-7eb0-4d97-bcca-c6a2c9c3d4a5",
+   "metadata": {},
+   "source": [
+    "# Move ExperimenterList data to Session.Experimenter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e393aed7-ee6c-4320-9052-3c5703333545",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# access the old ExperimenterList table\n",
+    "schema = dj.schema(\"common_session\")\n",
+    "@schema\n",
+    "class ExperimenterList(dj.Imported):\n",
+    "    definition = \"\"\"\n",
+    "    -> Session\n",
+    "    \"\"\"\n",
+    "\n",
+    "    class Experimenter(dj.Part):\n",
+    "        definition = \"\"\"\n",
+    "        -> ExperimenterList\n",
+    "        -> LabMember\n",
+    "        \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6d1b2db-4c65-4e95-8665-e8f2ffd29816",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = ExperimenterList.Experimenter()\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a72571b-7936-4d82-a0c7-4654f47c9171",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgc.Session.Experimenter.insert(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7fd8fda-c42a-4f25-8b45-7829918d03c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgc.Session.Experimenter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba75818b-ee71-4f85-a183-28f894f2644f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ExperimenterList.drop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "629eef8f-d46d-4890-993a-12b7f784e100",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/db_alter.ipynb
+++ b/examples/db_alter.ipynb
@@ -7,7 +7,7 @@
     "tags": []
    },
    "source": [
-    "# Altering a Spyglass DataJoint table "
+    "# Altering a Spyglass DataJoint table\n"
    ]
   },
   {
@@ -16,11 +16,12 @@
    "metadata": {},
    "source": [
     "This notebook was used to do the following modifications to Loren Frank Lab's Spyglass database:\n",
+    "\n",
     "1. Move table LFPElectrodeGroup from lfp_v1 schema to new schema called lfp_electrode\n",
     "2. Move table ImportedLFPV1 from lfp_v1 schema to new schema called lfp_imported\n",
     "3. Remove empty tables in the lfp-related schema that are not associated with any code and create issues when plotting ERDs\n",
     "\n",
-    "See https://github.com/LorenFrankLab/spyglass/pull/594"
+    "See https://github.com/LorenFrankLab/spyglass/pull/594\n"
    ]
   },
   {
@@ -29,9 +30,10 @@
    "metadata": {},
    "source": [
     "# Prepare local test database using backup of production database\n",
+    "\n",
     "```\n",
     "# ssh into a frank lab machine\n",
-    "ssh rly@typhoon.cin.ucsf.edu -p 7777\n",
+    "ssh rly@typhoon.cin.ucsf.edu -p XXXX\n",
     "\n",
     "# zip up the latest database backup and place in your home directory on the frank lab remote storage\n",
     "# change the dates in the file names as appropriate\n",
@@ -41,7 +43,7 @@
     "\n",
     "# copy the zipped up database backup to your local machine\n",
     "# NOTE: this is a large file >11 GB\n",
-    "scp -P 7777 rly@typhoon.cin.ucsf.edu:lmf-db-20230722.tar.gz ~/Downloads/\n",
+    "scp -P XXXX rly@typhoon.cin.ucsf.edu:lmf-db-20230722.tar.gz ~/Downloads/\n",
     "cd ~/Downloads\n",
     "tar -xzvf lmf-db-20230720.tar.gz\n",
     "# this will unzip into a stelmo folder in ~/Downloads\n",
@@ -54,7 +56,7 @@
     "# load the database backup into the local empty database\n",
     "# this will take ~20 minutes depending on the size of the backup and speed of the computer...\n",
     "cat ~/Downloads/stelmo/mysql-backup/lmf-db-20230722/mysql-all.sql | docker exec -i dj mysql -u root --password=tutorial -h 127.0.0.1\n",
-    "```"
+    "```\n"
    ]
   },
   {
@@ -67,16 +69,18 @@
     "For LFPElectrodeGroup (encoded as l_f_p_electrode_group in mysql tables):\n",
     "\n",
     "Search for all instances of the table name being altered in mysql-all.sql\n",
+    "\n",
     "```\n",
     "grep l_f_p_electrode_group ~/Downloads/stelmo/mysql-backup/lmf-db-20230722/mysql-all.sql > out.txt\n",
     "```\n",
     "\n",
     "take note of which tables these are in. for example:\n",
-    "- l_f_p_band_selection__l_f_p_band_electrode_ibfk_2 is a foreign key from LFPBandSelection._LFPBandElectrode that references\n",
-    "`` `lfp_v1`.`l_f_p_electrode_group__l_f_p_electrode` ``\n",
-    "- similarly for _imported_l_f_p_ibfk_2 and _imported_l_f_p_v1_ibfk_2\n",
-    "- l_f_p_band_selection__l_f_p_band_electrode_ibfk_2 is a foreign key from LFPBandSelection._LFPBandElectrode that references\n",
-    "`l_f_p_electrode_group__l_f_p_electrode`\n",
+    "\n",
+    "- l_f_p_band_selection**l_f_p_band_electrode_ibfk_2 is a foreign key from LFPBandSelection.\\_LFPBandElectrode that references\n",
+    "  `` `lfp_v1`.`l_f_p_electrode_group**l_f_p_electrode` ``\n",
+    "- similarly for \\_imported_l_f_p_ibfk_2 and \\_imported_l_f_p_v1_ibfk_2\n",
+    "- l_f_p_band_selection**l_f_p_band_electrode_ibfk_2 is a foreign key from LFPBandSelection.\\_LFPBandElectrode that references\n",
+    "  `l_f_p_electrode_group**l_f_p_electrode`\n",
     "- l_f_p_selection_ibfk_1 is a foreign key from LFPSelection that references `l_f_p_electrode_group`\n",
     "\n",
     "ignore all logs and innodb_table_stats.\n",
@@ -84,6 +88,7 @@
     "use `grep -A 20 -B 20` to get context around each match\n",
     "\n",
     "also search the spyglass codebase for references to this table\n",
+    "\n",
     "- imported in `lfp/v1/__init__.py`\n",
     "- defined in `lfp/v1/lfp.py`\n",
     "- has a part table\n",
@@ -96,6 +101,7 @@
     "- LFPOutput.ImportedLFP still has a foreign key to ImportedLFP. This should be a foreign key to ImportedLFPV1.\n",
     "\n",
     "The ImportedLFPV1 table is being moved and renamed. LFPOutput.ImportedLFPV1 is also being renamed.\n",
+    "\n",
     "- it is currently empty.\n",
     "- ImportedLFP is also empty.\n",
     "- LFPOutput.ImportedLFP is also empty.\n",
@@ -104,13 +110,14 @@
     "\n",
     "Need to find all the foreign keys to these tables and drop those keys (or tables) before dropping the above tables.\n",
     "In this order:\n",
+    "\n",
     "- Drop empty LFPMerge.ImportedLFPV1\n",
     "- Drop empty LFPOutput.ImportedLFP\n",
     "- Drop empty ImportedLFPV1\n",
     "- Drop empty ImportedLFP\n",
-    "...\n",
+    "  ...\n",
     "\n",
-    "Delete the local docker volume and reload the backup database as needed to nail down the sequence of steps that you will perform on the production database."
+    "Delete the local docker volume and reload the backup database as needed to nail down the sequence of steps that you will perform on the production database.\n"
    ]
   },
   {
@@ -118,7 +125,7 @@
    "id": "8153d27e-0aff-43f5-a695-be7036945e1c",
    "metadata": {},
    "source": [
-    "# Make sure your repo is on the master branch"
+    "# Make sure your repo is on the master branch\n"
    ]
   },
   {
@@ -126,7 +133,7 @@
    "id": "9610c0f7-d830-4d81-b539-813485ccece6",
    "metadata": {},
    "source": [
-    "# Configure a connection to the local database for a dry run - skip this cell if running on frank lab servers on the production database"
+    "# Configure a connection to the local database for a dry run - skip this cell if running on frank lab servers on the production database\n"
    ]
   },
   {
@@ -143,14 +150,16 @@
     "from pathlib import Path\n",
     "\n",
     "# set dirs\n",
-    "base_dir = Path('/Users/rly/Documents/NWB/spyglass-workspace') # change this to your desired directory\n",
-    "raw_dir = base_dir / 'raw'\n",
-    "analysis_dir = base_dir / 'analysis'\n",
-    "recording_dir = base_dir / 'recording'\n",
-    "sorting_dir = base_dir / 'sorting'\n",
-    "waveforms_dir = base_dir / 'waveforms'\n",
-    "tmp_dir = base_dir / 'tmp'\n",
-    "kachery_cloud_dir = base_dir / '.kachery_cloud'\n",
+    "base_dir = Path(\n",
+    "    \"/Users/rly/Documents/NWB/spyglass-workspace\"\n",
+    ")  # change this to your desired directory\n",
+    "raw_dir = base_dir / \"raw\"\n",
+    "analysis_dir = base_dir / \"analysis\"\n",
+    "recording_dir = base_dir / \"recording\"\n",
+    "sorting_dir = base_dir / \"sorting\"\n",
+    "waveforms_dir = base_dir / \"waveforms\"\n",
+    "tmp_dir = base_dir / \"tmp\"\n",
+    "kachery_cloud_dir = base_dir / \".kachery_cloud\"\n",
     "\n",
     "os.makedirs(raw_dir, exist_ok=True)\n",
     "os.makedirs(analysis_dir, exist_ok=True)\n",
@@ -161,32 +170,32 @@
     "os.makedirs(kachery_cloud_dir, exist_ok=True)\n",
     "\n",
     "# set dj config\n",
-    "dj.config['database.host'] = 'localhost'\n",
-    "dj.config['database.user'] = 'root'\n",
-    "dj.config['database.password'] = 'tutorial'\n",
-    "dj.config['database.port'] = 3306\n",
-    "dj.config['stores'] = {\n",
-    "  'raw': {\n",
-    "    'protocol': 'file',\n",
-    "    'location': str(raw_dir),\n",
-    "    'stage': str(raw_dir)\n",
-    "  },\n",
-    "  'analysis': {\n",
-    "    'protocol': 'file',\n",
-    "    'location': str(analysis_dir),\n",
-    "    'stage': str(analysis_dir)\n",
-    "  }\n",
+    "dj.config[\"database.host\"] = \"localhost\"\n",
+    "dj.config[\"database.user\"] = \"root\"\n",
+    "dj.config[\"database.password\"] = \"tutorial\"\n",
+    "dj.config[\"database.port\"] = 3306\n",
+    "dj.config[\"stores\"] = {\n",
+    "    \"raw\": {\n",
+    "        \"protocol\": \"file\",\n",
+    "        \"location\": str(raw_dir),\n",
+    "        \"stage\": str(raw_dir),\n",
+    "    },\n",
+    "    \"analysis\": {\n",
+    "        \"protocol\": \"file\",\n",
+    "        \"location\": str(analysis_dir),\n",
+    "        \"stage\": str(analysis_dir),\n",
+    "    },\n",
     "}\n",
     "dj.config[\"enable_python_native_blobs\"] = True\n",
     "\n",
     "# set env vars\n",
-    "os.environ['SPYGLASS_BASE_DIR'] = str(base_dir)\n",
-    "os.environ['SPYGLASS_RECORDING_DIR'] = str(recording_dir)\n",
-    "os.environ['SPYGLASS_SORTING_DIR'] = str(sorting_dir)\n",
-    "os.environ['SPYGLASS_WAVEFORMS_DIR'] = str(waveforms_dir)\n",
-    "os.environ['SPYGLASS_TEMP_DIR'] = str(tmp_dir)\n",
-    "os.environ['KACHERY_CLOUD_DIR'] = str(kachery_cloud_dir)\n",
-    "os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = 'TRUE'"
+    "os.environ[\"SPYGLASS_BASE_DIR\"] = str(base_dir)\n",
+    "os.environ[\"SPYGLASS_RECORDING_DIR\"] = str(recording_dir)\n",
+    "os.environ[\"SPYGLASS_SORTING_DIR\"] = str(sorting_dir)\n",
+    "os.environ[\"SPYGLASS_WAVEFORMS_DIR\"] = str(waveforms_dir)\n",
+    "os.environ[\"SPYGLASS_TEMP_DIR\"] = str(tmp_dir)\n",
+    "os.environ[\"KACHERY_CLOUD_DIR\"] = str(kachery_cloud_dir)\n",
+    "os.environ[\"DJ_SUPPORT_FILEPATH_MANAGEMENT\"] = \"TRUE\""
    ]
   },
   {
@@ -194,7 +203,7 @@
    "id": "9e2f53b3-8e47-4542-88db-61c5865214a2",
    "metadata": {},
    "source": [
-    "# Start here instead of above if running on the Frank Lab servers on the production database"
+    "# Start here instead of above if running on the Frank Lab servers on the production database\n"
    ]
   },
   {
@@ -224,7 +233,7 @@
    "id": "681d51ca-cf1b-4b9c-b4d1-4cbb94506195",
    "metadata": {},
    "source": [
-    "# Plot ERDs of the tables being altered to see what tables depend on these tables"
+    "# Plot ERDs of the tables being altered to see what tables depend on these tables\n"
    ]
   },
   {
@@ -254,7 +263,7 @@
    "id": "922847bc-a820-4327-9927-1dd27febe482",
    "metadata": {},
    "source": [
-    "# Start with tasks #2 and #3"
+    "# Start with tasks #2 and #3\n"
    ]
   },
   {
@@ -263,8 +272,9 @@
    "metadata": {},
    "source": [
     "# Confirm that the tables being dropped are empty\n",
+    "\n",
     "- If the table exists, just print the contents, e.g., `lfp.LFPOutput.ImportedLFPV1`\n",
-    "- If the table does not exist, use a MySQL database browser, like TablePlus for macOS."
+    "- If the table does not exist, use a MySQL database browser, like TablePlus for macOS.\n"
    ]
   },
   {
@@ -282,7 +292,7 @@
    "id": "437dabfa-e7cc-4094-acb3-3242200df9c7",
    "metadata": {},
    "source": [
-    "The `lfp_v1.l_f_p_output` table shouldn't even exist anymore. There are no references in the codebase to it anymore. It should have been replaced with the `lfp_merge.l_f_p_output` table. But the data in the two tables differ... Probably `lfp_v1.l_f_p_output` is old. It has only 80 rows. Ignore this for now."
+    "The `lfp_v1.l_f_p_output` table shouldn't even exist anymore. There are no references in the codebase to it anymore. It should have been replaced with the `lfp_merge.l_f_p_output` table. But the data in the two tables differ... Probably `lfp_v1.l_f_p_output` is old. It has only 80 rows. Ignore this for now.\n"
    ]
   },
   {
@@ -291,9 +301,10 @@
    "metadata": {},
    "source": [
     "# Drop tables starting with those that no other tables depend upon\n",
+    "\n",
     "Carefully, one at a time...\n",
     "\n",
-    "The expected output if the command passes is `<pymysql.cursors.Cursor at ...>`"
+    "The expected output if the command passes is `<pymysql.cursors.Cursor at ...>`\n"
    ]
   },
   {
@@ -305,7 +316,9 @@
    "source": [
     "conn = dj.conn()\n",
     "conn.query(\"USE `lfp_merge`\")\n",
-    "conn.query(\"DROP TABLE `lfp_merge`.`l_f_p_output__imported_l_f_p_v1`\")  # can't use datajoint to drop this because it's a part table"
+    "conn.query(\n",
+    "    \"DROP TABLE `lfp_merge`.`l_f_p_output__imported_l_f_p_v1`\"\n",
+    ")  # can't use datajoint to drop this because it's a part table"
    ]
   },
   {
@@ -317,7 +330,9 @@
    "source": [
     "conn = dj.conn()\n",
     "conn.query(\"USE `lfp_v1`\")\n",
-    "conn.query(\"DROP TABLE `lfp_v1`.`l_f_p_output__imported_l_f_p`\")  # can't use datajoint to drop this because it's a part table and also doesn't exist in the code"
+    "conn.query(\n",
+    "    \"DROP TABLE `lfp_v1`.`l_f_p_output__imported_l_f_p`\"\n",
+    ")  # can't use datajoint to drop this because it's a part table and also doesn't exist in the code"
    ]
   },
   {
@@ -329,7 +344,9 @@
    "source": [
     "conn = dj.conn()\n",
     "conn.query(\"USE `lfp_v1`\")\n",
-    "conn.query(\"DROP TABLE `lfp_v1`.`_imported_l_f_p_v1`\")  # can't use datajoint to drop this because it doesn't exist in the code"
+    "conn.query(\n",
+    "    \"DROP TABLE `lfp_v1`.`_imported_l_f_p_v1`\"\n",
+    ")  # can't use datajoint to drop this because it doesn't exist in the code"
    ]
   },
   {
@@ -341,7 +358,9 @@
    "source": [
     "conn = dj.conn()\n",
     "conn.query(\"USE `lfp_v1`\")\n",
-    "conn.query(\"DROP TABLE `lfp_v1`.`_imported_l_f_p`\")  # can't use datajoint to drop this because it doesn't exist in the code"
+    "conn.query(\n",
+    "    \"DROP TABLE `lfp_v1`.`_imported_l_f_p`\"\n",
+    ")  # can't use datajoint to drop this because it doesn't exist in the code"
    ]
   },
   {
@@ -349,7 +368,7 @@
    "id": "bd8fc6c0-6364-427d-8026-4bc11f676eb2",
    "metadata": {},
    "source": [
-    "# Task 1. Rename the tables while maintaining foreign key references from other tables to these tables "
+    "# Task 1. Rename the tables while maintaining foreign key references from other tables to these tables\n"
    ]
   },
   {
@@ -371,7 +390,9 @@
    "source": [
     "conn = dj.conn()\n",
     "conn.query(\"USE `lfp_v1`\")\n",
-    "conn.query(\"ALTER TABLE `lfp_v1`.`l_f_p_electrode_group` RENAME `lfp_electrode`.`l_f_p_electrode_group`\")"
+    "conn.query(\n",
+    "    \"ALTER TABLE `lfp_v1`.`l_f_p_electrode_group` RENAME `lfp_electrode`.`l_f_p_electrode_group`\"\n",
+    ")"
    ]
   },
   {
@@ -383,7 +404,9 @@
    "source": [
     "conn = dj.conn()\n",
     "conn.query(\"USE `lfp_v1`\")\n",
-    "conn.query(\"ALTER TABLE `lfp_v1`.`l_f_p_electrode_group__l_f_p_electrode` RENAME `lfp_electrode`.`l_f_p_electrode_group__l_f_p_electrode`\")"
+    "conn.query(\n",
+    "    \"ALTER TABLE `lfp_v1`.`l_f_p_electrode_group__l_f_p_electrode` RENAME `lfp_electrode`.`l_f_p_electrode_group__l_f_p_electrode`\"\n",
+    ")"
    ]
   },
   {
@@ -392,19 +415,22 @@
    "metadata": {},
    "source": [
     "# Verify the changes\n",
+    "\n",
     "Dump individual databases to a file and search for lingering references to `lfp_v1.l_f_p_electrode_group` or `lfp_v1.l_f_p_electrode_group__l_f_p_electrode`. Make sure they have been updated.\n",
+    "\n",
     "```\n",
     "docker exec -i dj mysqldump -u root --password=tutorial -h 127.0.0.1 --databases lfp_v1 > dump_lfp_v1.sql\n",
     "docker exec -i dj mysqldump -u root --password=tutorial -h 127.0.0.1 --databases lfp_band_v1 > dump_lfp_band_v1.sql\n",
     "```\n",
     "\n",
     "You might also just be able to run:\n",
+    "\n",
     "```\n",
     "SELECT * FROM information_schema.KEY_COLUMN_USAGE WHERE REFERENCED_TABLE_NAME = 'l_f_p_electrode_group'\n",
     "SELECT * FROM information_schema.KEY_COLUMN_USAGE WHERE REFERENCED_TABLE_NAME = 'l_f_p_electrode_group__l_f_p_electrode'\n",
     "```\n",
     "\n",
-    "If time permits, run through the steps of this notebook again to make sure it is smooth and foolproof before running this on the production database."
+    "If time permits, run through the steps of this notebook again to make sure it is smooth and foolproof before running this on the production database.\n"
    ]
   },
   {
@@ -412,7 +438,7 @@
    "id": "9f1cfdd0-202e-4a15-b6f9-0af768bb5a61",
    "metadata": {},
    "source": [
-    "# Then switch git branches to the PR with the new changes"
+    "# Then switch git branches to the PR with the new changes\n"
    ]
   },
   {
@@ -420,7 +446,7 @@
    "id": "8288acea-e97c-4a34-bb83-c89c49102b37",
    "metadata": {},
    "source": [
-    "# Restart the Jupyter kernel. Confirm things work. Connect to the local database again."
+    "# Restart the Jupyter kernel. Confirm things work. Connect to the local database again.\n"
    ]
   },
   {
@@ -435,14 +461,16 @@
     "from pathlib import Path\n",
     "\n",
     "# set dirs\n",
-    "base_dir = Path('/Users/rly/Documents/NWB/spyglass-workspace') # change this to your desired directory\n",
-    "raw_dir = base_dir / 'raw'\n",
-    "analysis_dir = base_dir / 'analysis'\n",
-    "recording_dir = base_dir / 'recording'\n",
-    "sorting_dir = base_dir / 'sorting'\n",
-    "waveforms_dir = base_dir / 'waveforms'\n",
-    "tmp_dir = base_dir / 'tmp'\n",
-    "kachery_cloud_dir = base_dir / '.kachery_cloud'\n",
+    "base_dir = Path(\n",
+    "    \"/Users/rly/Documents/NWB/spyglass-workspace\"\n",
+    ")  # change this to your desired directory\n",
+    "raw_dir = base_dir / \"raw\"\n",
+    "analysis_dir = base_dir / \"analysis\"\n",
+    "recording_dir = base_dir / \"recording\"\n",
+    "sorting_dir = base_dir / \"sorting\"\n",
+    "waveforms_dir = base_dir / \"waveforms\"\n",
+    "tmp_dir = base_dir / \"tmp\"\n",
+    "kachery_cloud_dir = base_dir / \".kachery_cloud\"\n",
     "\n",
     "os.makedirs(raw_dir, exist_ok=True)\n",
     "os.makedirs(analysis_dir, exist_ok=True)\n",
@@ -453,32 +481,32 @@
     "os.makedirs(kachery_cloud_dir, exist_ok=True)\n",
     "\n",
     "# set dj config\n",
-    "dj.config['database.host'] = 'localhost'\n",
-    "dj.config['database.user'] = 'root'\n",
-    "dj.config['database.password'] = 'tutorial'\n",
-    "dj.config['database.port'] = 3306\n",
-    "dj.config['stores'] = {\n",
-    "  'raw': {\n",
-    "    'protocol': 'file',\n",
-    "    'location': str(raw_dir),\n",
-    "    'stage': str(raw_dir)\n",
-    "  },\n",
-    "  'analysis': {\n",
-    "    'protocol': 'file',\n",
-    "    'location': str(analysis_dir),\n",
-    "    'stage': str(analysis_dir)\n",
-    "  }\n",
+    "dj.config[\"database.host\"] = \"localhost\"\n",
+    "dj.config[\"database.user\"] = \"root\"\n",
+    "dj.config[\"database.password\"] = \"tutorial\"\n",
+    "dj.config[\"database.port\"] = 3306\n",
+    "dj.config[\"stores\"] = {\n",
+    "    \"raw\": {\n",
+    "        \"protocol\": \"file\",\n",
+    "        \"location\": str(raw_dir),\n",
+    "        \"stage\": str(raw_dir),\n",
+    "    },\n",
+    "    \"analysis\": {\n",
+    "        \"protocol\": \"file\",\n",
+    "        \"location\": str(analysis_dir),\n",
+    "        \"stage\": str(analysis_dir),\n",
+    "    },\n",
     "}\n",
     "dj.config[\"enable_python_native_blobs\"] = True\n",
     "\n",
     "# set env vars\n",
-    "os.environ['SPYGLASS_BASE_DIR'] = str(base_dir)\n",
-    "os.environ['SPYGLASS_RECORDING_DIR'] = str(recording_dir)\n",
-    "os.environ['SPYGLASS_SORTING_DIR'] = str(sorting_dir)\n",
-    "os.environ['SPYGLASS_WAVEFORMS_DIR'] = str(waveforms_dir)\n",
-    "os.environ['SPYGLASS_TEMP_DIR'] = str(tmp_dir)\n",
-    "os.environ['KACHERY_CLOUD_DIR'] = str(kachery_cloud_dir)\n",
-    "os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = 'TRUE'"
+    "os.environ[\"SPYGLASS_BASE_DIR\"] = str(base_dir)\n",
+    "os.environ[\"SPYGLASS_RECORDING_DIR\"] = str(recording_dir)\n",
+    "os.environ[\"SPYGLASS_SORTING_DIR\"] = str(sorting_dir)\n",
+    "os.environ[\"SPYGLASS_WAVEFORMS_DIR\"] = str(waveforms_dir)\n",
+    "os.environ[\"SPYGLASS_TEMP_DIR\"] = str(tmp_dir)\n",
+    "os.environ[\"KACHERY_CLOUD_DIR\"] = str(kachery_cloud_dir)\n",
+    "os.environ[\"DJ_SUPPORT_FILEPATH_MANAGEMENT\"] = \"TRUE\""
    ]
   },
   {
@@ -903,6 +931,7 @@
    ],
    "source": [
     "from spyglass.lfp.lfp_electrode import LFPElectrodeGroup\n",
+    "\n",
     "LFPElectrodeGroup()"
    ]
   },
@@ -912,10 +941,12 @@
    "metadata": {},
    "source": [
     "# Run this on the production database on the frank lab servers\n",
+    "\n",
     "- Log in to the frank lab server\n",
     "- Reinstall the master branch of spyglass\n",
+    "\n",
     "```\n",
-    "ssh rly@typhoon.cin.ucsf.edu -p 7777\n",
+    "ssh rly@typhoon.cin.ucsf.edu -p XXXX\n",
     "cd spyglass\n",
     "# remove the existing spyglass repo if it exists\n",
     "mamba remove --name spyglass --all --yes\n",
@@ -926,9 +957,10 @@
     "mamba activate spyglass\n",
     "pip install -e .\n",
     "```\n",
+    "\n",
     "- Copy this notebook there\n",
     "- Start jupyter\n",
-    "- Run through all the above steps EXCEPT do not configure datajoint to connect to a local database. Datajoint is already configured to connect to the Frank Lab spyglass production database (at least on Ryan's account) "
+    "- Run through all the above steps EXCEPT do not configure datajoint to connect to a local database. Datajoint is already configured to connect to the Frank Lab spyglass production database (at least on Ryan's account)\n"
    ]
   },
   {
@@ -973,10 +1005,12 @@
     "2. Copy all entries from common_ephys.LFPSelection to new lfp_electrode.LFPElectrodeGroup and set the \"lfp_electrode_group_name\" values to \"full_session_full_channel_set\"\n",
     "3. Add a column in common_ephys.LFP that is a foreign key to new lfp_electrode.LFPElectrodeGroup with the values equal to the new entries in lfp_electrode.LFPElectrodeGroup\n",
     "4. Change the primary key of common_ephys.LFP to new lfp_electrode.LFPElectrodeGroup (this might involve adding a new primary key and then removing the old one).\n",
+    "\n",
     "- If changing the primary key requires manually adding the new \"lfp_electrode_group_name\" to every table downstream of common_ephys.LFP, then abort mission.\n",
     "- To add a new primary key, we would need to drop the foreign key to the primary key of common_ephys.LFP (recursively) on every downstream table, some of which may be primary keys themselves. This would require dropping basically reference to common_ephys.LFP and every reference to a table that references that, etc.\n",
     "\n",
     "### ChatGPT says:\n",
+    "\n",
     "If you encounter the \"Foreign key constraint is incorrectly formed\" error when trying to drop the primary key, it might be because there are foreign key constraints referencing the primary key you're attempting to drop.\n",
     "\n",
     "To add a new column to an existing primary key without encountering this issue, you can follow these steps:\n",
@@ -1027,7 +1061,7 @@
     "\n",
     "   Replace `referencing_table1`, `referencing_table2`, etc., with the names of the tables that have foreign key constraints, `constraint_name1`, `constraint_name2`, etc., with the desired names of the foreign key constraints, and `foreign_key_column1`, `foreign_key_column2`, etc., with the columns in the referencing tables that reference the new primary key column.\n",
     "\n",
-    "Please be cautious when modifying primary keys and foreign key constraints, as they are critical to maintaining data integrity. Always have proper backups and thoroughly test any changes in a safe environment before applying them to production data."
+    "Please be cautious when modifying primary keys and foreign key constraints, as they are critical to maintaining data integrity. Always have proper backups and thoroughly test any changes in a safe environment before applying them to production data.\n"
    ]
   },
   {
@@ -1043,7 +1077,7 @@
    "id": "14e670e7-d50b-46b2-b9a4-06c97332dc63",
    "metadata": {},
    "source": [
-    "# Old cells from previous database surgery"
+    "# Old cells from previous database surgery\n"
    ]
   },
   {
@@ -1051,7 +1085,7 @@
    "id": "2a3ed9e2-dda3-4c6f-8ae8-e4adf1f5f69f",
    "metadata": {},
    "source": [
-    "# Alter DataAcquisitionDevice and create DataAcquisitionDeviceSystem and DataAcquisitionDeviceAmplifier tables"
+    "# Alter DataAcquisitionDevice and create DataAcquisitionDeviceSystem and DataAcquisitionDeviceAmplifier tables\n"
    ]
   },
   {
@@ -1085,7 +1119,12 @@
    "outputs": [],
    "source": [
     "# rename the fields\n",
-    "res.dtype.names=[\"data_acquisition_device_name\", \"data_acquisition_device_system\", \"data_acquisition_device_amplifier\", \"adc_circuit\"]\n",
+    "res.dtype.names = [\n",
+    "    \"data_acquisition_device_name\",\n",
+    "    \"data_acquisition_device_system\",\n",
+    "    \"data_acquisition_device_amplifier\",\n",
+    "    \"adc_circuit\",\n",
+    "]\n",
     "res"
    ]
   },
@@ -1111,13 +1150,17 @@
     "# these new tables may already exist and have dummy data from testing\n",
     "# temporarily make a class for them and then drop the tables\n",
     "schema = dj.schema(\"common_device\")\n",
+    "\n",
+    "\n",
     "@schema\n",
     "class DataAcquisitionDeviceSystem(dj.Manual):\n",
     "    pass\n",
     "\n",
+    "\n",
     "@schema\n",
     "class DataAcquisitionDeviceAmplifier(dj.Manual):\n",
     "    pass\n",
+    "\n",
     "\n",
     "DataAcquisitionDeviceSystem.drop()\n",
     "DataAcquisitionDeviceAmplifier.drop()"
@@ -1132,6 +1175,7 @@
    "source": [
     "# load new class definitions\n",
     "schema = dj.schema(\"common_device\")\n",
+    "\n",
     "\n",
     "@schema\n",
     "class DataAcquisitionDeviceSystem(dj.Manual):\n",
@@ -1171,7 +1215,9 @@
    "source": [
     "# populate DataAcquisitionDeviceSystem\n",
     "for name in res[\"data_acquisition_device_system\"]:\n",
-    "    DataAcquisitionDeviceSystem.insert1({\"data_acquisition_device_system\": name}, skip_duplicates=True)\n",
+    "    DataAcquisitionDeviceSystem.insert1(\n",
+    "        {\"data_acquisition_device_system\": name}, skip_duplicates=True\n",
+    "    )\n",
     "DataAcquisitionDeviceSystem()"
    ]
   },
@@ -1184,7 +1230,9 @@
    "source": [
     "# populate DataAcquisitionDeviceAmplifier\n",
     "for name in res[\"data_acquisition_device_amplifier\"]:\n",
-    "    DataAcquisitionDeviceAmplifier.insert1({\"data_acquisition_device_amplifier\": name}, skip_duplicates=True)\n",
+    "    DataAcquisitionDeviceAmplifier.insert1(\n",
+    "        {\"data_acquisition_device_amplifier\": name}, skip_duplicates=True\n",
+    "    )\n",
     "DataAcquisitionDeviceAmplifier()"
    ]
   },
@@ -1205,7 +1253,7 @@
    "id": "9310d24d-6f11-4dcb-a399-767d026dc59b",
    "metadata": {},
    "source": [
-    "# Create new ProbeType table"
+    "# Create new ProbeType table\n"
    ]
   },
   {
@@ -1218,6 +1266,8 @@
     "# these new tables may already exist and have dummy data from testing\n",
     "# temporarily make a class for them and then drop the tables\n",
     "schema = dj.schema(\"common_device\")\n",
+    "\n",
+    "\n",
     "@schema\n",
     "class ProbeType(dj.Manual):\n",
     "    definition = \"\"\"\n",
@@ -1232,6 +1282,7 @@
     "    num_shanks: int                                # number of shanks on this probe\n",
     "    \"\"\"\n",
     "\n",
+    "\n",
     "ProbeType.drop()"
    ]
   },
@@ -1244,6 +1295,7 @@
    "source": [
     "# load new class definition\n",
     "schema = dj.schema(\"common_device\")\n",
+    "\n",
     "\n",
     "@schema\n",
     "class ProbeType(dj.Manual):\n",
@@ -1270,11 +1322,13 @@
     "# populate ProbeType from Probe\n",
     "res = sgc.Probe.fetch()\n",
     "for row in res:\n",
-    "    ProbeType.insert1({\n",
-    "        \"probe_type\": row[\"probe_type\"],\n",
-    "        \"probe_description\": row[\"probe_description\"],\n",
-    "        \"num_shanks\": row[\"num_shanks\"]\n",
-    "    })\n",
+    "    ProbeType.insert1(\n",
+    "        {\n",
+    "            \"probe_type\": row[\"probe_type\"],\n",
+    "            \"probe_description\": row[\"probe_description\"],\n",
+    "            \"num_shanks\": row[\"num_shanks\"],\n",
+    "        }\n",
+    "    )\n",
     "ProbeType()"
    ]
   },
@@ -1283,7 +1337,7 @@
    "id": "28f93788-27d6-408e-a26b-e8ec445cac03",
    "metadata": {},
    "source": [
-    "# Alter primary key of Probe table"
+    "# Alter primary key of Probe table\n"
    ]
   },
   {
@@ -1329,14 +1383,28 @@
    "source": [
     "conn = dj.conn()\n",
     "conn.query(\"USE `common_device`\")\n",
-    "conn.query(\"ALTER TABLE `probe` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\")\n",
-    "conn.query(\"ALTER TABLE `probe__shank` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\")\n",
-    "conn.query(\"ALTER TABLE `probe__electrode` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `probe` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\"\n",
+    ")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `probe__shank` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\"\n",
+    ")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `probe__electrode` CHANGE `probe_type` `probe_id` varchar(80) NOT NULL\"\n",
+    ")\n",
     "conn.query(\"USE `common_ephys`\")\n",
-    "conn.query(\"ALTER TABLE `_electrode_group` CHANGE `probe_type` `probe_id` varchar(80) DEFAULT NULL\")\n",
-    "conn.query(\"ALTER TABLE `_electrode_group` DROP KEY `probe_type`, ADD KEY `probe_id` (`probe_id`)\")\n",
-    "conn.query(\"ALTER TABLE `_electrode` CHANGE `probe_type` `probe_id` varchar(80) DEFAULT NULL\")\n",
-    "conn.query(\"ALTER TABLE `_electrode` DROP KEY `probe_type`, ADD KEY `probe_id` (`probe_id`,`probe_shank`,`probe_electrode`)\")"
+    "conn.query(\n",
+    "    \"ALTER TABLE `_electrode_group` CHANGE `probe_type` `probe_id` varchar(80) DEFAULT NULL\"\n",
+    ")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `_electrode_group` DROP KEY `probe_type`, ADD KEY `probe_id` (`probe_id`)\"\n",
+    ")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `_electrode` CHANGE `probe_type` `probe_id` varchar(80) DEFAULT NULL\"\n",
+    ")\n",
+    "conn.query(\n",
+    "    \"ALTER TABLE `_electrode` DROP KEY `probe_type`, ADD KEY `probe_id` (`probe_id`,`probe_shank`,`probe_electrode`)\"\n",
+    ")"
    ]
   },
   {
@@ -1411,7 +1479,7 @@
    "id": "27cbf2c9-9fa4-499f-bb30-2e0c08652945",
    "metadata": {},
    "source": [
-    "# Alter columns of Probe table"
+    "# Alter columns of Probe table\n"
    ]
   },
   {
@@ -1423,7 +1491,8 @@
    "source": [
     "# load new class definition\n",
     "schema = dj.schema(\"common_device\")\n",
-    "from spyglass.common import DataAcquisitionDevice \n",
+    "from spyglass.common import DataAcquisitionDevice\n",
+    "\n",
     "\n",
     "@schema\n",
     "class Probe(dj.Manual):\n",
@@ -1529,7 +1598,7 @@
    "id": "a8cbc1eb-7eb0-4d97-bcca-c6a2c9c3d4a5",
    "metadata": {},
    "source": [
-    "# Move ExperimenterList data to Session.Experimenter"
+    "# Move ExperimenterList data to Session.Experimenter\n"
    ]
   },
   {
@@ -1541,6 +1610,8 @@
    "source": [
     "# access the old ExperimenterList table\n",
     "schema = dj.schema(\"common_session\")\n",
+    "\n",
+    "\n",
     "@schema\n",
     "class ExperimenterList(dj.Imported):\n",
     "    definition = \"\"\"\n",


### PR DESCRIPTION
Add a notebook to the `examples` directory that demonstrates my steps for altering a spyglass/datajoint database table used in #594. It also has some code with notes on the changes from #400. The process is very manual in order to double and triple check the changes in a local copy of the production database before applying them to the live production database. This notebook is not meant to be run "off-the-shelf" but used as a guide for how to implement any future table changes. 

Each situation is different. Renaming/moving a table is easy. Deleting empty tables that no other table references is easy. Moving data from one table to another is more difficult. Adding or removing primary keys on a table that many tables depend on is very difficult.

Regardless of the difficulty, be very careful and test everything locally first.