### PR TITLE
Fault-permit insert and remove mutual exclusivity protections on Merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add overview of Spyglass to docs. #779
 - Update linting for Black 24. #808
 - Steamline dependency management. #822
+- Add catch errorst during `populate_all_common`, log in `common_usage`. #XXX
 
 ### Pipelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,31 +4,38 @@
 
 ### Infrastructure
 
-- Additional documentation. #690
-- Clean up following pre-commit checks. #688
-- Add Mixin class to centralize `fetch_nwb` functionality. #692, #734
-- Refactor restriction use in `delete_downstream_merge` #703
-- Add `cautious_delete` to Mixin class
-    - Initial implementation. #711, #762
-    - More robust caching of join to downstream tables. #806
-    - Overwrite datajoint `delete` method to use `cautious_delete`. #806
-    - Reverse join order for session summary. #821
-    - Add temporary logging of use to `common_usage`. #811, #821
-- Add `deprecation_factory` to facilitate table migration. #717
-- Add Spyglass logger. #730
-- IntervalList: Add secondary key `pipeline` #742
-- Increase pytest coverage for `common`, `lfp`, and `utils`. #743
-- Update docs to reflect new notebooks. #776
-- Add overview of Spyglass to docs. #779
-- Update linting for Black 24. #808
-- Steamline dependency management. #822
-- Add catch errors during `populate_all_common`, log in `common_usage`. #XXX
-- Merge UUIDs #XXX
-    - Revise Merge table uuid generation to include source.
-    - Remove mutual exclusivity logic due to new UUID generation.
+- Docs:
+    - Additional documentation. #690
+    - Add overview of Spyglass to docs. #779
+    - Update docs to reflect new notebooks. #776
+- Mixin:
+    - Add Mixin class to centralize `fetch_nwb` functionality. #692, #734
+    - Refactor restriction use in `delete_downstream_merge` #703
+    - Add `cautious_delete` to Mixin class
+        - Initial implementation. #711, #762
+        - More robust caching of join to downstream tables. #806
+        - Overwrite datajoint `delete` method to use `cautious_delete`. #806
+        - Reverse join order for session summary. #821
+        - Add temporary logging of use to `common_usage`. #811, #821
+- Merge Tables:
+    - UUIDs: Revise Merge table uuid generation to include source. #824
+    - UUIDs: Remove mutual exclusivity logic due to new UUID generation. #824
+    - Add method for `merge_populate`. #824
+- Linting:
+    - Clean up following pre-commit checks. #688
+    - Update linting for Black 24. #808
+- Misc:
+    - Add `deprecation_factory` to facilitate table migration. #717
+    - Add Spyglass logger. #730
+    - Increase pytest coverage for `common`, `lfp`, and `utils`. #743
+    - Steamline dependency management. #822
 
 ### Pipelines
 
+- Common:
+    - `IntervalList`: Add secondary key `pipeline` #742
+    - Add `common_usage` table. #811, #821, #824
+    - Add catch errors during `populate_all_common`. #824
 - Spike sorting:
     - Add SpikeSorting V1 pipeline. #651
     - Move modules into spikesorting.v0 #807

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@
 - Add overview of Spyglass to docs. #779
 - Update linting for Black 24. #808
 - Steamline dependency management. #822
-- Add catch errorst during `populate_all_common`, log in `common_usage`. #XXX
+- Add catch errors during `populate_all_common`, log in `common_usage`. #XXX
+- Merge UUIDs #XXX
+    - Revise Merge table uuid generation to include source.
+    - Remove mutual exclusivity logic due to new UUID generation.
 
 ### Pipelines
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -42,6 +42,20 @@ class PositionSource(SpyglassMixin, dj.Manual):
         name=null: varchar(32)       # name of spatial series
         """
 
+    def populate(self, key=None):
+        """Insert position source data from NWB file.
+
+        WARNING: populate method on Manual table is not protected by transaction
+                protections like other DataJoint tables.
+        """
+        nwb_file_name = key.get("nwb_file_name")
+        if not nwb_file_name:
+            raise ValueError(
+                "PositionSource.populate is an alias for a non-computed table "
+                + "and must be passed a key with nwb_file_name"
+            )
+        self.insert_from_nwbfile(nwb_file_name)
+
     @classmethod
     def insert_from_nwbfile(cls, nwb_file_name):
         """Add intervals to ItervalList and PositionSource.

--- a/src/spyglass/common/common_usage.py
+++ b/src/spyglass/common/common_usage.py
@@ -31,6 +31,7 @@ class InsertError(dj.Manual):
     ---
     dj_user: varchar(64)
     connection_id: int     # MySQL CONNECTION_ID()
+    nwb_file_name: varchar(64)
     table: varchar(64)
     error_type: varchar(64)
     error_message: varchar(255)

