### PR TITLE
Spikesorting artifact interval debug

### DIFF
--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -51,11 +51,11 @@ class IntervalList(dj.Manual):
         for _, epoch_data in epochs.iterrows():
             epoch_dict = {
                 "nwb_file_name": nwb_file_name,
-                "interval_list_name": epoch_data[1].tags[0]
-                if epoch_data[1].tags
+                "interval_list_name": epoch_data.tags[0]
+                if epoch_data.tags
                 else f"interval_{epoch_data[0]}",
                 "valid_times": np.asarray(
-                    [[epoch_data[1].start_time, epoch_data[1].stop_time]]
+                    [[epoch_data.start_time, epoch_data.stop_time]]
                 ),
             }
 

--- a/src/spyglass/common/common_region.py
+++ b/src/spyglass/common/common_region.py
@@ -45,5 +45,8 @@ class BrainRegion(dj.Lookup):
             subregion_name=subregion_name,
             subsubregion_name=subsubregion_name,
         )
-        cls.insert1(key, skip_duplicates=True)
-        return (BrainRegion & key).fetch1("region_id")
+        query = BrainRegion & key
+        if not query:
+            cls.insert1(key)
+            query = BrainRegion & key
+        return query.fetch1("region_id")

--- a/src/spyglass/spikesorting/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/spikesorting_artifact.py
@@ -197,7 +197,7 @@ def _get_artifact_times(
     # if both thresholds are None, we skip artifract detection
     if (amplitude_thresh is None) and (zscore_thresh is None):
         recording_interval = np.asarray(
-            [valid_timestamps[0], valid_timestamps[-1]]
+            [[valid_timestamps[0], valid_timestamps[-1]]]
         )
         artifact_times_empty = np.asarray([])
         print(


### PR DESCRIPTION
When using settings for Artifact detection is None in the spikesorting pipeline,  the recording interval is created with the incorrect shape (e.g. (2,) instead of (1,2)). 

This PR changes the shape created in line 200 of `spikesorting_artifact.py` (ArtifactDetection is None case) to match that in line 256 of `spikesorting_artifact.py`  (ArtifactDetection occurs case)