### PR TITLE
Check for entry in merge part table prior to insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix errors in config import #882
 - Save current spyglass version in analysis nwb files to aid diagnosis #897
 - Add pynapple support #898
+- Fix potential duplicate entries in Merge part tables #922
 
 ### Pipelines
 

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -332,6 +332,9 @@ class Merge(dj.Manual):
                             + f"{part_name}:\n\tData:{row}\n\t{keys}"
                         )
                     key = keys[0]
+                    if part & key:
+                        print(f"Key already in part {part_name}: {key}")
+                        continue
                     master_sk = {cls()._reserved_sk: part_name}
                     uuid = dj.hash.key_hash(key | master_sk)
                     master_pk = {cls()._reserved_pk: uuid}


### PR DESCRIPTION
# Description

Fixes #920 
- Prior change in hash function allows possible duplicate entries in a merge part table  with different merge_ids
- during `_merge_insert`, prior to generation of UUID, check for presence of source primary key as an entry to avoid generating duplicates.

# Checklist:

- [ ] This PR should be accompanied by a release: no
- [ ] (If release) I have updated the `CITATION.cff`
- [ ] I have updated the `CHANGELOG.md`
- [ ] I have added/edited docs/notebooks to reflect the changes
