### PR TITLE
Change method of defining base dir in get_abs_path

### DIFF
--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -11,6 +11,7 @@ import pynwb
 import spikeinterface as si
 from hdmf.common import DynamicTable
 
+from spyglass.settings import analysis_dir
 from spyglass.utils.dj_mixin import SpyglassMixin
 
 from ..settings import raw_dir
@@ -298,7 +299,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
     def get_abs_path(analysis_nwb_file_name):
         """Return the absolute path for a stored analysis NWB file given just the file name.
 
-        The SPYGLASS_BASE_DIR environment variable must be set.
+        The spyglass config from settings.py must be set.
 
         Parameters
         ----------
@@ -310,26 +311,16 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         analysis_nwb_file_abspath : str
             The absolute path for the given file name.
         """
-        try:
-            base_dir = Path(dj.config["stores"]["analysis"]["location"])
-        except KeyError as e:
-            raise KeyError(
-                "You must set the 'analysis' store location in dj.config"
-            ) from e
-
         # see if the file exists and is stored in the base analysis dir
-        test_path = str(base_dir / analysis_nwb_file_name)
+        test_path = str(Path(analysis_dir) / analysis_nwb_file_name)
 
         if os.path.exists(test_path):
             return test_path
         else:
             # use the new path
-            analysis_file_base_path = (
-                base_dir
-                / AnalysisNwbfile.__get_analysis_file_dir(
-                    analysis_nwb_file_name
-                )
-            )
+            analysis_file_base_path = Path(
+                analysis_dir
+            ) / AnalysisNwbfile.__get_analysis_file_dir(analysis_nwb_file_name)
             if not analysis_file_base_path.exists():
                 os.mkdir(str(analysis_file_base_path))
             return str(analysis_file_base_path / analysis_nwb_file_name)

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -11,10 +11,8 @@ import pynwb
 import spikeinterface as si
 from hdmf.common import DynamicTable
 
-from spyglass.settings import analysis_dir
+from spyglass.settings import analysis_dir, rar_dir
 from spyglass.utils.dj_mixin import SpyglassMixin
-
-from ..settings import raw_dir
 from ..utils.dj_helper_fn import get_child_tables
 from ..utils.nwb_helper_fn import get_electrode_indices, get_nwb_file
 

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -310,13 +310,15 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         analysis_nwb_file_abspath : str
             The absolute path for the given file name.
         """
-        base_dir = Path(os.getenv("SPYGLASS_BASE_DIR", None))
-        assert (
-            base_dir is not None
-        ), "You must set SPYGLASS_BASE_DIR environment variable."
+        try:
+            base_dir = Path(dj.config["stores"]["analysis"]["location"])
+        except KeyError as e:
+            raise KeyError(
+                "You must set the 'analysis' store location in dj.config"
+            ) from e
 
         # see if the file exists and is stored in the base analysis dir
-        test_path = str(base_dir / "analysis" / analysis_nwb_file_name)
+        test_path = str(base_dir / analysis_nwb_file_name)
 
         if os.path.exists(test_path):
             return test_path
@@ -324,7 +326,6 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             # use the new path
             analysis_file_base_path = (
                 base_dir
-                / "analysis"
                 / AnalysisNwbfile.__get_analysis_file_dir(
                     analysis_nwb_file_name
                 )

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -310,7 +310,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             The absolute path for the given file name.
         """
         # see if the file exists and is stored in the base analysis dir
-        test_path = str(Path(analysis_dir) / analysis_nwb_file_name)
+        test_path = f"{analysis_dir}/{analysis_nwb_file_name}"
 
         if os.path.exists(test_path):
             return test_path

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -11,7 +11,7 @@ import pynwb
 import spikeinterface as si
 from hdmf.common import DynamicTable
 
-from spyglass.settings import analysis_dir, rar_dir
+from spyglass.settings import analysis_dir, raw_dir
 from spyglass.utils.dj_mixin import SpyglassMixin
 from ..utils.dj_helper_fn import get_child_tables
 from ..utils.nwb_helper_fn import get_electrode_indices, get_nwb_file


### PR DESCRIPTION
# Description

Fixes #712 

- Changes the method of defining file path in `AnalysisNwbFile.get_abs_path()` from using `SPYGLASS_BASE_DIR + "/analysis"` to `dj.config["stores"]["analysis"]["location"]`
- This ensures consistency with `AnalysisNwbFile.fetch("analysis_file_abs_path")` which is a datajoint filepath object.
- Enables users to set their analysis directory separate from the spyglass base directory if desired
- No changes to current users on Franklab network

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
