### PR TITLE
Make sampling rate for LFP user-defined instead of hard-coded to 1000 Hz

### DIFF
--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -96,7 +96,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
         )
 
         # target user-specified sampling rate
-        decimation = sampling_rate // key["lfp_sampling_rate"]
+        decimation = sampling_rate // key["target_sampling_rate"]
 
         # get the LFP filter that matches the raw data
         filter = (

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -42,7 +42,7 @@ class LFPSelection(dj.Manual):
      -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
      -> FirFilterParameters                                                # the filter to be used
      ---
-     lfp_sampling_rate = 1000 : float                                              # the desired output sampling rate, in HZ                                                                                                                                                                                                                
+     target_sampling_rate = 1000 : float                                     # the desired output sampling rate, in HZ                                                                                                                                                                                                                
      """
 
 

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -33,7 +33,7 @@ class LFPSelection(dj.Manual):
     filtered.  The user can also specify the filter to be used.
 
     The LFP data is filtered and downsampled to the user-defined sampling rate, specified
-    as lfp_sampling_rate.  The filtered data is stored in the AnalysisNwbfile table.  
+    as lfp_sampling_rate.  The filtered data is stored in the AnalysisNwbfile table.
     The valid times for the filtered data are stored in the IntervalList table.
     """
 

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -60,7 +60,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
-        DECIMATION_FACTOR = key["lfp_sampling_rate"] #1000
+        DECIMATION_FACTOR = key["lfp_sampling_rate"]
         # get the NWB object with the data
         nwbf_key = {"nwb_file_name": key["nwb_file_name"]}
         rawdata = (Raw & nwbf_key).fetch_nwb()[0]["raw"]

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -32,15 +32,17 @@ class LFPSelection(dj.Manual):
     The interval list is used to select the times from the raw data that will be
     filtered.  The user can also specify the filter to be used.
 
-    The LFP data is filtered and downsampled to 1 KHz.  The filtered data is stored
-    in the AnalysisNwbfile table.  The valid times for the filtered data are stored
-    in the IntervalList table.
+    The LFP data is filtered and downsampled to the user-defined sampling rate, specified
+    as lfp_sampling_rate.  The filtered data is stored in the AnalysisNwbfile table.  
+    The valid times for the filtered data are stored in the IntervalList table.
     """
 
     definition = """
      -> LFPElectrodeGroup                                                  # the group of electrodes to be filtered
      -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
      -> FirFilterParameters                                                # the filter to be used
+     ---
+     lfp_sampling_rate: float                                              # the desired output sampling rate, in HZ                                                                                                                                                                                                                
      """
 
 
@@ -58,7 +60,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
-        DECIMATION_FACTOR = 1000
+        DECIMATION_FACTOR = key["lfp_sampling_rate"] #1000
         # get the NWB object with the data
         nwbf_key = {"nwb_file_name": key["nwb_file_name"]}
         rawdata = (Raw & nwbf_key).fetch_nwb()[0]["raw"]

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -42,7 +42,7 @@ class LFPSelection(dj.Manual):
      -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
      -> FirFilterParameters                                                # the filter to be used
      ---
-     lfp_sampling_rate: float                                              # the desired output sampling rate, in HZ                                                                                                                                                                                                                
+     lfp_sampling_rate = 1000 : float                                              # the desired output sampling rate, in HZ                                                                                                                                                                                                                
      """
 
 
@@ -60,7 +60,6 @@ class LFPV1(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
-        DECIMATION_FACTOR = key["lfp_sampling_rate"]
         # get the NWB object with the data
         nwbf_key = {"nwb_file_name": key["nwb_file_name"]}
         rawdata = (Raw & nwbf_key).fetch_nwb()[0]["raw"]
@@ -96,8 +95,8 @@ class LFPV1(SpyglassMixin, dj.Computed):
             f"LFP: found {len(valid_times)} intervals > {MIN_LFP_INTERVAL_DURATION} sec long."
         )
 
-        # target 1 KHz sampling rate
-        decimation = sampling_rate // DECIMATION_FACTOR
+        # target user-specified sampling rate
+        decimation = sampling_rate // key["lfp_sampling_rate"]
 
         # get the LFP filter that matches the raw data
         filter = (


### PR DESCRIPTION
# Description

Currently `LFPSelection` and `LFPV1` downsample the LFP from `Raw` to 1000 Hz, which is hard-coded. This change is intended to allow the user to downsample the LFP to a user-specified sampling frequency, which is needed because some analyses need to analyze higher frequencies than 500 Hz. 

-lfp.py: 1. Added `lfp_sampling_rate` as a secondary key which is the user-defined desired output sampling frequency. 
              2. Changed `DECIMATION FACTOR` so that the resultant `decimation` input into `filter_data_nwb` will yield a sampling frequency equal to the user-desired desired output sampling frequency in `key["lfp_sampling_rate"]`. 

Note that this pull request entails adding a secondary key to an existing table. I was unable to test this pull request as I couldn't get permission for docker and attempting to test as a new schema resulted in getting stuck in a loop when trying to import the new tables. 

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes

@CBroz1 @edeno 