### PR TITLE
Fix Minor bugs in TrodesV1 pipeline

### DIFF
--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -175,7 +175,7 @@ class IntervalPositionInfo(dj.Computed):
         )
 
         if add_frame_ind:
-            if not video_frame_ind is None:
+            if video_frame_ind is not None:
                 velocity.create_timeseries(
                     name="video_frame_ind",
                     unit="index",

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -175,7 +175,7 @@ class IntervalPositionInfo(dj.Computed):
         )
 
         if add_frame_ind:
-            if video_frame_ind:
+            if not video_frame_ind is None:
                 velocity.create_timeseries(
                     name="video_frame_ind",
                     unit="index",
@@ -250,18 +250,29 @@ class IntervalPositionInfo(dj.Computed):
 
         # Accepts x/y 'loc' or 'loc1' format for first pos. Renames to 'loc'
         DEFAULT_COLS = ["xloc", "yloc", "xloc2", "yloc2", "xloc1", "yloc1"]
+        ALTERNATIVE_COLS = ["xloc1", "xloc2", "yloc1", "yloc2"]
 
-        cols = list(spatial_df.columns)
-        if len(cols) != 4 or not all([c in DEFAULT_COLS for c in cols]):
-            choice = dj.utils.user_choice(
-                "Unexpected columns in raw position. Assume "
-                + f"{DEFAULT_COLS[:4]}?\n{spatial_df}\n"
-            )
-            if choice.lower() not in ["yes", "y"]:
-                raise ValueError(f"Unexpected columns in raw position: {cols}")
-        # rename first 4 columns, keep rest. Rest dropped below
-        spatial_df.columns = DEFAULT_COLS[:4] + cols[4:]
-
+        if all([c in spatial_df.columns for c in DEFAULT_COLS[:4]]):
+            # move the 4 position columns to front, continue
+            spatial_df = spatial_df[DEFAULT_COLS[:4]]
+        elif all([c in spatial_df.columns for c in ALTERNATIVE_COLS]):
+            # move the 4 position columns to front, rename to default, continue
+            spatial_df = spatial_df[ALTERNATIVE_COLS]
+            spatial_df.columns = DEFAULT_COLS[:4]
+        else:
+            cols = list(spatial_df.columns)
+            if len(cols) != 4 or not all([c in DEFAULT_COLS for c in cols]):
+                choice = dj.utils.user_choice(
+                    "Unexpected columns in raw position. Assume "
+                    + f"{DEFAULT_COLS[:4]}?\n{spatial_df}\n"
+                )
+                if choice.lower() not in ["yes", "y"]:
+                    raise ValueError(
+                        f"Unexpected columns in raw position: {cols}"
+                    )
+            # rename first 4 columns, keep rest. Rest dropped below
+            spatial_df.columns = DEFAULT_COLS[:4] + cols[4:]
+        print(spatial_df)
         # Get spatial series properties
         time = np.asarray(spatial_df.index)  # seconds
         position = np.asarray(spatial_df.iloc[:, :4])  # meters

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -272,7 +272,6 @@ class IntervalPositionInfo(dj.Computed):
                     )
             # rename first 4 columns, keep rest. Rest dropped below
             spatial_df.columns = DEFAULT_COLS[:4] + cols[4:]
-        print(spatial_df)
         # Get spatial series properties
         time = np.asarray(spatial_df.index)  # seconds
         position = np.asarray(spatial_df.iloc[:, :4])  # meters


### PR DESCRIPTION
# Description

- Enable correctly populating TrodesPos when columns in position dataframe contain correct xloc yloc elements but in a different order or with additional column values. Necessary for data from older rec_to_nwb conversions 

- Fix minor bug arising from checking if frame indexes are present

# Checklist:

- [ ] This PR should be accompanied by a release: unsure
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
