### PR TITLE
positionVideo debug

### DIFF
--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -899,7 +899,7 @@ class PositionVideo(dj.Computed):
             VideoFile()
             & {"nwb_file_name": key["nwb_file_name"], "epoch": epoch}
         ).fetch1()
-        io = pynwb.NWBHDF5IO(raw_dir + '/' + video_info["nwb_file_name"], "r")
+        io = pynwb.NWBHDF5IO(raw_dir + "/" + video_info["nwb_file_name"], "r")
         nwb_file = io.read()
         nwb_video = nwb_file.objects[video_info["video_file_object_id"]]
         video_filename = nwb_video.external_file[0]
@@ -916,7 +916,9 @@ class PositionVideo(dj.Computed):
             raw_position_df.columns = columns
         # if IntervalPositionInfo supersampled position, downsample to video
         if position_info_df.shape[0] > raw_position_df.shape[0]:
-            ind = np.digitize(raw_position_df.index, position_info_df.index,right=True)
+            ind = np.digitize(
+                raw_position_df.index, position_info_df.index,right=True
+            )
             position_info_df = position_info_df.iloc[ind]
 
         centroids = {

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -917,7 +917,7 @@ class PositionVideo(dj.Computed):
         # if IntervalPositionInfo supersampled position, downsample to video
         if position_info_df.shape[0] > raw_position_df.shape[0]:
             ind = np.digitize(
-                raw_position_df.index, position_info_df.index,right=True
+                raw_position_df.index, position_info_df.index, right=True
             )
             position_info_df = position_info_df.iloc[ind]
 

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -898,10 +898,10 @@ class PositionVideo(dj.Computed):
             VideoFile()
             & {"nwb_file_name": key["nwb_file_name"], "epoch": epoch}
         ).fetch1()
-        io = pynwb.NWBHDF5IO(raw_dir() + video_info["nwb_file_name"], "r")
+        io = pynwb.NWBHDF5IO(raw_dir + '/' + video_info["nwb_file_name"], "r")
         nwb_file = io.read()
         nwb_video = nwb_file.objects[video_info["video_file_object_id"]]
-        video_filename = nwb_video.external_file.value[0]
+        video_filename = nwb_video.external_file[0]
 
         nwb_base_filename = key["nwb_file_name"].replace(".nwb", "")
         output_video_filename = (

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -910,9 +910,15 @@ class PositionVideo(dj.Computed):
             f'{key["position_info_param_name"]}.mp4'
         )
 
+        # ensure standardized column names
         if raw_position_df.columns[0] == "xloc1":
             columns = ["xloc", "yloc", "xloc2", "yloc2"]
             raw_position_df.columns = columns
+        # if IntervalPositionInfo supersampled position, downsample to video
+        if position_info_df.shape[0] > raw_position_df.shape[0]:
+            ind = np.digitize(raw_position_df.index, position_info_df.index,right=True)
+            position_info_df = position_info_df.iloc[ind]
+
         centroids = {
             "red": np.asarray(raw_position_df[["xloc", "yloc"]]),
             "green": np.asarray(raw_position_df[["xloc2", "yloc2"]]),

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -23,7 +23,7 @@ from track_linearization import (
     plot_track_graph,
 )
 
-from ..settings import raw_dir
+from ..settings import raw_dir, video_dir
 from ..utils.dj_helper_fn import fetch_nwb
 from .common_behav import RawPosition, VideoFile
 from .common_interval import IntervalList  # noqa F401
@@ -935,7 +935,7 @@ class PositionVideo(dj.Computed):
 
         print("Making video...")
         self.make_video(
-            video_filename,
+            f"{video_dir}/{video_filename}",
             centroids,
             head_position_mean,
             head_orientation_mean,

--- a/src/spyglass/settings.py
+++ b/src/spyglass/settings.py
@@ -442,3 +442,4 @@ analysis_dir = sg_config.analysis_dir
 sorting_dir = sg_config.sorting_dir
 waveform_dir = sg_config.waveform_dir
 debug_mode = sg_config.debug_mode
+video_dir = sg_config.video_dir


### PR DESCRIPTION
# Description

Fixes several issues in the `positionVideo` make function

- Minor changes to make the raw_dir string and access to the video file path in the nwbfile work correctly
- Allow table to make videos with position data upsampled for decoding
- Ensures proper selection of position data from the nwbfile spatial series across more versions of rec_to_nwb/trodes_to_nwb conversion. (now matches strategy in TrodesPosV1 pipeline from 59b68df)
- Use the video_dir to access the video file

# Checklist:

- [ ] This PR should be accompanied by a release: unsure
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ na] I have added/edited docs/notebooks to reflect the changes
