### PR TITLE
restrict get position info by session name

### DIFF
--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -305,7 +305,10 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
 
     @staticmethod
     def load_position_info(key):
-        position_group_key = {"position_group_name": key["position_group_name"]}
+        position_group_key = {
+            "position_group_name": key["position_group_name"],
+            "nwb_file_name": key["nwb_file_name"],
+        }
         position_variable_names = (PositionGroup & position_group_key).fetch1(
             "position_variables"
         )

--- a/src/spyglass/decoding/v1/sorted_spikes.py
+++ b/src/spyglass/decoding/v1/sorted_spikes.py
@@ -296,7 +296,10 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
 
     @staticmethod
     def load_position_info(key):
-        position_group_key = {"position_group_name": key["position_group_name"]}
+        position_group_key = {
+            "position_group_name": key["position_group_name"],
+            "nwb_file_name": key["nwb_file_name"],
+        }
         position_variable_names = (PositionGroup & position_group_key).fetch1(
             "position_variables"
         )


### PR DESCRIPTION
# Description

Fixes #756 

- `get_position_info` in the v1 clusterless and sorted spikes decoding tables now restricts `PositionGroup` by "nwb_file_name" To avoid error when multiple groups from different sessions have the same "position_group_name"

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
