### PR TITLE
Add error message for single-led with wrong parameters

### DIFF
--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -406,6 +406,12 @@ class IntervalPositionInfo(dj.Computed):
         # Set points to NaN where the front and back LEDs are too separated
         dist_between_LEDs = get_distance(back_LED, front_LED)
         is_too_separated = dist_between_LEDs >= max_LED_separation
+        if np.all(is_too_separated):
+            raise ValueError(
+                "All points are too far apart. If this is single LED data,"
+                + "please check that using a parameter set with large max_LED_seperation."
+                + f"Current max_LED_separation: {max_LED_separation}"
+            )
 
         back_LED[is_too_separated] = np.nan
         front_LED[is_too_separated] = np.nan


### PR DESCRIPTION
# Description

Fixes #679.  Adds an error and suggested fix in cases where LED separation is too high in every frame. Note that this case would cause a later less-informative error prior to this PR, so doesn't remove any functionality.

# Checklist:

- [x] This PR should be accompanied by a release: no
- [x] (If release) I have updated the `CITATION.cff`
- [x] I have updated the `CHANGELOG.md`
- [x] I have added/edited docs/notebooks to reflect the changes
