### PR TITLE
Changed SpyglassMixin to be imported from dj_mixin rather than dj_hel…

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/spikesorting_curation.py
@@ -15,7 +15,7 @@ import spikeinterface.qualitymetrics as sq
 
 from ..common.common_interval import IntervalList
 from ..common.common_nwbfile import AnalysisNwbfile
-from ..utils.dj_helper_fn import SpyglassMixin
+from ..utils.dj_mixin import SpyglassMixin
 from .merged_sorting_extractor import MergedSortingExtractor
 from .spikesorting_recording import SortInterval, SpikeSortingRecording
 from .spikesorting_sorting import SpikeSorting


### PR DESCRIPTION
# Description

SpyglassMixin was previously imported from utils.dj_helper_fn but seems it should be from dj_mixin. Updated to reflect this.

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff` 
- [ ] I have updated the `CHANGELOG.md` 
- [ ] I have added/edited docs/notebooks to reflect the changes
