### PR TITLE
V0 migration model, revised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,17 @@
 - Add Mixin class to centralize `fetch_nwb` functionality. #692
 - Refactor restriction use in `delete_downstream_merge` #703
 - Add `cautious_delete` to Mixin class, initial implementation. #711
-- Add `deprecation_factory` to facilitate table migration
+- Add `deprecation_factory` to facilitate table migration. #717
 
 ### Pipelines
 
 - Position: Refactor input validation in DLC pipeline. #688
-- Spike sorting: Add SpikeSorting V1 pipeline #651
-- LFP: Minor fixes to LFPBandV1 populator #706
+- Spike sorting: Add SpikeSorting V1 pipeline. #651
+- LFP: Minor fixes to LFPBandV1 populator. #706
 - Linearization:
     - Minor fixes to LinearizedPositionV1 pipeline #695
-    - Rename `position_linearization` -> `linearization`
-    - Migrate linearization tables: `common_position` -> `linearization.v0`
+    - Rename `position_linearization` -> `linearization`. #717
+    - Migrate tables: `common_position` -> `linearization.v0`. #717
 
 ## [0.4.3] (November 7, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
     - Migrate tables: `common_position` -> `linearization.v0`. #717
 - Position:
     - Refactor input validation in DLC pipeline. #688
-    - DLC path handling from config, and normailze naming convention. #722
+    - DLC path handling from config, and normalize naming convention. #722
 
 ## [0.4.3] (November 7, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,24 @@
 
 ## [0.4.4] (Unreleased)
 
+### Infrastructure
+
 - Additional documentation. #690
-- Refactor input validation in DLC pipeline. #688
 - Clean up following pre-commit checks. #688
 - Add Mixin class to centralize `fetch_nwb` functionality. #692
-- Minor fixes to LinearizedPositionV1 pipeline #695
-- Add SpikeSorting V1 pipeline #651
 - Refactor restriction use in `delete_downstream_merge` #703
-- Minor fixes to LFPBandV1 populator #706
 - Add `cautious_delete` to Mixin class, initial implementation. #711
+- Add `deprecation_factory` to facilitate table migration
+
+### Pipelines
+
+- Position: Refactor input validation in DLC pipeline. #688
+- Spike sorting: Add SpikeSorting V1 pipeline #651
+- LFP: Minor fixes to LFPBandV1 populator #706
+- Linearization:
+    - Minor fixes to LinearizedPositionV1 pipeline #695
+    - Rename `position_linearization` -> `linearization`
+    - Migrate linearization tables: `common_position` -> `linearization.v0`
 
 ## [0.4.3] (November 7, 2023)
 

