### PR TITLE
Priority for fetch_nwb function in merge tables

### DIFF
--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -13,7 +13,10 @@ schema = dj.schema("lfp_merge")
 
 
 @schema
-class LFPOutput(SpyglassMixin, _Merge):
+class LFPOutput(
+    _Merge,
+    SpyglassMixin,
+):
     definition = """
     merge_id: uuid
     ---

--- a/src/spyglass/lfp/lfp_merge.py
+++ b/src/spyglass/lfp/lfp_merge.py
@@ -13,10 +13,7 @@ schema = dj.schema("lfp_merge")
 
 
 @schema
-class LFPOutput(
-    _Merge,
-    SpyglassMixin,
-):
+class LFPOutput( _Merge, SpyglassMixin):
     definition = """
     merge_id: uuid
     ---

--- a/src/spyglass/position/position_merge.py
+++ b/src/spyglass/position/position_merge.py
@@ -26,7 +26,7 @@ source_class_dict = {
 
 
 @schema
-class PositionOutput(SpyglassMixin, _Merge):
+class PositionOutput(_Merge, SpyglassMixin):
     """
     Table to identify source of Position Information from upstream options
     (e.g. DLC, Trodes, etc...) To add another upstream option, a new Part table

--- a/src/spyglass/position_linearization/position_linearization_merge.py
+++ b/src/spyglass/position_linearization/position_linearization_merge.py
@@ -10,7 +10,7 @@ schema = dj.schema("position_linearization_merge")
 
 
 @schema
-class LinearizedPositionOutput(SpyglassMixin, _Merge):
+class LinearizedPositionOutput(_Merge, SpyglassMixin):
     definition = """
     merge_id: uuid
     ---


### PR DESCRIPTION
# Description

- Order of `SpyglassMixin` and `Merge` parent classes in Merge table definitions (e.g. `LFPOutput`) put priority on `SpyglassMixin` for functions defined in both
- Problem because merge tables need to use this function as defined in the `Merge` class.
- This PR switches the order of the two parent classes so this happens

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
