### PR TITLE
Fix PositionOutput.fetch1_dataframe bug

### DIFF
--- a/src/spyglass/position/position_merge.py
+++ b/src/spyglass/position/position_merge.py
@@ -79,7 +79,7 @@ class PositionOutput(_Merge, SpyglassMixin):
     def fetch1_dataframe(self):
         # proj replaces operator restriction to enable
         # (TableName & restriction).fetch1_dataframe()
-        key = self.merge_restrict(self.proj())
+        key = self.merge_restrict(self.proj()).proj()
         query = (
             source_class_dict[
                 to_camel_case(self.merge_get_parent(self.proj()).table_name)


### PR DESCRIPTION
# Description

Fixes #745 

In `PositionOutput.fetch1_dataframe()`, there was a bug where the key was not projected to a datajoint query, causing an SQL error.  This fixes so that the key is a query.

# Checklist:

- [ ] This PR should be accompanied by a release: unsure
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
