### PR TITLE
Create Table and helper functions to get position interval name from Interval list key and/or epoch

### DIFF
--- a/src/spyglass/common/__init__.py
+++ b/src/spyglass/common/__init__.py
@@ -17,6 +17,7 @@ from .common_behav import (
     RawPosition,
     StateScriptFile,
     VideoFile,
+    PositionIntervalMap,
 )
 from .common_device import (
     CameraDevice,

--- a/src/spyglass/common/__init__.py
+++ b/src/spyglass/common/__init__.py
@@ -18,6 +18,7 @@ from .common_behav import (
     StateScriptFile,
     VideoFile,
     PositionIntervalMap,
+    convert_epoch_interval_name_to_position_interval_name,
 )
 from .common_device import (
     CameraDevice,

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -391,3 +391,28 @@ def get_pos_interval_list_names(nwb_file_name):
             and (" ".join(interval_list_name.split(" ")[2:]) == "valid times")
         )
     ]
+
+
+def convert_epoch_interval_name_to_position_interval_name(
+    key: dict,
+) -> str:
+    """Converts a primary key for IntervalList to the corresponding position interval name.
+
+    Parameters
+    ----------
+    key : dict
+
+    Returns
+    -------
+    position_interval_name : str
+    """
+    pos_interval_names = (PositionIntervalMap & key).fetch(
+        "position_interval_name"
+    )
+    if len(pos_interval_names) == 0:
+        PositionIntervalMap.populate(key)
+    if len(pos_interval_names) == 0:
+        print(f"No position intervals found for {key}")
+        return []
+    if len(pos_interval_names) == 1:
+        return pos_interval_names[0]

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -296,3 +296,98 @@ class VideoFile(dj.Imported):
                 f"video file with filename: {video_filename} "
                 f"does not exist in {video_dir}/"
             )
