### PR TITLE
Make artifact interval a 2d array

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/spikesorting_artifact.py
@@ -302,7 +302,7 @@ def _get_artifact_times(
             (valid_timestamps[i[0]], valid_timestamps[i[1]])
         )
 
-    return artifact_removed_valid_times, artifact_intervals_s
+    return np.asarray(artifact_removed_valid_times), artifact_intervals_s
 
 
 def _init_artifact_worker(


### PR DESCRIPTION
# Description

In artifact detection, intervals with artifacts were being saved as a list of tuples rather than a 2D array, which is inconsistent with the `valid_times` in the  `IntervalList` table. This PR changes to make consistent.

# Checklist:

- [ ] This PR should be accompanied by a release: No
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
