### PR TITLE
Cautious delete bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     - More robust caching of join to downstream tables. #806
     - Overwrite datajoint `delete` method to use `cautious_delete`. #806
     - Reverse join order for session summary. #821
+    - Add temporary logging of use to `common_usage`. #811, #821
 - Add `deprecation_factory` to facilitate table migration. #717
 - Add Spyglass logger. #730
 - IntervalList: Add secondary key `pipeline` #742

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Initial implementation. #711, #762
     - More robust caching of join to downstream tables. #806
     - Overwrite datajoint `delete` method to use `cautious_delete`. #806
+    - Reverse join order for session summary. #821
 - Add `deprecation_factory` to facilitate table migration. #717
 - Add Spyglass logger. #730
 - IntervalList: Add secondary key `pipeline` #742

--- a/src/spyglass/utils/dj_chains.py
+++ b/src/spyglass/utils/dj_chains.py
@@ -134,8 +134,7 @@ class TableChain:
             get_master(child.full_table_name) == ""
             and MERGE_PK in child.heading.names
         ):
-            logger.error("Child is a merge table. Use TableChains instead.")
-            return
+            raise TypeError("Child is a merge table. Use TableChains instead.")
 
         self._link_symbol = " -> "
         self.parent = parent

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -61,7 +61,10 @@ class SpyglassMixin:
 
         Used to determine fetch_nwb behavior. Also used in Merge.fetch_nwb.
         Implemented as a cached_property to avoid circular imports."""
-        from spyglass.common.common_nwbfile import AnalysisNwbfile, Nwbfile  # noqa F401
+        from spyglass.common.common_nwbfile import (
+            AnalysisNwbfile,
+            Nwbfile,
+        )  # noqa F401
 
         table_dict = {
             AnalysisNwbfile: "analysis_file_abs_path",
@@ -71,9 +74,7 @@ class SpyglassMixin:
         resolved = getattr(self, "_nwb_table", None) or (
             AnalysisNwbfile
             if "-> AnalysisNwbfile" in self.definition
-            else Nwbfile
-            if "-> Nwbfile" in self.definition
-            else None
+            else Nwbfile if "-> Nwbfile" in self.definition else None
         )
 
         if not resolved:

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -365,17 +365,29 @@ class SpyglassMixin:
 
     def _log_use(self, start, merge_deletes=None):
         """Log use of cautious_delete."""
-        self._usage_table.insert1(
-            dict(
-                duration=time() - start,
-                dj_user=dj.config["database.user"],
-                origin=self.full_table_name,
-                restriction=(
-                    str(self.restriction)[:255] if self.restriction else "None"
-                ),
-                merge_deletes=merge_deletes,
-            )
+        if isinstance(merge_deletes, QueryExpression):
+            merge_deletes = merge_deletes.fetch(as_dict=True)
+        safe_insert = dict(
+            duration=time() - start,
+            dj_user=dj.config["database.user"],
+            origin=self.full_table_name,
         )
+        try:
+            self._usage_table.insert1(
+                dict(
+                    **safe_insert,
+                    restriction=(
+                        "".join(self.restriction)[255:]  # handle list
+                        if self.restriction
+                        else "None"
+                    ),
+                    merge_deletes=merge_deletes,
+                )
+            )
+        except (DataJointError, DataError):
+            self._usage_table.insert1(
+                dict(**safe_insert, restriction="Unknown")
+            )
 
     # TODO: Intercept datajoint delete confirmation prompt for merge deletes
     def cautious_delete(self, force_permission: bool = False, *args, **kwargs):

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -61,10 +61,7 @@ class SpyglassMixin:
 
         Used to determine fetch_nwb behavior. Also used in Merge.fetch_nwb.
         Implemented as a cached_property to avoid circular imports."""
-        from spyglass.common.common_nwbfile import (
-            AnalysisNwbfile,
-            Nwbfile,
-        )  # noqa F401
+        from spyglass.common.common_nwbfile import AnalysisNwbfile, Nwbfile  # noqa F401
 
         table_dict = {
             AnalysisNwbfile: "analysis_file_abs_path",
@@ -74,7 +71,9 @@ class SpyglassMixin:
         resolved = getattr(self, "_nwb_table", None) or (
             AnalysisNwbfile
             if "-> AnalysisNwbfile" in self.definition
-            else Nwbfile if "-> Nwbfile" in self.definition else None
+            else Nwbfile
+            if "-> Nwbfile" in self.definition
+            else None
         )
 
         if not resolved:
@@ -278,7 +277,9 @@ class SpyglassMixin:
         empty_pk = {self._member_pk: "NULL"}
 
         format = dj.U(self._session_pk, self._member_pk)
-        sess_link = self._session_connection.join(self.restriction)
+        sess_link = self._session_connection.join(
+            self.restriction, reverse_order=True
+        )
 
         exp_missing = format & (sess_link - SesExp).proj(**empty_pk)
         exp_present = format & (sess_link * SesExp - exp_missing).proj()


### PR DESCRIPTION
# Description

- Fixes #820: Chains were attempting to apply downstream restriction to parent table. Add option to reverse chain order before applying restriction
  - `dj_chains.py`: Accept arg to reverse join order
  - `dj_mixin.py`: Add new arg to `_get_ext_summary` method
- Fixes #818: Adds join to prevent truncation from applying to restriction list. Adds fetch of QueryExpression to permit storage in table.

# Checklist:

- [x] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [x] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