+
+
+@schema
+class PositionIntervalMap(dj.Computed):
+    definition = """
+    -> IntervalList
+    ---
+    position_interval_name: varchar(200)  # name of the corresponding position interval
+    """
+
+    def make(self, key):
+        # Find correspondence between pos valid times names and epochs
+        # Use epsilon to tolerate small differences in epoch boundaries across epoch/pos intervals
+
+        # *** HARD CODED VALUES ***
+        epsilon = 0.11  # tolerated time difference in epoch boundaries across epoch/pos intervals
+        # *************************
+
+        # Unpack key
+        nwb_file_name = key["nwb_file_name"]
+
+        # Get pos interval list names
+        pos_interval_list_names = get_pos_interval_list_names(nwb_file_name)
+
+        # Skip populating if no pos interval list names
+        if len(pos_interval_list_names) == 0:
+            print(
+                f"NO POS INTERVALS FOR {key}; CANNOT POPULATE PositionIntervalMap"
+            )
+            return
+
+        # Get the interval times
+        valid_times = (IntervalList & key).fetch1("valid_times")
+        time_interval = [
+            valid_times[0][0] - epsilon,
+            valid_times[-1][-1] + epsilon,
+        ]  # [start, end], widen to tolerate small differences in epoch boundaries across epoch/pos intervals
+
+        # compare the position intervals against our interval
+        matching_pos_interval_list_names = []
+        for (
+            pos_interval_list_name
+        ) in pos_interval_list_names:  # for each pos valid time interval list
+            pos_valid_times = (
+                IntervalList
+                & {
+                    "nwb_file_name": nwb_file_name,
+                    "interval_list_name": pos_interval_list_name,
+                }
+            ).fetch1(
+                "valid_times"
+            )  # get interval valid times
+            pos_time_interval = [
+                pos_valid_times[0][0],
+                pos_valid_times[-1][-1],
+            ]  # [pos valid time interval start, pos valid time interval end]
+            if (time_interval[0] < pos_time_interval[0]) and (
+                time_interval[1] > pos_time_interval[1]
+            ):  # if pos valid time interval within epoch interval
+                matching_pos_interval_list_names.append(
+                    pos_interval_list_name
+                )  # add pos interval list name to list of matching pos interval list names
+
+        # Check that each pos interval was matched to only one epoch
+        if len(matching_pos_interval_list_names) > 1:
+            print(
+                f"MULTIPLE POS INTERVALS MATCHED TO EPOCH {key}; CANNOT POPULATE PositionIntervalMap"
+            )
+            print(matching_pos_interval_list_names)
+            return
+        # Check that at least one pos interval was matched to an epoch
+        if len(matching_pos_interval_list_names) == 0:
+            print(
+                f"No pos intervals matched to epoch {key}; CANNOT POPULATE PositionIntervalMap"
+            )
+            return
+        # Insert into table
+        key["position_interval_name"] = matching_pos_interval_list_names[0]
+        self.insert1(key)
+        print(
+            f'Populated PosIntervalMap for {nwb_file_name}, {key["interval_list_name"]}'
+        )
+
+
+def get_pos_interval_list_names(nwb_file_name):
+    return [
+        interval_list_name
+        for interval_list_name in (
+            IntervalList & {"nwb_file_name": nwb_file_name}
+        ).fetch("interval_list_name")
+        if (
+            (interval_list_name.split(" ")[0] == "pos")
+            and (" ".join(interval_list_name.split(" ")[2:]) == "valid times")
+        )
+    ]

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -406,6 +406,12 @@ def convert_epoch_interval_name_to_position_interval_name(
     -------
     position_interval_name : str
     """
+    # get the interval list name if epoch given in key instead of interval list name
+    if "interval_list_name" not in key and "epoch" in key:
+        key["interval_list_name"] = get_interval_list_name_from_epoch(
+            key["nwb_file_name"], key["epoch"]
+        )
+
     pos_interval_names = (PositionIntervalMap & key).fetch(
         "position_interval_name"
     )
@@ -416,3 +422,36 @@ def convert_epoch_interval_name_to_position_interval_name(
         return []
     if len(pos_interval_names) == 1:
         return pos_interval_names[0]
+
+
+def get_interval_list_name_from_epoch(nwb_file_name: str, epoch: int) -> str:
+    """Returns the interval list name for the given epoch.
+
+    Parameters
+    ----------
+    nwb_file_name : str
+        The name of the NWB file.
+    epoch : int
+        The epoch number.
+
+    Returns
+    -------
+    interval_list_name : str
+        The interval list name.
+    """
+    interval_names = [
+        x
+        for x in (IntervalList() & {"nwb_file_name": nwb_file_name}).fetch(
+            "interval_list_name"
+        )
+        if (x.split("_")[0] == f"{epoch:02}")
+    ]
+    if len(interval_names) == 0:
+        print(f"No interval list name found for {nwb_file_name} epoch {epoch}")
+        return None
+    if len(interval_names) > 1:
+        print(
+            f"Multiple interval list names found for {nwb_file_name} epoch {epoch}"
+        )
+        return None
+    return interval_names[0]

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -311,7 +311,7 @@ class PositionIntervalMap(dj.Computed):
         # Use epsilon to tolerate small differences in epoch boundaries across epoch/pos intervals
 
         # *** HARD CODED VALUES ***
-        epsilon = 0.11  # tolerated time difference in epoch boundaries across epoch/pos intervals
+        EPSILON = 0.11  # tolerated time difference in epoch boundaries across epoch/pos intervals
         # *************************
 
         # Unpack key
@@ -330,8 +330,8 @@ class PositionIntervalMap(dj.Computed):
         # Get the interval times
         valid_times = (IntervalList & key).fetch1("valid_times")
         time_interval = [
-            valid_times[0][0] - epsilon,
-            valid_times[-1][-1] + epsilon,
+            valid_times[0][0] - EPSILON,
+            valid_times[-1][-1] + EPSILON,
         ]  # [start, end], widen to tolerate small differences in epoch boundaries across epoch/pos intervals
 
         # compare the position intervals against our interval

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -417,6 +417,9 @@ def convert_epoch_interval_name_to_position_interval_name(
     )
     if len(pos_interval_names) == 0:
         PositionIntervalMap.populate(key)
+        pos_interval_names = (PositionIntervalMap & key).fetch(
+            "position_interval_name"
+        )
     if len(pos_interval_names) == 0:
         print(f"No position intervals found for {key}")
         return []

--- a/src/spyglass/decoding/clusterless.py
+++ b/src/spyglass/decoding/clusterless.py
@@ -41,8 +41,10 @@ from spyglass.common.common_interval import IntervalList
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.common.common_position import IntervalPositionInfo
 from spyglass.utils.dj_helper_fn import fetch_nwb
-from spyglass.decoding.core import (
+from spyglass.common.common_behav import (
     convert_epoch_interval_name_to_position_interval_name,
+)
+from spyglass.decoding.core import (
     convert_valid_times_to_slice,
     get_valid_ephys_position_times_by_epoch,
 )

--- a/src/spyglass/decoding/clusterless.py
+++ b/src/spyglass/decoding/clusterless.py
@@ -733,7 +733,10 @@ def get_decoding_data_for_epoch(
     valid_slices = convert_valid_times_to_slice(valid_ephys_position_times)
     position_interval_name = (
         convert_epoch_interval_name_to_position_interval_name(
-            interval_list_name
+            {
+                "nwb_file_name": nwb_file_name,
+                "interval_list_name": interval_list_name,
+            }
         )
     )
 

--- a/src/spyglass/decoding/core.py
+++ b/src/spyglass/decoding/core.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from spyglass.common.common_behav import RawPosition
+from spyglass.common.common_behav import RawPosition, PositionIntervalMap
 from spyglass.common.common_interval import (
     IntervalList,
     interval_list_intersect,
@@ -125,21 +125,28 @@ def get_valid_ephys_position_times_by_epoch(
 
 
 def convert_epoch_interval_name_to_position_interval_name(
-    epoch_interval_name: str,
+    key: dict,
 ) -> str:
-    """Converts the epoch interval name to the position interval name.
+    """Converts a primary key for IntervalList to the corresponding position interval name.
 
     Parameters
     ----------
-    epoch_interval_name : str
+    key : dict
 
     Returns
     -------
     position_interval_name : str
     """
-
-    pos_interval_number = int(epoch_interval_name.split("_")[0]) - 1
-    return f"pos {pos_interval_number} valid times"
+    pos_interval_names = (PositionIntervalMap & key).fetch(
+        "position_interval_name"
+    )
+    if len(pos_interval_names) == 0:
+        PositionIntervalMap.populate(key)
+    if len(pos_interval_names) == 0:
+        print(f"No position intervals found for {key}")
+        return []
+    if len(pos_interval_names) == 1:
+        return pos_interval_names[0]
 
 
 def convert_valid_times_to_slice(valid_times: np.ndarray) -> list[slice]:

--- a/src/spyglass/decoding/core.py
+++ b/src/spyglass/decoding/core.py
@@ -124,31 +124,6 @@ def get_valid_ephys_position_times_by_epoch(
     }
 
 
-def convert_epoch_interval_name_to_position_interval_name(
-    key: dict,
-) -> str:
-    """Converts a primary key for IntervalList to the corresponding position interval name.
-
-    Parameters
-    ----------
-    key : dict
-
-    Returns
-    -------
-    position_interval_name : str
-    """
-    pos_interval_names = (PositionIntervalMap & key).fetch(
-        "position_interval_name"
-    )
-    if len(pos_interval_names) == 0:
-        PositionIntervalMap.populate(key)
-    if len(pos_interval_names) == 0:
-        print(f"No position intervals found for {key}")
-        return []
-    if len(pos_interval_names) == 1:
-        return pos_interval_names[0]
-
-
 def convert_valid_times_to_slice(valid_times: np.ndarray) -> list[slice]:
     """Converts the valid times to a list of slices so that arrays can be indexed easily.
 

--- a/src/spyglass/decoding/sorted_spikes.py
+++ b/src/spyglass/decoding/sorted_spikes.py
@@ -28,8 +28,10 @@ from spyglass.common.common_interval import IntervalList
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.common.common_position import IntervalPositionInfo
 from spyglass.utils.dj_helper_fn import fetch_nwb
-from spyglass.decoding.core import (
+from spyglass.common.common_behav import (
     convert_epoch_interval_name_to_position_interval_name,
+)
+from spyglass.decoding.core import (
     convert_valid_times_to_slice,
     get_valid_ephys_position_times_by_epoch,
 )

--- a/src/spyglass/decoding/sorted_spikes.py
+++ b/src/spyglass/decoding/sorted_spikes.py
@@ -339,7 +339,10 @@ def get_decoding_data_for_epoch(
     # position interval
     position_interval_name = (
         convert_epoch_interval_name_to_position_interval_name(
-            interval_list_name
+            {
+                "nwb_file_name": nwb_file_name,
+                "interval_list_name": interval_list_name,
+            }
         )
     )
 

--- a/src/spyglass/position/v1/position_dlc_pose_estimation.py
+++ b/src/spyglass/position/v1/position_dlc_pose_estimation.py
@@ -9,7 +9,11 @@ import pandas as pd
 import pynwb
 from IPython.display import display
 
-from ...common.common_behav import RawPosition, VideoFile  # noqa: F401
+from ...common.common_behav import (
+    RawPosition,
+    VideoFile,
+    convert_epoch_interval_name_to_position_interval_name,
+)  # noqa: F401
 from ...common.common_nwbfile import AnalysisNwbfile
 from ...utils.dj_helper_fn import fetch_nwb
 from .dlc_utils import OutputLogger, infer_output_dir
@@ -232,7 +236,14 @@ class DLCPoseEstimation(dj.Computed):
             ).strftime("%Y-%m-%d %H:%M:%S")
 
             logger.logger.info("getting raw position")
-            interval_list_name = f"pos {key['epoch']-1} valid times"
+            interval_list_name = (
+                convert_epoch_interval_name_to_position_interval_name(
+                    {
+                        "nwb_file_name": key["nwb_file_name"],
+                        "epoch": key["epoch"],
+                    }
+                )
+            )
             spatial_series = (
                 RawPosition()
                 & {**key, "interval_list_name": interval_list_name}

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -9,6 +9,9 @@ from datajoint.utils import to_camel_case
 from tqdm import tqdm as tqdm
 
 from ...common.common_nwbfile import AnalysisNwbfile
+from ...common.common_behav import (
+    convert_epoch_interval_name_to_position_interval_name,
+)
 from ...utils.dj_helper_fn import fetch_nwb
 from .dlc_utils import get_video_path, make_video
 from .position_dlc_centroid import DLCCentroid
@@ -323,7 +326,15 @@ class DLCPosVideo(dj.Computed):
         if "video_params" not in params:
             params["video_params"] = {}
         M_TO_CM = 100
-        key["interval_list_name"] = f"pos {key['epoch']-1} valid times"
+        interval_list_name = (
+            convert_epoch_interval_name_to_position_interval_name(
+                {
+                    "nwb_file_name": key["nwb_file_name"],
+                    "epoch": key["epoch"],
+                }
+            )
+        )
+        key["interval_list_name"] = interval_list_name
         epoch = (
             int(
                 key["interval_list_name"]


### PR DESCRIPTION
Addresses issue of position interval not always being "pos {epoch-1} valid times". 

- Introduces a new table `PositionIntervalMap` in `common_behav`  composed of `IntervalList` primary keys and `position_interval_name` secondary key
- Updates the `convert_epoch_interval_name_to_position_interval_name` function from the decoding core to make use of this table and moves it to `common_behav`. Function populates `PositionIntervalMap`  if map is not found, meaning shouldn't need to populate table elsewhere if you use this function.
-  `convert_epoch_interval_name_to_position_interval_name`  can find position interval using `nwb_file_name` and either `epoch` or `interval_list_name'
- Cleanup cases where position interval defined assuming epoch-1 with calls to this function