### PR TITLE
Remove logger.info() without message

### DIFF
--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -87,15 +87,12 @@ class Session(SpyglassMixin, dj.Imported):
         if not debug_mode:  # TODO: remove when demo files agree on device
             logger.info("Populate DataAcquisitionDevice...")
             DataAcquisitionDevice.insert_from_nwbfile(nwbf, config)
-            logger.info()
 
         logger.info("Populate CameraDevice...")
         CameraDevice.insert_from_nwbfile(nwbf)
-        logger.info()
 
         logger.info("Populate Probe...")
         Probe.insert_from_nwbfile(nwbf, config)
-        logger.info()
 
         if nwbf.subject is not None:
             subject_id = nwbf.subject.subject_id


### PR DESCRIPTION
# Description

Print statements were converted to using the logging module. Empty print statements do not error but logger.info does. This removes the leftover print statements.
