### PR TITLE
Fix ref channel append error

### DIFF
--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -412,7 +412,7 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             }
         ).fetch1("sort_reference_electrode_id")
         recording_channel_ids = np.setdiff1d(channel_ids, ref_channel_id)
-        all_channel_ids = np.unique(channel_ids + ref_channel_id)
+        all_channel_ids = np.unique(np.append(channel_ids, ref_channel_id))
 
         probe_type_by_channel = []
         electrode_group_by_channel = []


### PR DESCRIPTION
# Description

Appending the ref channel id to the list of channels in sort group fails because it used the wrong syntax. This fixes it.

- Fixes #000: How this PR fixes the issue
  - `path/file.py`: Description of the change
  - `path/file.py`: Description of the change
- Fixes #000: How this PR fixes the issue
  - `path/file.py`: Description of the change
  - `path/file.py`: Description of the change

# Checklist:

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
