### PR TITLE
Increase tolerance for interval allignment

### DIFF
--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -473,7 +473,7 @@ class PositionIntervalMap(dj.Computed):
             return
 
         # *** HARD CODED VALUES ***
-        EPSILON = 0.11  # tolerated time diff in bounds across epoch/pos
+        EPSILON = 0.51  # tolerated time diff in bounds across epoch/pos
         no_pop_msg = "CANNOT POPULATE PositionIntervalMap"
 
         nwb_file_name = key["nwb_file_name"]


### PR DESCRIPTION
Increase threshold for offset between intervals when mapping epochs to position to avoid missing dues to start timing of position and ephys data in experiment