### PR TITLE
Spikesort populator efficiency improvements

### DIFF
--- a/src/spyglass/spikesorting/__init__.py
+++ b/src/spyglass/spikesorting/__init__.py
@@ -1,3 +1,4 @@
+from .curation_figurl import CurationFigurl, CurationFigurlSelection
 from .sortingview import SortingviewWorkspace, SortingviewWorkspaceSelection
 from .spikesorting_artifact import (
     ArtifactDetection,
@@ -20,6 +21,10 @@ from .spikesorting_curation import (
     Waveforms,
     WaveformSelection,
 )
+from .spikesorting_populator import (
+    SpikeSortingPipelineParameters,
+    spikesorting_pipeline_populator,
+)
 from .spikesorting_recording import (
     SortGroup,
     SortInterval,
@@ -31,11 +36,4 @@ from .spikesorting_sorting import (
     SpikeSorterParameters,
     SpikeSorting,
     SpikeSortingSelection,
-)
-
-from .curation_figurl import CurationFigurlSelection, CurationFigurl
-
-from .spikesorting_populator import (
-    spikesorting_pipeline_populator,
-    SpikeSortingPipelineParameters,
 )


### PR DESCRIPTION
### Edits:

- isort to rearrange imports
- replace populate commands projected keys with restriction
- declare variables for dicts that get used mult times
- use list comprehension to add field to dicts when fetched
- above allows use of insert instead of insert1
- replace if len(x) > 0 checks with if x
- wrap comments and docstrings to len 80
- use string template for github url to avoid repeated declaration of str

### Further possible improvements:

- break long func into mult to avoid complexity and permit piecewise execution
- lookup selection table for defaults to separate out pipeline_params fetch
- defaults are not intuitive - rename in main pipeline?