### PR TITLE
Fix `CurationV1.get_sorting`

### DIFF
--- a/src/spyglass/spikesorting/v1/curation.py
+++ b/src/spyglass/spikesorting/v1/curation.py
@@ -213,7 +213,7 @@ class CurationV1(SpyglassMixin, dj.Manual):
             }
         ]
 
-        sorting = si.NumpySorting.from_dict(
+        sorting = si.NumpySorting.from_unit_dict(
             units_dict_list, sampling_frequency=sampling_frequency
         )
 


### PR DESCRIPTION
# Description

This fixes the `CurationV1.get_sorting` method from which one can retrieve the sorting in `CurationV1` as a `spikeinterface.BaseSorting` object

- Fixes #000: How this PR fixes the issue
  - `path/file.py`: Description of the change
  - `path/file.py`: Description of the change
- Fixes #000: How this PR fixes the issue
  - `path/file.py`: Description of the change
  - `path/file.py`: Description of the change

# Checklist:

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
