### PR TITLE
Lfp band fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Clean up following pre-commit checks. #688
 - Add Mixin class to centralize `fetch_nwb` functionality. #692
 - Minor fixes to LinearizedPositionV1 pipeline #695
+- Minor fixes to LFPBandV1 populator #706
 
 ## [0.4.3] (November 7, 2023)
 

--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -461,7 +461,8 @@ class FirFilterParameters(dj.Manual):
             frm, to = self._time_bound_check(
                 a_start, a_stop, timestamps, n_samples
             )
-
+            if frm == to:
+                continue
             indices.append((frm, to))
 
             shape, _ = gsp.filter_data_fir(

--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -461,7 +461,7 @@ class FirFilterParameters(dj.Manual):
             frm, to = self._time_bound_check(
                 a_start, a_stop, timestamps, n_samples
             )
-            if frm == to:
+            if np.isclose(frm, to, rtol=0, atol=1e-8):
                 continue
             indices.append((frm, to))
 

--- a/src/spyglass/lfp/analysis/v1/lfp_band.py
+++ b/src/spyglass/lfp/analysis/v1/lfp_band.py
@@ -355,6 +355,9 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
                 }
             )
         else:
+            lfp_band_valid_times = interval_list_censor(
+                lfp_band_valid_times, new_timestamps
+            )
             # check that the valid times are the same
             assert np.isclose(
                 tmp_valid_times[0], lfp_band_valid_times


### PR DESCRIPTION
# Description

Fixes minor bugs in the LFPBand population processs

- When making filtering intervals in `FirFilterParameters.filter_data()` skip zero-sized intervals which cause error in `ghostipy`

- When validating that a interval list created in `LFPBandV1.make()` matches a pre-existing ine with the same sampling rate, first apply `interval_list_censor()`. This is already applied when makeing the interval with a given sampling rate, and ensures that they will match if appropriate. 

# Checklist:

- [x] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [x] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
