### PR TITLE
Delete downstream restriction fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Clean up following pre-commit checks. #688
 - Add Mixin class to centralize `fetch_nwb` functionality. #692
 - Minor fixes to LinearizedPositionV1 pipeline #695
+- Add SpikeSorting V1 pipeline #651
+- Refactor restriction use in `delete_downstream_merge`
 
 ## [0.4.3] (November 7, 2023)
 


### PR DESCRIPTION
# Description

I'm working on a solution for #226 and was coincidentally working on edits that fix #700 when @samuelbray32 reported the issue.

- Fixes #700 : Uses arg restriction on parent table, joins with merge-part to ID keys for deletion
  - `spyglass/utils/dj_merge_tables.py`: only edits required for #700

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [x] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
