### PR TITLE
Update waveform_features.py

### DIFF
--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -37,7 +37,7 @@ class WaveformFeaturesParams(SpyglassMixin, dj.Lookup):
         "ms_after": 0.5,
         "max_spikes_per_unit": None,
         "n_jobs": 5,
-        "total_memory": "5G",
+        "chunk_duration":"1000s",
     }
     contents = [
         [

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -37,7 +37,7 @@ class WaveformFeaturesParams(SpyglassMixin, dj.Lookup):
         "ms_after": 0.5,
         "max_spikes_per_unit": None,
         "n_jobs": 5,
-        "chunk_duration":"1000s",
+        "chunk_duration": "1000s",
     }
     contents = [
         [


### PR DESCRIPTION
i updated the default parameters. i think chunk_duration is needed for spike interface to use the n_jobs keyword. this allows parallelization for waveform extraction