### PR TITLE
Add new function to retrieve spatial series from NWB file

### DIFF
--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -174,10 +174,13 @@ def get_position_obj(nwbfile):
     -------
     pynwb.behavior.Position object
     """
+    ret = []
     for obj in nwbfile.processing["behavior"].data_interfaces.values():
         if isinstance(obj, pynwb.behavior.Position):
-            return obj
-    return None
+            ret.append(obj)
+    if len(ret) > 1: 
+        raise ValueError(f"Found more than one position object in {nwbfile}")
+    return ret[0] if ret and len(ret) else None
 
 
 def get_raw_eseries(nwbfile):

--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -178,7 +178,7 @@ def get_position_obj(nwbfile):
     for obj in nwbfile.processing["behavior"].data_interfaces.values():
         if isinstance(obj, pynwb.behavior.Position):
             ret.append(obj)
-    if len(ret) > 1: 
+    if len(ret) > 1:
         raise ValueError(f"Found more than one position object in {nwbfile}")
     return ret[0] if ret and len(ret) else None
 

--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -158,6 +158,28 @@ def get_data_interface(nwbfile, data_interface_name, data_interface_class=None):
     return None
 
 
+def get_position_obj(nwbfile):
+    """Return the Position object from the behavior processing module.
+    Meant to find position spatial series that are not found by
+    `get_data_interface(nwbfile, 'position', pynwb.behavior.Position)`.
+    The code returns the first `pynwb.behavior.Position` object (technically
+    there should only be one).
+
+    Parameters
+    ----------
+    nwbfile : pynwb.NWBFile
+        The NWB file object.
+
+    Returns
+    -------
+    pynwb.behavior.Position object
+    """
+    for obj in nwbfile.processing["behavior"].data_interfaces.values():
+        if isinstance(obj, pynwb.behavior.Position):
+            return obj
+    return None
+
+
 def get_raw_eseries(nwbfile):
     """Return all ElectricalSeries in the acquisition group of an NWB file.
 
@@ -459,9 +481,7 @@ def get_all_spatial_series(nwbf, verbose=False, incl_times=True) -> dict:
         the file. The 'raw_position_object_id' is the object ID of the
         SpatialSeries object.
     """
-    pos_interface = get_data_interface(
-        nwbf, "position", pynwb.behavior.Position
-    )
+    pos_interface = get_position_obj(nwbf)
 
     if pos_interface is None:
         return None


### PR DESCRIPTION
# Description
Currently `RawPosition` is populated by loading spatial series with `get_all_spatial_series`, which calls `get_data_interface(nwbfile, 'position', pynwb.behavior.Position)`, which looks for an object of name `position` and type `pynwb.behavior.Position` within the processing modules of the NWB file. Some NWB files (e.g. the Buzsaki lab data) don't use the name `position` (instead they use `SubjectPosition`). As a result, the spatial series in the NWB file don't show up in `RawPosition` upon ingestion into spygass.

This fixes this by creating a new function called `get_position_obj` which looks for object of the type `pynwb.behavior.Position` within the `behavior` processing module of the NWB file without caring about the name. `get_all_spatial_series` now calls this function instead of `get_data_interface(nwbfile, 'position', pynwb.behavior.Position)`.

I have tested this on an NWB file from our lab and have confirmed that this doesn't cause any change in the output of `get_all_spatial_series`. I have also tested it on the Buzsaki lab NWB file and confirmed that this now returns the spatial series (used to return nothing).

# Checklist:

- [ ] This PR should be accompanied by a release: unsure
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