--- a/notebooks/24_Linearization.ipynb
+++ b/notebooks/24_Linearization.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Position - Linearization"
+    "# Position - Linearization\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Overview"
+    "## Overview\n"
    ]
   },
   {
@@ -33,7 +33,7 @@
     "\"linearizes\" it to 1D position. If you haven't already done so, please generate\n",
     "input data with either the [Trodes](./20_Position_Trodes.ipynb) or DLC notebooks\n",
     "([1](./21_Position_DLC_1.ipynb), [2](./22_Position_DLC_2.ipynb),\n",
-    "[3](./23_Position_DLC_3.ipynb))."
+    "[3](./23_Position_DLC_3.ipynb)).\n"
    ]
   },
   {
@@ -81,7 +81,7 @@
     "\n",
     "import spyglass.common as sgc\n",
     "import spyglass.position.v1 as sgp\n",
-    "import spyglass.position_linearization.v1 as sgpl\n",
+    "import spyglass.linearization.v1 as sgpl\n",
     "\n",
     "# ignore datajoint+jupyter async warnings\n",
     "import warnings\n",
@@ -94,7 +94,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Retrieve 2D position "
+    "## Retrieve 2D position\n"
    ]
   },
   {
@@ -102,7 +102,7 @@
    "metadata": {},
    "source": [
     "To retrieve 2D position data, we'll specify an nwb file, a position time\n",
-    "interval, and the set of parameters used to compute the position info."
+    "interval, and the set of parameters used to compute the position info.\n"
    ]
   },
   {
@@ -133,7 +133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will fetch the pandas dataframe from the `PositionOutput` table."
+    "We will fetch the pandas dataframe from the `PositionOutput` table.\n"
    ]
   },
   {
@@ -354,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before linearizing, plotting the head position will help us understand the data."
+    "Before linearizing, plotting the head position will help us understand the data.\n"
    ]
   },
   {
@@ -411,11 +411,11 @@
     "\n",
     "- `node_positions` (cm): the 2D positions of the graph\n",
     "- `edges`: how the nodes are connected, as pairs of node indices, labeled by\n",
-    "  their respective index in `node_positions`. \n",
-    "- `linear_edge_order`: layout of edges in linear space in *order*, as tuples. \n",
+    "  their respective index in `node_positions`.\n",
+    "- `linear_edge_order`: layout of edges in linear space in _order_, as tuples.\n",
     "- `linear_edge_spacing`: spacing between each edge, as either a single number\n",
-    "for all gaps or an array with a number for each gap. Gaps may be important for\n",
-    "edges not connected in 2D space.\n",
+    "  for all gaps or an array with a number for each gap. Gaps may be important for\n",
+    "  edges not connected in 2D space.\n",
     "\n",
     "For example, (79.910, 216.720) is the 2D position of node 0 and (183.784,\n",
     "45.375) is the 2D position of node 8. Edge (0, 8) means there is an edge between\n",
@@ -423,8 +423,8 @@
     "from node 0 to 1. Edge (1, 0) would connect from node 1 to 0, reversing the\n",
     "linear positions for that edge.\n",
     "\n",
-    "For more examples, see \n",
-    "[this notebook](https://github.com/LorenFrankLab/track_linearization/blob/master/notebooks/)."
+    "For more examples, see\n",
+    "[this notebook](https://github.com/LorenFrankLab/track_linearization/blob/master/notebooks/).\n"
    ]
   },
   {
@@ -481,7 +481,7 @@
    "metadata": {},
    "source": [
     "With these variables, we then add a `track_graph_name` and the corresponding\n",
-    "`environment`."
+    "`environment`.\n"
    ]
   },
   {
@@ -611,7 +611,7 @@
    "metadata": {},
    "source": [
     "`TrackGraph` has several methods for visualizing in 2D and 1D space.\n",
-    "`plot_track_graph` plots in 2D to make sure our layout makes sense."
+    "`plot_track_graph` plots in 2D to make sure our layout makes sense.\n"
    ]
   },
   {
@@ -648,7 +648,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`plot_track_graph_as_1D` shows what this looks like in 1D."
+    "`plot_track_graph_as_1D` shows what this looks like in 1D.\n"
    ]
   },
   {
@@ -683,7 +683,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
     "By default, linearization assigns each 2D position to its nearest point on the\n",
     "track graph. This is then translated into 1D space.\n",
     "\n",
@@ -691,7 +690,7 @@
     "The HMM takes into account the prior position and edge, and can keep the\n",
     "position from suddenly jumping to another. Position jumping like this may occur\n",
     "at intersections or the head position swings closer to a non-target reward well\n",
-    "while on another edge."
+    "while on another edge.\n"
    ]
   },
   {
@@ -806,15 +805,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Linearization"
+    "## Linearization\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With linearization parameters, we specify the position interval we wish to \n",
-    "linearize from the `PositionOutput` table and create an entry in `LinearizationSelection`"
+    "With linearization parameters, we specify the position interval we wish to\n",
+    "linearize from the `PositionOutput` table and create an entry in `LinearizationSelection`\n"
    ]
   },
   {
@@ -1051,7 +1050,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And then run linearization by populating `LinearizedPositionV1`."
+    "And then run linearization by populating `LinearizedPositionV1`.\n"
    ]
   },
   {
@@ -1225,7 +1224,7 @@
     "- `time`: dataframe index\n",
     "- `linear_position`: 1D linearized position\n",
     "- `track_segment_id`: index number of the edges given to track graph\n",
-    "- `projected_{x,y}_position`: 2D position projected to the track graph"
+    "- `projected_{x,y}_position`: 2D position projected to the track graph\n"
    ]
   },
   {
@@ -1394,7 +1393,7 @@
     "    \"linearization_param_name\": \"default\",\n",
     "}\n",
     "\n",
-    "from spyglass.position_linearization import LinearizedPositionOutput\n",
+    "from spyglass.linearization.merge import LinearizedPositionOutput\n",
     "\n",
     "linear_position_df = (LinearizedPositionOutput & linear_key).fetch1_dataframe()\n",
     "linear_position_df"
@@ -1405,7 +1404,7 @@
    "metadata": {},
    "source": [
     "We'll plot the 1D position over time, colored by edge, and use the 1D track\n",
-    "graph layout on the y-axis."
+    "graph layout on the y-axis.\n"
    ]
   },
   {
@@ -1455,7 +1454,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also plot the 2D position projected to the track graph"
+    "We can also plot the 2D position projected to the track graph\n"
    ]
   },
   {

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -23,11 +23,12 @@ from track_linearization import (
     plot_track_graph,
 )
 
-from ..settings import raw_dir, video_dir
-from ..utils.dj_mixin import SpyglassMixin
-from .common_behav import RawPosition, VideoFile
-from .common_interval import IntervalList  # noqa F401
-from .common_nwbfile import AnalysisNwbfile
+from spyglass.common.common_behav import RawPosition, VideoFile
+from spyglass.common.common_interval import IntervalList  # noqa F401
+from spyglass.common.common_nwbfile import AnalysisNwbfile
+from spyglass.settings import raw_dir, video_dir
+from spyglass.utils.dj_helper_fn import deprecated_factory
+from spyglass.utils.dj_mixin import SpyglassMixin
 
 schema = dj.schema("common_position")
 
@@ -499,306 +500,6 @@ class IntervalPositionInfo(SpyglassMixin, dj.Computed):
 
 
 @schema
-class LinearizationParameters(SpyglassMixin, dj.Lookup):
-    """Choose whether to use an HMM to linearize position.
-
-    This can help when the euclidean distances between separate arms are too
-    close and the previous position has some information about which arm the
-    animal is on.
-
-    route_euclidean_distance_scaling: How much to prefer route distances between
-    successive time points that are closer to the euclidean distance. Smaller
-    numbers mean the route distance is more likely to be close to the euclidean
-    distance.
-    """
-
-    definition = """
-    linearization_param_name : varchar(80)   # name for this set of parameters
-    ---
-    use_hmm = 0 : int   # use HMM to determine linearization
-    route_euclidean_distance_scaling = 1.0 : float # Preference for euclidean.
-    sensor_std_dev = 5.0 : float   # Uncertainty of position sensor (in cm).
-    # Biases the transition matrix to prefer the current track segment.
-    diagonal_bias = 0.5 : float
-    """
-
-
-@schema
-class TrackGraph(SpyglassMixin, dj.Manual):
-    """Graph representation of track representing the spatial environment.
-
-    Used for linearizing position.
-    """
-
-    definition = """
-    track_graph_name : varchar(80)
-    ----
-    environment : varchar(80)  # Type of Environment
-    node_positions : blob      # 2D position of nodes, (n_nodes, 2)
-    edges: blob                # shape (n_edges, 2)
-    linear_edge_order : blob   # order of edges in linear space, (n_edges, 2)
-    linear_edge_spacing : blob # space btwn edges in linear space, (n_edges,)
-    """
-
-    def get_networkx_track_graph(self, track_graph_parameters=None):
-        if track_graph_parameters is None:
-            track_graph_parameters = self.fetch1()
-        return make_track_graph(
-            node_positions=track_graph_parameters["node_positions"],
-            edges=track_graph_parameters["edges"],
-        )
-
-    def plot_track_graph(self, ax=None, draw_edge_labels=False, **kwds):
-        """Plot the track graph in 2D position space."""
-        track_graph = self.get_networkx_track_graph()
-        plot_track_graph(
-            track_graph, ax=ax, draw_edge_labels=draw_edge_labels, **kwds
-        )
-
-    def plot_track_graph_as_1D(
-        self,
-        ax=None,
-        axis="x",
-        other_axis_start=0.0,
-        draw_edge_labels=False,
-        node_size=300,
-        node_color="#1f77b4",
-    ):
-        """Plot the track graph in 1D to see how the linearization is set up."""
-        track_graph_parameters = self.fetch1()
-        track_graph = self.get_networkx_track_graph(
-            track_graph_parameters=track_graph_parameters
-        )
-        plot_graph_as_1D(
-            track_graph,
-            edge_order=track_graph_parameters["linear_edge_order"],
-            edge_spacing=track_graph_parameters["linear_edge_spacing"],
-            ax=ax,
-            axis=axis,
-            other_axis_start=other_axis_start,
-            draw_edge_labels=draw_edge_labels,
-            node_size=node_size,
-            node_color=node_color,
-        )
-
-
-@schema
-class IntervalLinearizationSelection(SpyglassMixin, dj.Lookup):
-    definition = """
-    -> IntervalPositionInfo
-    -> TrackGraph
-    -> LinearizationParameters
-    ---
-    """
-
-
-@schema
-class IntervalLinearizedPosition(SpyglassMixin, dj.Computed):
-    """Linearized position for a given interval"""
-
-    definition = """
-    -> IntervalLinearizationSelection
-    ---
-    -> AnalysisNwbfile
-    linearized_position_object_id : varchar(40)
-    """
-
-    def make(self, key):
-        print(f"Computing linear position for: {key}")
-
-        key["analysis_file_name"] = AnalysisNwbfile().create(
-            key["nwb_file_name"]
-        )
-
-        position_nwb = (
-            IntervalPositionInfo
-            & {
-                "nwb_file_name": key["nwb_file_name"],
-                "interval_list_name": key["interval_list_name"],
-                "position_info_param_name": key["position_info_param_name"],
-            }
-        ).fetch_nwb()[0]
-
-        position = np.asarray(
-            position_nwb["head_position"].get_spatial_series().data
-        )
-        time = np.asarray(
-            position_nwb["head_position"].get_spatial_series().timestamps
-        )
-
-        linearization_parameters = (
-            LinearizationParameters()
-            & {"linearization_param_name": key["linearization_param_name"]}
-        ).fetch1()
-        track_graph_info = (
-            TrackGraph() & {"track_graph_name": key["track_graph_name"]}
-        ).fetch1()
-
-        track_graph = make_track_graph(
-            node_positions=track_graph_info["node_positions"],
-            edges=track_graph_info["edges"],
-        )
-
-        linear_position_df = get_linearized_position(
-            position=position,
-            track_graph=track_graph,
-            edge_spacing=track_graph_info["linear_edge_spacing"],
-            edge_order=track_graph_info["linear_edge_order"],
-            use_HMM=linearization_parameters["use_hmm"],
-            route_euclidean_distance_scaling=linearization_parameters[
-                "route_euclidean_distance_scaling"
-            ],
-            sensor_std_dev=linearization_parameters["sensor_std_dev"],
-            diagonal_bias=linearization_parameters["diagonal_bias"],
-        )
-
-        linear_position_df["time"] = time
-
-        # Insert into analysis nwb file
-        nwb_analysis_file = AnalysisNwbfile()
-
-        key["linearized_position_object_id"] = nwb_analysis_file.add_nwb_object(
-            analysis_file_name=key["analysis_file_name"],
-            nwb_object=linear_position_df,
-        )
-
-        nwb_analysis_file.add(
-            nwb_file_name=key["nwb_file_name"],
-            analysis_file_name=key["analysis_file_name"],
-        )
-
-        self.insert1(key)
-
-    def fetch1_dataframe(self):
-        return self.fetch_nwb()[0]["linearized_position"].set_index("time")
-
-
-class NodePicker:
-    """Interactive creation of track graph by looking at video frames."""
-
-    def __init__(
-        self, ax=None, video_filename=None, node_color="#1f78b4", node_size=100
-    ):
-        if ax is None:
-            ax = plt.gca()
-        self.ax = ax
-        self.canvas = ax.get_figure().canvas
-        self.cid = None
-        self._nodes = []
-        self.node_color = node_color
-        self._nodes_plot = ax.scatter(
-            [], [], zorder=5, s=node_size, color=node_color
-        )
-        self.edges = [[]]
-        self.video_filename = video_filename
-
-        if video_filename is not None:
-            self.video = cv2.VideoCapture(video_filename)
-            frame = self.get_video_frame()
-            ax.imshow(frame, picker=True)
-            ax.set_title(
-                "Left click to place node.\nRight click to remove node."
-                "\nShift+Left click to clear nodes."
-                "\nCntrl+Left click two nodes to place an edge"
-            )
-
-        self.connect()
-
-    @property
-    def node_positions(self):
-        return np.asarray(self._nodes)
-
-    def connect(self):
-        if self.cid is None:
-            self.cid = self.canvas.mpl_connect(
-                "button_press_event", self.click_event
-            )
-
-    def disconnect(self):
-        if self.cid is not None:
-            self.canvas.mpl_disconnect(self.cid)
-            self.cid = None
-
-    def click_event(self, event):
-        if not event.inaxes:
-            return
-        if (event.key not in ["control", "shift"]) & (
-            event.button == 1
-        ):  # left click
-            self._nodes.append((event.xdata, event.ydata))
-        if (event.key not in ["control", "shift"]) & (
-            event.button == 3
-        ):  # right click
-            self.remove_point((event.xdata, event.ydata))
-        if (event.key == "shift") & (event.button == 1):
-            self.clear()
-        if (event.key == "control") & (event.button == 1):
-            point = (event.xdata, event.ydata)
-            distance_to_nodes = np.linalg.norm(
-                self.node_positions - point, axis=1
-            )
-            closest_node_ind = np.argmin(distance_to_nodes)
-            if len(self.edges[-1]) < 2:
-                self.edges[-1].append(closest_node_ind)
-            else:
-                self.edges.append([closest_node_ind])
-
-        self.redraw()
-
-    def redraw(self):
-        # Draw Node Circles
-        if len(self.node_positions) > 0:
-            self._nodes_plot.set_offsets(self.node_positions)
-        else:
-            self._nodes_plot.set_offsets([])
-
-        # Draw Node Numbers
-        self.ax.texts = []
-        for ind, (x, y) in enumerate(self.node_positions):
-            self.ax.text(
-                x,
-                y,
-                ind,
-                zorder=6,
-                fontsize=12,
-                horizontalalignment="center",
-                verticalalignment="center",
-                clip_on=True,
-                bbox=None,
-                transform=self.ax.transData,
-            )
-        # Draw Edges
-        self.ax.lines = []  # clears the existing lines
-        for edge in self.edges:
-            if len(edge) > 1:
-                x1, y1 = self.node_positions[edge[0]]
-                x2, y2 = self.node_positions[edge[1]]
-                self.ax.plot(
-                    [x1, x2], [y1, y2], color=self.node_color, linewidth=2
-                )
-
-        self.canvas.draw_idle()
-
-    def remove_point(self, point):
-        if len(self._nodes) > 0:
-            distance_to_nodes = np.linalg.norm(
-                self.node_positions - point, axis=1
-            )
-            closest_node_ind = np.argmin(distance_to_nodes)
-            self._nodes.pop(closest_node_ind)
-
-    def clear(self):
-        self._nodes = []
-        self.edges = [[]]
-        self.redraw()
-
-    def get_video_frame(self):
-        is_grabbed, frame = self.video.read()
-        if is_grabbed:
-            return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-
-
-@schema
 class PositionVideo(SpyglassMixin, dj.Computed):
     """Creates a video of the computed head position and orientation as well as
     the original LED positions overlaid on the video of the animal.
@@ -807,7 +508,6 @@ class PositionVideo(SpyglassMixin, dj.Computed):
 
     definition = """
     -> IntervalPositionInfo
-    ---
     """
 
     def make(self, key):
@@ -1036,6 +736,35 @@ class PositionVideo(SpyglassMixin, dj.Computed):
         video.release()
         out.release()
         cv2.destroyAllWindows()
+
+
+# ----------------------------- Migrated Tables -----------------------------
+
+
+from spyglass.linearization.v0 import main as linV0  # noqa: E402
+
+(
+    LinearizationParameters,
+    TrackGraph,
+    IntervalLinearizationSelection,
+    IntervalLinearizedPosition,
+) = deprecated_factory(
+    [
+        ("LinearizationParameters", linV0.LinearizationParameters),
+        ("TrackGraph", linV0.TrackGraph),
+        (
+            "IntervalLinearizationSelection",
+            linV0.IntervalLinearizationSelection,
+        ),
+        (
+            "IntervalLinearizedPosition",
+            linV0.IntervalLinearizedPosition,
+        ),
+    ],
+    old_module=__name__,
+)
+
+# ----------------------------- Helper Functions -----------------------------
 
 
 def _fix_col_names(spatial_df):

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -13,7 +13,7 @@ schema = dj.schema("lfp_merge")
 
 
 @schema
-class LFPOutput( _Merge, SpyglassMixin):
+class LFPOutput(_Merge, SpyglassMixin):
     definition = """
     merge_id: uuid
     ---

--- a/src/spyglass/linearization/__init__.py
+++ b/src/spyglass/linearization/__init__.py
@@ -1,0 +1,1 @@
+from spyglass.linearization.merge import LinearizedPositionOutput

--- a/src/spyglass/linearization/merge.py
+++ b/src/spyglass/linearization/merge.py
@@ -1,10 +1,10 @@
 import datajoint as dj
 
-from spyglass.position_linearization.v1.linearization import (  # noqa F401
-    LinearizedPositionV1,
-)
-from spyglass.utils.dj_merge_tables import _Merge
-from spyglass.utils.dj_mixin import SpyglassMixin
+from spyglass.linearization.v0.main import (
+    IntervalLinearizedPosition,
+)  # noqa F401
+from spyglass.linearization.v1.main import LinearizedPositionV1  # noqa F401
+from spyglass.utils import SpyglassMixin, _Merge
 
 schema = dj.schema("position_linearization_merge")
 
@@ -16,6 +16,13 @@ class LinearizedPositionOutput(SpyglassMixin, _Merge):
     ---
     source: varchar(32)
     """
+
+    class LinearizedPositionV0(SpyglassMixin, dj.Part):  # noqa: F811
+        definition = """
+        -> LinearizedPositionOutput
+        ---
+        -> IntervalLinearizedPosition
+        """
 
     class LinearizedPositionV1(SpyglassMixin, dj.Part):  # noqa: F811
         definition = """

--- a/src/spyglass/linearization/v0/__init__.py
+++ b/src/spyglass/linearization/v0/__init__.py
@@ -1,0 +1,8 @@
+from spyglass.utils.dj_mixin import SpyglassMixin  # isort:skip
+
+from spyglass.linearization.v0.main import (  # isort:skip
+    IntervalLinearizationSelection,
+    IntervalLinearizedPosition,
+    LinearizationParameters,
+    TrackGraph,
+)

--- a/src/spyglass/linearization/v0/main.py
+++ b/src/spyglass/linearization/v0/main.py
@@ -1,0 +1,188 @@
+import datajoint as dj
+import numpy as np
+from track_linearization import (
+    get_linearized_position,
+    make_track_graph,
+    plot_graph_as_1D,
+    plot_track_graph,
+)
+
+from spyglass.common.common_nwbfile import AnalysisNwbfile  # noqa F401
+from spyglass.common.common_position import IntervalPositionInfo  # noqa F401
+from spyglass.utils.dj_mixin import SpyglassMixin
+
+schema = dj.schema("common_position")
+
+
+@schema
+class LinearizationParameters(SpyglassMixin, dj.Lookup):
+    """Choose whether to use an HMM to linearize position.
+
+    This can help when the euclidean distances between separate arms are too
+    close and the previous position has some information about which arm the
+    animal is on.
+
+    route_euclidean_distance_scaling: How much to prefer route distances between
+    successive time points that are closer to the euclidean distance. Smaller
+    numbers mean the route distance is more likely to be close to the euclidean
+    distance.
+    """
+
+    definition = """
+    linearization_param_name : varchar(80)   # name for this set of parameters
+    ---
+    use_hmm = 0 : int   # use HMM to determine linearization
+    route_euclidean_distance_scaling = 1.0 : float # Preference for euclidean.
+    sensor_std_dev = 5.0 : float   # Uncertainty of position sensor (in cm).
+    # Biases the transition matrix to prefer the current track segment.
+    diagonal_bias = 0.5 : float
+    """
+
+
+@schema
+class TrackGraph(SpyglassMixin, dj.Manual):
+    """Graph representation of track representing the spatial environment.
+
+    Used for linearizing position.
+    """
+
+    definition = """
+    track_graph_name : varchar(80)
+    ----
+    environment : varchar(80)  # Type of Environment
+    node_positions : blob      # 2D position of nodes, (n_nodes, 2)
+    edges: blob                # shape (n_edges, 2)
+    linear_edge_order : blob   # order of edges in linear space, (n_edges, 2)
+    linear_edge_spacing : blob # space btwn edges in linear space, (n_edges,)
+    """
+
+    def get_networkx_track_graph(self, track_graph_parameters=None):
+        if track_graph_parameters is None:
+            track_graph_parameters = self.fetch1()
+        return make_track_graph(
+            node_positions=track_graph_parameters["node_positions"],
+            edges=track_graph_parameters["edges"],
+        )
+
+    def plot_track_graph(self, ax=None, draw_edge_labels=False, **kwds):
+        """Plot the track graph in 2D position space."""
+        track_graph = self.get_networkx_track_graph()
+        plot_track_graph(
+            track_graph, ax=ax, draw_edge_labels=draw_edge_labels, **kwds
+        )
+
+    def plot_track_graph_as_1D(
+        self,
+        ax=None,
+        axis="x",
+        other_axis_start=0.0,
+        draw_edge_labels=False,
+        node_size=300,
+        node_color="#1f77b4",
+    ):
+        """Plot the track graph in 1D to see how the linearization is set up."""
+        track_graph_parameters = self.fetch1()
+        track_graph = self.get_networkx_track_graph(
+            track_graph_parameters=track_graph_parameters
+        )
+        plot_graph_as_1D(
+            track_graph,
+            edge_order=track_graph_parameters["linear_edge_order"],
+            edge_spacing=track_graph_parameters["linear_edge_spacing"],
+            ax=ax,
+            axis=axis,
+            other_axis_start=other_axis_start,
+            draw_edge_labels=draw_edge_labels,
+            node_size=node_size,
+            node_color=node_color,
+        )
+
+
+@schema
+class IntervalLinearizationSelection(SpyglassMixin, dj.Lookup):
+    definition = """
+    -> IntervalPositionInfo
+    -> TrackGraph
+    -> LinearizationParameters
+    """
+
+
+@schema
+class IntervalLinearizedPosition(SpyglassMixin, dj.Computed):
+    """Linearized position for a given interval"""
+
+    definition = """
+    -> IntervalLinearizationSelection
+    ---
+    -> AnalysisNwbfile
+    linearized_position_object_id : varchar(40)
+    """
+
+    def make(self, key):
+        print(f"Computing linear position for: {key}")
+
+        key["analysis_file_name"] = AnalysisNwbfile().create(
+            key["nwb_file_name"]
+        )
+
+        position_nwb = (
+            IntervalPositionInfo
+            & {
+                "nwb_file_name": key["nwb_file_name"],
+                "interval_list_name": key["interval_list_name"],
+                "position_info_param_name": key["position_info_param_name"],
+            }
+        ).fetch_nwb()[0]
+
+        position = np.asarray(
+            position_nwb["head_position"].get_spatial_series().data
+        )
+        time = np.asarray(
+            position_nwb["head_position"].get_spatial_series().timestamps
+        )
+
+        linearization_parameters = (
+            LinearizationParameters()
+            & {"linearization_param_name": key["linearization_param_name"]}
+        ).fetch1()
+        track_graph_info = (
+            TrackGraph() & {"track_graph_name": key["track_graph_name"]}
+        ).fetch1()
+
+        track_graph = make_track_graph(
+            node_positions=track_graph_info["node_positions"],
+            edges=track_graph_info["edges"],
+        )
+
+        linear_position_df = get_linearized_position(
+            position=position,
+            track_graph=track_graph,
+            edge_spacing=track_graph_info["linear_edge_spacing"],
+            edge_order=track_graph_info["linear_edge_order"],
+            use_HMM=linearization_parameters["use_hmm"],
+            route_euclidean_distance_scaling=linearization_parameters[
+                "route_euclidean_distance_scaling"
+            ],
+            sensor_std_dev=linearization_parameters["sensor_std_dev"],
+            diagonal_bias=linearization_parameters["diagonal_bias"],
+        )
+
+        linear_position_df["time"] = time
+
+        # Insert into analysis nwb file
+        nwb_analysis_file = AnalysisNwbfile()
+
+        key["linearized_position_object_id"] = nwb_analysis_file.add_nwb_object(
+            analysis_file_name=key["analysis_file_name"],
+            nwb_object=linear_position_df,
+        )
+
+        nwb_analysis_file.add(
+            nwb_file_name=key["nwb_file_name"],
+            analysis_file_name=key["analysis_file_name"],
+        )
+
+        self.insert1(key)
+
+    def fetch1_dataframe(self):
+        return self.fetch_nwb()[0]["linearized_position"].set_index("time")

--- a/src/spyglass/linearization/v1/__init__.py
+++ b/src/spyglass/linearization/v1/__init__.py
@@ -1,0 +1,6 @@
+from spyglass.linearization.v1.main import (
+    LinearizationParameters,
+    LinearizationSelection,
+    LinearizedPositionV1,
+    TrackGraph,
+)

--- a/src/spyglass/linearization/v1/main.py
+++ b/src/spyglass/linearization/v1/main.py
@@ -174,7 +174,7 @@ class LinearizedPositionV1(SpyglassMixin, dj.Computed):
 
         self.insert1(key)
 
-        from ..position_linearization_merge import LinearizedPositionOutput
+        from ..merge import LinearizedPositionOutput
 
         part_name = to_camel_case(self.table_name.split("__")[-1])
 

--- a/src/spyglass/position_linearization/__init__.py
+++ b/src/spyglass/position_linearization/__init__.py
@@ -1,3 +1,0 @@
-from spyglass.position_linearization.position_linearization_merge import (
-    LinearizedPositionOutput,
-)

--- a/src/spyglass/position_linearization/v1/__init__.py
+++ b/src/spyglass/position_linearization/v1/__init__.py
@@ -1,7 +1,0 @@
-from spyglass.common.common_position import NodePicker
-from spyglass.position_linearization.v1.linearization import (
-    LinearizationParameters,
-    LinearizationSelection,
-    LinearizedPositionV1,
-    TrackGraph,
-)

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import time
 import uuid

--- a/src/spyglass/utils/__init__.py
+++ b/src/spyglass/utils/__init__.py
@@ -1,0 +1,4 @@
+from spyglass.utils.dj_merge_tables import _Merge
+from spyglass.utils.dj_mixin import SpyglassMixin
+
+__all__ = ["_Merge", "SpyglassMixin"]

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -1,11 +1,70 @@
 """Helper functions for manipulating information from DataJoint fetch calls."""
 import inspect
 import os
+from typing import Type
 
 import datajoint as dj
 import numpy as np
 
 from .nwb_helper_fn import get_nwb_file
+
+
+def deprecated_factory(classes: list, old_module: str = "") -> list:
+    """Creates a list of classes and prints a warning when instantiated
+
+    Parameters
+    ---------
+    classes : list
+        list of tuples containing old_class, new_class
+
+    Returns
+    ------
+    list
+        list of classes that will print a warning when instantiated
+    """
+
+    if not isinstance(classes, list):
+        classes = [classes]
+
+    ret = [
+        _subclass_factory(old_name=c[0], new_class=c[1], old_module=old_module)
+        for c in classes
+    ]
+
+    return ret[0] if len(ret) == 1 else ret
+
+
+def _subclass_factory(
+    old_name: str, new_class: Type, old_module: str = ""
+) -> Type:
+    """Creates a subclass with a deprecation warning on __init__
+
+    Old class is a subclass of new class, so it will inherit all of the new
+    class's methods. Old class retains its original name and module. Use
+    __name__ to get the module name of the caller.
+
+    Usage: OldClass = _subclass_factory('OldClass', __name__, NewClass)
+    """
+
+    new_module = new_class().__class__.__module__
+
+    # Define the __call__ method for the new class
+    def init_override(self, *args, **kwargs):
+        print(
+            "Deprecation Warning: this class has been moved out of "
+            + f"{old_module}\n"
+            + f"\t{old_name} -> {new_module}.{new_class.__name__}"
+            + "\nPlease use the new location."
+        )
+        return super(self.__class__, self).__init__(*args, **kwargs)
+
+    class_dict = {
+        "__module__": old_module or new_class.__class__.__module__,
+        "__init__": init_override,
+        "_is_deprecated": True,
+    }
+
+    return type(old_name, (new_class,), class_dict)
 
 
 def dj_replace(original_table, new_values, key_column, replace_column):

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -211,7 +211,7 @@ class Merge(dj.Manual):
             for p in cls._merge_restrict_parts(
                 restriction=restriction,
                 add_invalid_restrict=False,
-                return_empties=False,
+                return_empties=True,
             )
         ]
 


