### PR TITLE
Support explicit 2d track definition.

### DIFF
--- a/notebooks/11_2D_Clusterless_Decoding.ipynb
+++ b/notebooks/11_2D_Clusterless_Decoding.ipynb
@@ -1099,7 +1099,7 @@
     "    position_info,\n",
     "    marks,\n",
     "    results,\n",
-    "    classifier.environments[0].place_bin_size,,\n",
+    "    classifier.environments[0].place_bin_size,\n",
     "    position_name=[\"head_position_x\", \"head_position_y\"],\n",
     "    head_direction_name=\"head_orientation\",\n",
     "    speed_name=\"head_speed\",\n",

--- a/notebooks/11_2D_Clusterless_Decoding.ipynb
+++ b/notebooks/11_2D_Clusterless_Decoding.ipynb
@@ -1173,7 +1173,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12 (main, Jun  1 2022, 06:36:29) \n[Clang 12.0.0 ]"
+   "version": "3.9.17"
   },
   "vscode": {
    "interpreter": {

--- a/src/spyglass/decoding/visualization.py
+++ b/src/spyglass/decoding/visualization.py
@@ -562,10 +562,11 @@ def create_interactive_1D_decoding_figurl(
 
 
 def create_interactive_2D_decoding_figurl(
+    track_bin_centers: np.ndarray,
+    track_bin_dimensions: np.ndarray,
     position_info: pd.DataFrame,
     marks: xr.DataArray,
     results: xr.Dataset,
-    bin_size: float,
     position_name: list[str] = ["head_position_x", "head_position_y"],
     head_direction_name: str = "head_orientation",
     speed_name: str = "head_speed",
@@ -576,8 +577,9 @@ def create_interactive_2D_decoding_figurl(
     decode_view = create_2D_decode_view(
         position_time=position_info.index,
         position=position_info[position_name],
+        track_bin_centers=track_bin_centers,
+        track_bin_dimensions=track_bin_dimensions,
         posterior=results[posterior_type].sum("state"),
-        bin_size=bin_size,
         head_dir=position_info[head_direction_name],
     )
 

--- a/src/spyglass/decoding/visualization.py
+++ b/src/spyglass/decoding/visualization.py
@@ -562,8 +562,8 @@ def create_interactive_1D_decoding_figurl(
 
 
 def create_interactive_2D_decoding_figurl(
-    track_bin_centers: np.ndarray,
-    track_bin_dimensions: np.ndarray,
+    interior_place_bin_centers: np.ndarray,
+    place_bin_size: np.ndarray,
     position_info: pd.DataFrame,
     marks: xr.DataArray,
     results: xr.Dataset,
@@ -577,8 +577,8 @@ def create_interactive_2D_decoding_figurl(
     decode_view = create_2D_decode_view(
         position_time=position_info.index,
         position=position_info[position_name],
-        track_bin_centers=track_bin_centers,
-        track_bin_dimensions=track_bin_dimensions,
+        interior_place_bin_centers=interior_place_bin_centers,
+        place_bin_size=place_bin_size,
         posterior=results[posterior_type].sum("state"),
         head_dir=position_info[head_direction_name],
     )

--- a/src/spyglass/decoding/visualization_2D_view.py
+++ b/src/spyglass/decoding/visualization_2D_view.py
@@ -305,7 +305,7 @@ def create_2D_decode_view(
     track_bin_width = place_bin_size[0]
     track_bin_height = place_bin_size[1]
     # NOTE: We expect caller to have converted from fortran ordering already
-    # i.e. somewhere upstream, centers = env.place_bin_centers_[env.is_track_interior_.ravel(oder="F")]
+    # i.e. somewhere upstream, centers = env.place_bin_centers_[env.is_track_interior_.ravel(order="F")]
     upper_left_points = get_ul_corners(track_bin_width, track_bin_height, interior_place_bin_centers)
 
     data = create_static_track_animation(

--- a/src/spyglass/decoding/visualization_2D_view.py
+++ b/src/spyglass/decoding/visualization_2D_view.py
@@ -266,28 +266,12 @@ def get_ul_corners(width: float, height: float, centers):
     return ul.T
 
 
-def make_track(position, bin_size: float = 1.0):
-    (edges, _, place_bin_centers, _) = get_grid(position, bin_size)
-    is_track_interior = get_track_interior(position, edges)
-
-    # bin dimensions are the difference between bin centers in the x and y directions.
-    bin_width = np.max(np.diff(place_bin_centers, axis=0)[:, 0])
-    bin_height = np.max(np.diff(place_bin_centers, axis=0)[:, 1])
-
-    # so we can represent the track as a collection of rectangles of width bin_width and height bin_height,
-    # centered on the values of place_bin_centers where track_interior = true.
-    # Note, the original code uses Fortran ordering.
-    true_ctrs = place_bin_centers[is_track_interior.ravel(order="F")]
-    upper_left_points = get_ul_corners(bin_width, bin_height, true_ctrs)
-
-    return bin_width, bin_height, upper_left_points
-
-
 def create_2D_decode_view(
     position_time: np.ndarray,
     position: np.ndarray,
+    track_bin_centers: np.ndarray,
+    track_bin_dimensions: np.ndarray,
     posterior: xr.DataArray,
-    bin_size: float,
     head_dir: np.ndarray = None,
 ) -> vvf.TrackPositionAnimationV1:
     """Creates a 2D decoding movie view
@@ -296,8 +280,9 @@ def create_2D_decode_view(
     ----------
     position_time : np.ndarray, shape (n_time,)
     position : np.ndarray, shape (n_time, 2)
+    track_bin_centers: np.ndarray, shape (n_track_bins, 2)
+    track_bin_dimensions : np.ndarray, shape (2, 1)
     posterior : xr.DataArray, shape (n_time, n_position_bins)
-    bin_size : float
     head_dir : np.ndarray, optional
 
     Returns
@@ -317,14 +302,16 @@ def create_2D_decode_view(
     if head_dir is not None:
         head_dir = np.squeeze(np.asarray(head_dir))
 
-    track_width, track_height, upper_left_points = make_track(
-        position, bin_size=bin_size
-    )
+    track_bin_width = track_bin_dimensions[0]
+    track_bin_height = track_bin_dimensions[1]
+    # NOTE: We expect caller to have converted from fortran ordering already
+    # i.e. somewhere upstream, centers = env.place_bin_centers_[env.is_track_interior_.ravel(oder="F")]
+    upper_left_points = get_ul_corners(track_bin_width, track_bin_height, track_bin_centers)
 
     data = create_static_track_animation(
         ul_corners=upper_left_points,
-        track_rect_height=track_height,
-        track_rect_width=track_width,
+        track_rect_height=track_bin_height,
+        track_rect_width=track_bin_width,
         timestamps=position_time,
         positions=position.T,
         head_dir=head_dir,

--- a/src/spyglass/decoding/visualization_2D_view.py
+++ b/src/spyglass/decoding/visualization_2D_view.py
@@ -306,7 +306,9 @@ def create_2D_decode_view(
     track_bin_height = place_bin_size[1]
     # NOTE: We expect caller to have converted from fortran ordering already
     # i.e. somewhere upstream, centers = env.place_bin_centers_[env.is_track_interior_.ravel(order="F")]
-    upper_left_points = get_ul_corners(track_bin_width, track_bin_height, interior_place_bin_centers)
+    upper_left_points = get_ul_corners(
+        track_bin_width, track_bin_height, interior_place_bin_centers
+    )
 
     data = create_static_track_animation(
         ul_corners=upper_left_points,

--- a/src/spyglass/decoding/visualization_2D_view.py
+++ b/src/spyglass/decoding/visualization_2D_view.py
@@ -269,8 +269,8 @@ def get_ul_corners(width: float, height: float, centers):
 def create_2D_decode_view(
     position_time: np.ndarray,
     position: np.ndarray,
-    track_bin_centers: np.ndarray,
-    track_bin_dimensions: np.ndarray,
+    interior_place_bin_centers: np.ndarray,
+    place_bin_size: np.ndarray,
     posterior: xr.DataArray,
     head_dir: np.ndarray = None,
 ) -> vvf.TrackPositionAnimationV1:
@@ -280,8 +280,8 @@ def create_2D_decode_view(
     ----------
     position_time : np.ndarray, shape (n_time,)
     position : np.ndarray, shape (n_time, 2)
-    track_bin_centers: np.ndarray, shape (n_track_bins, 2)
-    track_bin_dimensions : np.ndarray, shape (2, 1)
+    interior_place_bin_centers: np.ndarray, shape (n_track_bins, 2)
+    place_bin_size : np.ndarray, shape (2, 1)
     posterior : xr.DataArray, shape (n_time, n_position_bins)
     head_dir : np.ndarray, optional
 
@@ -302,11 +302,11 @@ def create_2D_decode_view(
     if head_dir is not None:
         head_dir = np.squeeze(np.asarray(head_dir))
 
-    track_bin_width = track_bin_dimensions[0]
-    track_bin_height = track_bin_dimensions[1]
+    track_bin_width = place_bin_size[0]
+    track_bin_height = place_bin_size[1]
     # NOTE: We expect caller to have converted from fortran ordering already
     # i.e. somewhere upstream, centers = env.place_bin_centers_[env.is_track_interior_.ravel(oder="F")]
-    upper_left_points = get_ul_corners(track_bin_width, track_bin_height, track_bin_centers)
+    upper_left_points = get_ul_corners(track_bin_width, track_bin_height, interior_place_bin_centers)
 
     data = create_static_track_animation(
         ul_corners=upper_left_points,


### PR DESCRIPTION
### Purpose
Partially addresses `figurl-franklab-views` repo issue #19 (https://github.com/magland/figurl-franklab-views/issues/19) which requested that the 1D and 2D decode visualizations should be explicitly passed the track geometry, rather than inferring it from the animal position data.

### Changes
This PR addresses the issue for the 2D case by removing the `make_track` code from `visualization_2D_view.py` (which was largely cut-and-paste from https://github.com/Eden-Kramer-Lab/replay_trajectory_classification/blob/master/replay_trajectory_classification/environments.py anyway) and instead requiring the physical track description to be input as two arrays:
 - an array of `track_bin_centers`: `n_track_bins` x `2` where each outer entry has the `[x, y]` position (in native units) of the corresponding track bin's center, *in C ordering*
 - an array of `track_bin_dimensions`: `(2,)` which is just a list of the x-dimension (width) and y-dimension (height) to use for displaying each track bin. (I'd recommend using the modal difference along the corresponding dimension, i.e.:
 ```python
track_bin_dimensions = [pd.DataFrame(np.diff(xcoords)).mode().values[0][0], pd.DataFrame(np.diff(ycoords)).mode().values[0][0]]
tbd = np.array(track_bin_dimensions)
 ```
though you could probably adjust these if you wanted e.g. a square representation of each bin, or to change the track in some other way. I've not tested it though--that might result in gaps between the bins or something.)

The balance of the figure-creation logic is unchanged, but I've made corresponding changes in `decoding/visualization.py`'s `create_interactive_2D_decoding_figurl` function to accommodate the new parameters.

Additionally, I've removed what looks like a doubled comma in `notebooks/11_2D_Clusterless_Decoding.ipynb`--sorry about the drive-by.

### Possible further changes
Note the impedance mismatch in bin center layout: the bin centers reported out by the `Environment` object are in Fortran ordering, while the display code expects C ordering. In the interest of making minimal changes and assumptions in this code, I've left this the same; so the caller will need to do something like:
```python
centers = env.place_bin_centers_[env.is_track_interior_.ravel(order="F")]
```
before passing `centers` as the `place_bin_centers` parameter.

I can imagine we'd want to just define this parameter as the output from the `Environment` object and do the `ravel` in this function--if so, that's an easy change.

#### Note

Just as a reminder--since it was a source of confusion for me in revisiting the code--the bins that define the *track* are intentionally separate from the ones output by the decoding model. This is so that we can support cases where the track geometry has a different resolution from the model output. The only thing that's affected by this change is the code that represents the animal's physical position; decoded position uses its own geometry and is unaffected.

### Steps to test:

The following code should generate a 2d decode figurl for evaluation:
```python
import numpy as np; import scipy as sp; import xarray as xr; import pickle; import pandas as pd; import matplotlib as mp; import joblib;

# Ensure all of visualization_2D_view.py is defined in the session, e.g. by pasting the whole file

ds = xr.open_dataset("SOME_DECODING_FILE.nc")
env = joblib.load("CORRESPONDING_STORED_ENV_FILE.pkl")

centers = env.place_bin_centers_[env.is_track_interior_.ravel(order="F")]

xcoords = np.unique(centers[:, 0])
ycoords = np.unique(centers[:, 1])

# confirmation of bin dimensions
pd.DataFrame(np.diff(xcoords)).mode().values[0][0]
# e.g. 1.996609
pd.DataFrame(np.diff(ycoords)).mode()
# e.g. 1.992301

track_bin_dimensions = [pd.DataFrame(np.diff(xcoords)).mode().values[0][0], pd.DataFrame(np.diff(ycoords)).mode().values[0][0]]
tbd = np.array(track_bin_dimensions)
posterior = ds['acausal_posterior'].sum("state")
position_time = np.array(range(posterior.shape[0]))
position = np.array([[1, 1]] * posterior.shape[0])

v = create_2D_decode_view(position_time, position, centers, tbd, posterior)
```