### PR TITLE
add remove_existing_folder argument

### DIFF
--- a/src/spyglass/spikesorting/spikesorting_sorting.py
+++ b/src/spyglass/spikesorting/spikesorting_sorting.py
@@ -221,6 +221,7 @@ class SpikeSorting(dj.Computed):
                 sorter,
                 recording,
                 output_folder=sorter_temp_dir.name,
+                remove_existing_folder=True,
                 delete_output_folder=True,
                 **sorter_params,
             )


### PR DESCRIPTION
# Description

Fixes #707 

Passes `remove_existing_folder=True` to spikinterface's `run_sorter()` in spikesorting v0 pipeline.  Needed to account for change of default value of this argument in spikeinterface.

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
