### PR TITLE
Edits for docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,10 +12,19 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. This error is on file '....' at file path '....'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+
+</details><summary>Error Stack</summary>
+
+```python
+# Paste the error stack trace here
+```
+
+</details>
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
@@ -25,4 +34,3 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: 
+      - '!documentation'
+  pull_request:
 
 jobs:
   black:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Deploy
         run: |
-          FULL_VERSION=${{ github.ref }}
+          FULL_VERSION=${{ github.ref_name }}
           export MAJOR_VERSION=${FULL_VERSION:0:3}
           echo "OWNER: ${REPO_OWNER}. BUILD: ${MAJOR_VERSION}"
           bash ./docs/build-docs.sh push $REPO_OWNER

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - '!test_branch'
+      - '!documentation'
   schedule:  # once a day at midnight UTC
     - cron: '0 0 * * *'
 

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -6,6 +6,7 @@ on:
       - master
       - maint/*
       - '!test_branch'
+      - '!documentation'
     tags:
       - "*"
   pull_request:

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -7,6 +7,7 @@
 cp ./CHANGELOG.md ./docs/src/
 cp ./LICENSE ./docs/src/LICENSE.md
 mkdir -p ./docs/src/notebooks
+rm -r ./docs/src/notebooks/*
 cp ./notebooks/*ipynb ./docs/src/notebooks/
 cp ./notebooks/*md ./docs/src/notebooks/
 mv ./docs/src/notebooks/README.md ./docs/src/notebooks/index.md

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -55,14 +55,14 @@ Decoding can be from sorted or from unsorted data using spike waveform features
 (so-called clusterless decoding).
 
 The first notebook
-([Extracting Clusterless Waveform Features](./41_Extracting_Clusterless_Waveform_Features.ipynb))
+([Extracting Clusterless Waveform Features](./40_Extracting_Clusterless_Waveform_Features.ipynb))
 in this series shows how to retrieve the spike waveform features used for
 clusterless decoding.
 
-The second notebook ([Clusterless Decoding](./42_Decoding_Clusterless.ipynb))
+The second notebook ([Clusterless Decoding](./41_Decoding_Clusterless.ipynb))
 shows a detailed example of how to decode the position of the animal from the
 spike waveform features. The third notebook
-([Decoding](./43_Decoding_SortedSpikes.ipynb)) shows how to decode the position
+([Decoding](./42_Decoding_SortedSpikes.ipynb)) shows how to decode the position
 of the animal from the sorted spikes.
 
 ## Developer note
@@ -79,3 +79,11 @@ black .
 ```
 
 Unfortunately, jupytext-generated py script are not black-compliant by default.
+
+You can ensure black compliance with the `pre-commit` hook by running
+
+```bash
+pip install pre-commit
+```
+
+This will run black whenever you commit changes to the repository.

--- a/src/spyglass/position/v1/position_dlc_pose_estimation.py
+++ b/src/spyglass/position/v1/position_dlc_pose_estimation.py
@@ -86,9 +86,10 @@ class DLCPoseEstimationSelection(SpyglassMixin, dj.Manual):
 
         Parameters
         ----------
-        key: DataJoint key specifying a pairing of VideoRecording and Model.
-        task_mode (bool): Default 'trigger' computation.
-        Or 'load' existing results.
+        key: dict
+            DataJoint key specifying a pairing of VideoRecording and Model.
+        task_mode: bool, optional
+            Default 'trigger' computation. Or 'load' existing results.
         params (dict): Optional. Parameters passed to DLC's analyze_videos:
             videotype, gputouse, save_as_csv, batchsize, cropping,
             TFGPUinference, dynamic, robust_nframes, allow_growth, use_shelve


### PR DESCRIPTION
# Description

I have already force-pushed to redeploy docs, removing bad versions `ref`, `[version]` and `0.4.1`.

These edits will address issues with redeploying next time around. This includes...

- Fixing references to renamed notebooks
- Omitting the docs branch from lint and test builds
- Fixing docstring in position
- Adding `<details>` block to bug template ... something I've routinely reformatted for submitted issues

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
