### PR TITLE
Fix the length of `object_id` for `ImportedSpikeSorting`

### DIFF
--- a/src/spyglass/spikesorting/__init__.py
+++ b/src/spyglass/spikesorting/__init__.py
@@ -1,4 +1,5 @@
 from .curation_figurl import CurationFigurl, CurationFigurlSelection
+from .imported import ImportedSpikeSorting
 from .sortingview import SortingviewWorkspace, SortingviewWorkspaceSelection
 from .spikesorting_artifact import (
     ArtifactDetection,

--- a/src/spyglass/spikesorting/imported.py
+++ b/src/spyglass/spikesorting/imported.py
@@ -13,7 +13,7 @@ class ImportedSpikeSorting(SpyglassMixin, dj.Imported):
     definition = """
     -> Session
     ---
-    object_id: varchar(32)
+    object_id: varchar(40)
     """
 
     def make(self, key):

--- a/src/spyglass/spikesorting/v1/__init__.py
+++ b/src/spyglass/spikesorting/v1/__init__.py
@@ -1,3 +1,4 @@
+from ..imported import ImportedSpikeSorting
 from .artifact import (
     ArtifactDetection,
     ArtifactDetectionParameters,


### PR DESCRIPTION
# Description
- Previously it was too short and threw an error upon insert.
- Also added `ImportedSpikeSorting` to the init of v1 and v0 so it can be called directly regardless of what version user imports.
- I have tested the changes by importing `spyglass.spikesorting.v1`

# Checklist:

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
