### PR TITLE
Use trusted publishing for releases

### DIFF
--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -80,15 +80,19 @@ jobs:
       # - name: Run tests
       #   run: pytest --doctest-modules -v --pyargs spyglass
   publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
     needs: [test-package]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/spyglass-neuro
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,11 +4,18 @@
     "files.trimFinalNewlines": true,
     "editor.multiCursorModifier": "ctrlCmd",
     "autoDocstring.docstringFormat": "numpy",
-    "python.formatting.provider": "none",
     "remote.SSH.remoteServerListenOnSocket": true,
     "git.confirmSync": false,
     "python.analysis.typeCheckingMode": "off",
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": true
+        },
     },
+    "isort.args": [
+        "--profile",
+        "black"
+    ],
 }


### PR DESCRIPTION
# Description

This PR updates the release action to use trusted publishing instead of github secrets.  From this [blog post](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/): 

> This method can be used in automated environments and eliminates the need to use username/password combinations or manually generated API tokens to authenticate with PyPI when publishing.

This is recommended by PyPI.

I also added isort on save for vscode settings.


# Checklist:

- [x] This PR should be accompanied by a release: (yes/**no**/unsure)
- [x] (If release) I have updated the `CITATION.cff`
- [x] I have updated the `CHANGELOG.md` *doesn't seem necessary here*
- [x] I have added/edited docs/notebooks to reflect the changes
