### PR TITLE
Add sampling rate to LFPV1 interval_list_name

### DIFF
--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -161,6 +161,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
                 "lfp",
                 key["lfp_electrode_group_name"],
                 key["target_interval_list_name"],
+                str(key["lfp_sampling_rate"]) + "Hz",
                 "valid times",
             )
         )


### PR DESCRIPTION
# Description

Fixes #744 
- Error was happening when inserting multiple entries to `LFPV1` for the same `target_interval`
- Error happened when creating new `IntervalList` entry
- Adding `lfp_sampling_rate` to the new `interval_list_name` prevents the overlap preventing population


# Checklist:

- [x] This PR should be accompanied by a release: no
- [x] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