--- a/src/spyglass/common/common_usage.py
+++ b/src/spyglass/common/common_usage.py
@@ -1,6 +1,7 @@
 """A schema to store the usage of advanced Spyglass features.
 
-Records show usage of features such as table chains, which will be used to
+Records show usage of features such as cautious delete and fault-permitting
+insert, which will be used to
 determine which features are used, how often, and by whom. This will help
 plan future development of Spyglass.
 """
@@ -20,4 +21,18 @@ class CautiousDelete(dj.Manual):
     origin: varchar(64)
     restriction: varchar(255)
     merge_deletes = null: blob
+    """
+
+
+@schema
+class InsertError(dj.Manual):
+    definition = """
+    id: int auto_increment
+    ---
+    dj_user: varchar(64)
+    connection_id: int     # MySQL CONNECTION_ID()
+    table: varchar(64)
+    error_type: varchar(64)
+    error_message: varchar(255)
+    error_raw = null: blob
     """

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -17,12 +17,13 @@ from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session
 from spyglass.common.common_task import TaskEpoch
 from spyglass.common.common_usage import InsertError
-from spyglass.spikesorting.imported import ImportedSpikeSorting
 from spyglass.utils import logger
 
 
 def populate_all_common(nwb_file_name):
     """Insert all common tables for a given NWB file."""
+    from spyglass.spikesorting.imported import ImportedSpikeSorting
+
     key = [(Nwbfile & f"nwb_file_name LIKE '{nwb_file_name}'").proj()]
     tables = [
         Session,

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -44,6 +44,7 @@ def populate_all_common(nwb_file_name):
     error_constants = dict(
         dj_user=dj.config["database.user"],
         connection_id=dj.conn().connection_id,
+        nwb_file_name=nwb_file_name,
     )
 
     for table in tables:
@@ -62,8 +63,10 @@ def populate_all_common(nwb_file_name):
             )
     query = InsertError & error_constants
     if query:
+        err_tables = query.fetch("table")
         logger.error(
-            f"Errors occurred during population:\n{query}\n"
-            + "See common_useage.InsertError for more details"
+            f"Errors occurred during population for {nwb_file_name}:\n\t"
+            + f"Failed tables {err_tables}\n\t"
+            + "See common_usage.InsertError for more details"
         )
         return query.fetch("KEY")

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -1,3 +1,5 @@
+import datajoint as dj
+
 from spyglass.common.common_behav import (
     PositionSource,
     RawPosition,
@@ -14,51 +16,54 @@ from spyglass.common.common_ephys import (
 from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session
 from spyglass.common.common_task import TaskEpoch
+from spyglass.common.common_usage import InsertError
+from spyglass.spikesorting.imported import ImportedSpikeSorting
 from spyglass.utils import logger
 
 
 def populate_all_common(nwb_file_name):
-    # Insert session one by one
-    fp = [(Nwbfile & {"nwb_file_name": nwb_file_name}).proj()]
-    logger.info("Populate Session...")
-    Session.populate(fp)
+    """Insert all common tables for a given NWB file."""
+    key = [(Nwbfile & f"nwb_file_name LIKE '{nwb_file_name}'").proj()]
+    tables = [
+        Session,
+        # NwbfileKachery, # Not used by default
+        ElectrodeGroup,
+        Electrode,
+        Raw,
+        SampleCount,
+        DIOEvents,
+        # SensorData, # Not used by default. Generates large files
+        RawPosition,
+        TaskEpoch,
+        StateScriptFile,
+        VideoFile,
+        PositionSource,
+        RawPosition,
+        ImportedSpikeSorting,
+    ]
+    error_constants = dict(
+        dj_user=dj.config["database.user"],
+        connection_id=dj.conn().connection_id,
+    )
 
-    # If we use Kachery for data sharing we can uncomment the following two lines. TBD
-    # logger.info('Populate NwbfileKachery...')
-    # NwbfileKachery.populate()
-
-    logger.info("Populate ElectrodeGroup...")
-    ElectrodeGroup.populate(fp)
-
-    logger.info("Populate Electrode...")
-    Electrode.populate(fp)
-
-    logger.info("Populate Raw...")
-    Raw.populate(fp)
-
-    logger.info("Populate SampleCount...")
-    SampleCount.populate(fp)
-
-    logger.info("Populate DIOEvents...")
-    DIOEvents.populate(fp)
-
-    # sensor data (from analog ProcessingModule) is temporarily removed from NWBFile
-    # to reduce file size while it is not being used. add it back in by commenting out
-    # the removal code in spyglass/data_import/insert_sessions.py when ready
-    # logger.info('Populate SensorData')
-    # SensorData.populate(fp)
-
-    logger.info("Populate TaskEpochs")
-    TaskEpoch.populate(fp)
-    logger.info("Populate StateScriptFile")
-    StateScriptFile.populate(fp)
-    logger.info("Populate VideoFile")
-    VideoFile.populate(fp)
-    logger.info("RawPosition...")
-    PositionSource.insert_from_nwbfile(nwb_file_name)
-    RawPosition.populate(fp)
-
-    logger.info("Populate ImportedSpikeSorting...")
-    from spyglass.spikesorting.imported import ImportedSpikeSorting
-
-    ImportedSpikeSorting.populate(fp)
+    for table in tables:
+        logger.info(f"Populating {table.__name__}...")
+        try:
+            table.populate(key)
+        except Exception as e:
+            InsertError.insert1(
+                dict(
+                    **error_constants,
+                    table=table.__name__,
+                    error_type=type(e).__name__,
+                    error_message=str(e),
+                    error_raw=str(e),
+                )
+            )
+    query = InsertError & error_constants
+    if query:
+        logger.error(
+            f"Errors occurred during population:\n{query}\n"
+            + "See common_useage.InsertError for more details"
+        )
+        return query.fetch("KEY")

--- a/src/spyglass/linearization/__init__.py
+++ b/src/spyglass/linearization/__init__.py
@@ -1,1 +1,3 @@
-from spyglass.linearization.merge import LinearizedPositionOutput
+# CB: Circular import if only importing PositionOutput
+
+# from spyglass.linearization.merge import LinearizedPositionOutput

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -215,8 +215,8 @@ class SpyglassMixin:
         if not merge_join_dict and not disable_warning:
             logger.warning(
                 f"No merge deletes found w/ {self.table_name} & "
-                + f"{restriction}.\n\tIf this is unexpected, try running with "
-                + "`reload_cache`."
+                + f"{restriction}.\n\tIf this is unexpected, try importing "
+                + " Merge table(s) and running with `reload_cache`."
             )
 
         if dry_run:

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -365,7 +365,7 @@ class SpyglassMixin:
 
         return CautiousDelete()
 
-    def _log_use(self, start, merge_deletes=None):
+    def _log_use(self, start, merge_deletes=None, super_delete=False):
         """Log use of cautious_delete."""
         if isinstance(merge_deletes, QueryExpression):
             merge_deletes = merge_deletes.fetch(as_dict=True)
@@ -374,15 +374,13 @@ class SpyglassMixin:
             dj_user=dj.config["database.user"],
             origin=self.full_table_name,
         )
+        restr_str = "Super delete: " if super_delete else ""
+        restr_str += "".join(self.restriction) if self.restriction else "None"
         try:
             self._usage_table.insert1(
                 dict(
                     **safe_insert,
-                    restriction=(
-                        "".join(self.restriction)[255:]  # handle list
-                        if self.restriction
-                        else "None"
-                    ),
+                    restriction=restr_str[:255],
                     merge_deletes=merge_deletes,
                 )
             )
@@ -455,4 +453,5 @@ class SpyglassMixin:
     def super_delete(self, *args, **kwargs):
         """Alias for datajoint.table.Table.delete."""
         logger.warning("!! Using super_delete. Bypassing cautious_delete !!")
+        self._log_use(start=time(), super_delete=True)
         super().delete(*args, **kwargs)


### PR DESCRIPTION
# Description

Adds fault-permit insert process and a new table to common_usage to  keep track of errors across sessions. Will help monitor for recurring issues.

- Fixes #719: Adds try/catch to `populate_all_common`. For each fail, adds entry to `InsertError` table and returns the IDs of entries to the user.
  - `common/populate_all_common.py`: Turn tables into a list to loop through, avoiding repeated logger calls. 
  - `common/common_behav.py`: Adds a `populate` method to handle the fact that `PositionSource` was the only table in the previous list without a populate method. If unwanted, this change could instead be migrated to `populate_all_common` which would loop through a set of tables and methods to be run for each.
  - This does not fully solve #804 because we expect the same fail state for the same file, but it does remove the halting nature of the issue
  - This does not fully solve #212 because it does not print out successes
- Fixes #768: Adds `source` to uuid generation for merge tables, avoiding the case where the same PK set across part-parents results in collision
  - `utils/dj_merge.py`: add secondary key to hashing func.
  - `path/file.py`: Description of the change
- Misc: 
  - Add merge `delete` method to further enforce the use of `cautious_delete`
  - More verbose warning when `delete_downstream_merge` yields nothing  
  - Finally able to add `merge_populate` to avoid mess of part parent populate inserting into merge table
  - Removed unused import of linearization merge table at init due to circularity issue if only importing `PositionOutput`

# Checklist:

- [ ] This PR should be accompanied by a release: Unsure
- [ ] (If release) I have updated the `CITATION.cff`
- [X] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
