### PR TITLE
Only apply include labels filter if include_labels not empty

### DIFF
--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -97,7 +97,8 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
             if isinstance(unit_labels, str):
                 unit_labels = [unit_labels]
             if (
-                include_labels and np.all(~np.isin(unit_labels, include_labels))
+                include_labels.size > 0
+                and np.all(~np.isin(unit_labels, include_labels))
             ) or np.any(np.isin(unit_labels, exclude_labels)):
                 # if the unit does not have any of the include labels
                 # or has any of the exclude labels, skip

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -96,9 +96,9 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
         for ind, unit_labels in enumerate(labels):
             if isinstance(unit_labels, str):
                 unit_labels = [unit_labels]
-            if np.all(~np.isin(unit_labels, include_labels)) or np.any(
-                np.isin(unit_labels, exclude_labels)
-            ):
+            if (
+                include_labels and np.all(~np.isin(unit_labels, include_labels))
+            ) or np.any(np.isin(unit_labels, exclude_labels)):
                 # if the unit does not have any of the include labels
                 # or has any of the exclude labels, skip
                 continue


### PR DESCRIPTION
# Description

Small bug fix in `SortedSpikesGroup.filter_units()`
- if `include_labels` is non-empty, unit labels must have at least one label from this list to pass filtering
- PR fixes a bug where all units were filtered out in empty `include_labels` case

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
