### PR TITLE
fix CuratedSpikeSorting insert with no curation

### DIFF
--- a/src/spyglass/spikesorting/v0/spikesorting_populator.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_populator.py
@@ -278,7 +278,7 @@ def spikesorting_pipeline_populator(
         curation_keys = (Curation() & sort_dict).fetch("KEY")
         for curation_key in curation_keys:
             CuratedSpikeSortingSelection.insert1(
-                curation_auto_key, skip_duplicates=True
+                curation_key, skip_duplicates=True
             )
 
     # Populate curated spike sorting


### PR DESCRIPTION
# Description

Minor bug.  Fixes what key is inserted in `CuratedSpikeSorting` when no curation done on the sorting results (as is the case in clusterless sorting


# Checklist:

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
