### PR TITLE
Prevent Curation from re-adding an existing sorting key with a new cu…

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_populator.py
+++ b/src/spyglass/spikesorting/spikesorting_populator.py
@@ -214,7 +214,8 @@ def spikesorting_pipeline_populator(
     # initial curation
     print("Beginning curation")
     for sorting_key in (SpikeSorting() & sort_dict).fetch("KEY"):
-        Curation.insert_curation(sorting_key)
+        if not (Curation() & sorting_key):
+            Curation.insert_curation(sorting_key)
 
     # Calculate quality metrics and perform automatic curation if specified
     if (


### PR DESCRIPTION
# Description

Calling the `spikesorting_pipeline_populator()` again with the same parameters after already running resulted in many duplicate entries.  This was because `insert_curation()` called with an existing key will create a new entry with a iterated curation_id.  This new entry then runs in all susequent steps of the pipeline, using up compute time and memory.  

This PR avoids this by checking for existing entries in Curation for the sort key before calling `insert_curation()`

# Checklist:

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
