### PR TITLE
Update call to get_template_extremum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [0.5.2] (Unreleased)
 
+### Infrastructure
+
 - Refactor `TableChain` to include `_searched` attribute. #867
 - Fix errors in config import #882
+
+### Pipelines
+
+-Spikesorting
+    - Update calls in v0 pipline for spikeinterface>=0.99 #893
 
 ## [0.5.1] (March 7, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Pipelines
 
 -Spikesorting
-    - Update calls in v0 pipline for spikeinterface>=0.99 #893
+    - Update calls in v0 pipeline for spikeinterface>=0.99 #893
 
 ## [0.5.1] (March 7, 2024)
 

--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -11,6 +11,12 @@ from packaging import version
 import datajoint as dj
 import numpy as np
 import spikeinterface as si
+
+if version.parse(si.__version__) < version.parse("0.99.1"):
+    raise ImportError(
+        "SpikeInterface version must updated. "
+        + "Please run `pip install spikeinterface==0.99.1` to update."
+    )
 import spikeinterface.preprocessing as sip
 import spikeinterface.qualitymetrics as sq
 
@@ -633,13 +639,7 @@ def _get_peak_channel(
     """Computes the electrode_id of the channel with the extremum peak for each unit."""
     if "peak_sign" in metric_params:
         del metric_params["peak_sign"]
-    if version.parse(si.__version__) < version.parse("0.99.0"):
-        get_template_extremum_channel = (
-            si.postprocessing.get_template_extremum_channel
-        )
-    else:
-        get_template_extremum_channel = si.core.get_template_extremum_channel
-    peak_channel_dict = get_template_extremum_channel(
+    peak_channel_dict = si.core.get_template_extremum_channel(
         waveform_extractor=waveform_extractor,
         peak_sign=peak_sign,
         **metric_params,

--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -634,7 +634,13 @@ def _get_peak_channel(
     """Computes the electrode_id of the channel with the extremum peak for each unit."""
     if "peak_sign" in metric_params:
         del metric_params["peak_sign"]
-    peak_channel_dict = si.postprocessing.get_template_extremum_channel(
+    if int(si.__version__.split(".")[1]) < 99:
+        get_template_extremum_channel = (
+            si.postprocessing.get_template_extremum_channel
+        )
+    else:
+        get_template_extremum_channel = si.core.get_template_extremum_channel
+    peak_channel_dict = get_template_extremum_channel(
         waveform_extractor=waveform_extractor,
         peak_sign=peak_sign,
         **metric_params,

--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -618,12 +618,10 @@ def _get_peak_offset(
     """Computes the shift of the waveform peak from center of window."""
     if "peak_sign" in metric_params:
         del metric_params["peak_sign"]
-    peak_offset_inds = (
-        si.postprocessing.get_template_extremum_channel_peak_shift(
-            waveform_extractor=waveform_extractor,
-            peak_sign=peak_sign,
-            **metric_params,
-        )
+    peak_offset_inds = si.core.get_template_extremum_channel_peak_shift(
+        waveform_extractor=waveform_extractor,
+        peak_sign=peak_sign,
+        **metric_params,
     )
     peak_offset = {key: int(abs(val)) for key, val in peak_offset_inds.items()}
     return peak_offset

--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -6,6 +6,7 @@ import uuid
 import warnings
 from pathlib import Path
 from typing import List
+from packaging import version
 
 import datajoint as dj
 import numpy as np
@@ -634,7 +635,7 @@ def _get_peak_channel(
     """Computes the electrode_id of the channel with the extremum peak for each unit."""
     if "peak_sign" in metric_params:
         del metric_params["peak_sign"]
-    if int(si.__version__.split(".")[1]) < 99:
+    if version.parse(si.__version__) < version.parse("0.99.0"):
         get_template_extremum_channel = (
             si.postprocessing.get_template_extremum_channel
         )


### PR DESCRIPTION
# Description

Fixes #884 
- `get_template_extremum` moved from `si.preprocessing` to `si.core` in v0.99.

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
