### PR TITLE
Fix non-referencing option in lfp artifact detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
     - Increase the required `spikeinterface` version to >=0.99.1 for `get_sorting` method associated with `SpikeSorting` and `CurationV1` tables in spike sorting V1 pipeline. Limit version to <0.100 in case there are other issues with it. #852
     - Bug fix in single artifact interval edge case #859
 
+- LFP
+    - In LFPArtifactDetection, only apply referencing if explicitly selected #863
+
 ## [0.5.0] (February 9, 2024)
 
 ### Infrastructure

--- a/src/spyglass/lfp/v1/lfp_artifact.py
+++ b/src/spyglass/lfp/v1/lfp_artifact.py
@@ -132,36 +132,41 @@ class LFPArtifactDetection(SpyglassMixin, dj.Computed):
 
         algorithm = artifact_params["artifact_detection_algorithm"]
         params = artifact_params["artifact_detection_algorithm_params"]
-        lfp_band_ref_id = artifact_params["referencing"]["reference_list"]
 
         # get LFP data
         lfp_eseries = (LFPV1 & key).fetch_nwb()[0]["lfp"]
         sampling_frequency = (LFPV1 & key).fetch("lfp_sampling_rate")[0]
-
-        # do referencing at this step
         lfp_data = np.asarray(
             lfp_eseries.data[:, :],
             dtype=type(lfp_eseries.data[0][0]),
         )
 
-        lfp_band_ref_index = get_electrode_indices(lfp_eseries, lfp_band_ref_id)
-        lfp_band_elect_index = get_electrode_indices(
-            lfp_eseries, artifact_params["referencing"]["electrode_list"]
-        )
-
-        # maybe this lfp_elec_list is supposed to be a list on indices
-
-        for index, elect_index in enumerate(lfp_band_elect_index):
-            if lfp_band_ref_id[index] == -1:
-                continue
-            lfp_data[:, elect_index] = (
-                lfp_data[:, elect_index]
-                - lfp_data[:, lfp_band_ref_index[index]]
-            )
-
         is_diff = algorithm == "difference"
+        # do referencing at this step
+        if "referencing" in artifact_params:
+            ref = artifact_params["referencing"]["ref_on"] if is_diff else None
+            lfp_band_ref_id = artifact_params["referencing"]["reference_list"]
+            if artifact_params["referencing"]["ref_on"]:
+                lfp_band_ref_index = get_electrode_indices(
+                    lfp_eseries, lfp_band_ref_id
+                )
+                lfp_band_elect_index = get_electrode_indices(
+                    lfp_eseries,
+                    artifact_params["referencing"]["electrode_list"],
+                )
+
+                # maybe this lfp_elec_list is supposed to be a list on indices
+                for index, elect_index in enumerate(lfp_band_elect_index):
+                    if lfp_band_ref_id[index] == -1:
+                        continue
+                    lfp_data[:, elect_index] = (
+                        lfp_data[:, elect_index]
+                        - lfp_data[:, lfp_band_ref_index[index]]
+                    )
+        else:
+            ref = False if is_diff else None
+
         data = lfp_data if is_diff else lfp_eseries
-        ref = artifact_params["referencing"]["ref_on"] if is_diff else None
 
         (
             artifact_removed_valid_times,

--- a/src/spyglass/lfp/v1/lfp_artifact_difference_detection.py
+++ b/src/spyglass/lfp/v1/lfp_artifact_difference_detection.py
@@ -24,7 +24,7 @@ def difference_artifact_detector(
     removal_window_ms: float = 1.0,
     local_window_ms: float = 1.0,
     sampling_frequency: float = 1000.0,
-    referencing: int = 0,
+    referencing: bool = False,
 ):
     """Detects times during which artifacts do and do not occur.
 
@@ -52,6 +52,8 @@ def difference_artifact_detector(
     removal_window_ms : float, optional
         Width of the window in milliseconds to mask out per artifact (window/2
         removed on each side of threshold crossing), defaults to 1 ms
+    referencing : bool, optional
+        Whether or not the data passed to this function is referenced, defaults to False
 
     Returns
     -------
@@ -66,7 +68,7 @@ def difference_artifact_detector(
     # NOTE: 7-17-23 updated to remove recording.data, since it will converted to
     # numpy array before referencing check for referencing flag
 
-    if referencing == 1:
+    if referencing:
         logger.info("referencing activated. may be set to -1")
 
     # valid_timestamps = recording.timestamps


### PR DESCRIPTION
# Description

Fixes #862, #850
- Assume no referencing if no `referencing` key present in `artifact_params`
- Only apply referencing if `ref_on` is True
- make `referencing a bool in `difference_artifact_detector` (no functional change)

# Checklist:

- [x] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [x] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
