### PR TITLE
added Path library to imports

### DIFF
--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pynwb
 import spikeinterface as si
 from hdmf.common import DynamicTable
+from pathlib import Path
 
 from ..settings import raw_dir
 from ..utils.dj_helper_fn import get_child_tables


### PR DESCRIPTION
# Description

Import library for Path which is needed for li 310 `base_dir = Path(os.getenv("SPYGLASS_BASE_DIR", None))`

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
