### PR TITLE
Fix parameter name for clusterless

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_sorting.py
+++ b/src/spyglass/spikesorting/spikesorting_sorting.py
@@ -207,7 +207,7 @@ class SpikeSorting(dj.Computed):
             # Detect peaks for clusterless decoding
             detected_spikes = detect_peaks(recording, **sorter_params)
             sorting = si.NumpySorting.from_times_labels(
-                times_list=detected_spikes["sample_ind"],
+                times_list=detected_spikes["sample_index"],
                 labels_list=np.zeros(len(detected_spikes), dtype=np.int),
                 sampling_frequency=recording.get_sampling_frequency(),
             )


### PR DESCRIPTION
`spikeinterface` changed the name of the parameter. I am using version `0.98.2`.