### PR DESCRIPTION
# Description

PR #694 had a lot of conflicts related to PR #711, and discussions suggested avoiding rename of existing tables. Rather than cherry pick and rebase, this PR replaces the work in #694.

The goal of this PR is demonstrated in the following image, where an import from the old location results in a warning, but an import from the new location does not:
![Screenshot from 2023-12-19 10-17-47](https://github.com/LorenFrankLab/spyglass/assets/9404707/76a241e3-fb74-473c-8c7a-a5d3e6538949) 

# This PR...

- Revises changelog to separate change types
- Renames subpackage `position_linearization` -> `linearization` for more distinct prefix when navigating package
- Migrates tables
  - `utils/dj_helper_fn.py`: Add deprecation factory, class that returns classes with an added `print` statement in the `__init__` that specifies where a table was migrated from/to
  - `common/common_position.py` -> `linearization/v0/main.py`: Move 4 tables and replace with factory
    - `LinearizationParameters`
    - `TrackGraph`
    - `IntervalLinearizationSelection`
    - `IntervalLinearizedPosition`
- Proposes new naming structure that avoids redundancy: 
  - `subpackage/subpackage_merge.py` -> `subpackage/merge.py`
  - `subpackage/vX/subpackage.py` -> `subpackage/vX/main.py`
  - `subpackage/vX/subpackage_specific.py` -> `subpackage/vX/specific.py`
- Revises notebook 24 to reflect subpackage renaming

# Checklist:

- [X] This PR should be accompanied by a release: No - still want do give time for cautious delete rollout
- [ ] (If release) I have updated the `CITATION.cff`
- [X] I have updated the `CHANGELOG.md`
- [x] I have added/edited docs/notebooks to reflect the changes
