### PR TITLE
Handle single intervals in spike sorting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "explicit"
         },
     },
     "isort.args": [

--- a/src/spyglass/spikesorting/merge.py
+++ b/src/spyglass/spikesorting/merge.py
@@ -12,7 +12,7 @@ schema = dj.schema("spikesorting_merge")
 
 
 @schema
-class SpikeSortingOutput(_Merge):
+class SpikeSortingOutput(_Merge, SpyglassMixin):
     definition = """
     # Output of spike sorting pipelines.
     merge_id: uuid

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -554,6 +554,8 @@ def _consolidate_intervals(intervals, timestamps):
     """
     # Convert intervals to a numpy array if it's not
     intervals = np.array(intervals)
+    if intervals.ndim == 1:
+        intervals = intervals.reshape(-1, 2)
     if intervals.shape[1] != 2:
         raise ValueError(
             "Input array must have shape (N, 2) where N is the number of intervals."

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -335,12 +335,17 @@ def _write_sorting_to_nwb(
             name="curation_label",
             description="curation label applied to a unit",
         )
+        obs_interval = (
+            sort_interval
+            if sort_interval.ndim == 2
+            else sort_interval.reshape(1, 2)
+        )
         for unit_id in sorting.get_unit_ids():
             spike_times = sorting.get_unit_spike_train(unit_id)
             nwbf.add_unit(
                 spike_times=timestamps[spike_times],
                 id=unit_id,
-                obs_intervals=sort_interval,
+                obs_intervals=obs_interval,
                 curation_label="uncurated",
             )
         units_object_id = nwbf.units.object_id


### PR DESCRIPTION
# Description
This is a minor fix to handle single intervals in spike sorting
Also adds spyglass mixin to SpikeSortingOutput merge table

# Checklist:

- [x] This PR should be accompanied by a release: (yes/**no**/unsure)
- [x] (If release) I have updated the `CITATION.cff`
- [x] I have updated the `CHANGELOG.md`
- [x] I have added/edited docs/notebooks to reflect the changes
