### PR TITLE
Quickfix for removal of old kachery tables

### DIFF
--- a/src/spyglass/common/__init__.py
+++ b/src/spyglass/common/__init__.py
@@ -42,9 +42,7 @@ from spyglass.common.common_interval import (
 from spyglass.common.common_lab import Institution, Lab, LabMember, LabTeam
 from spyglass.common.common_nwbfile import (
     AnalysisNwbfile,
-    AnalysisNwbfileKachery,
     Nwbfile,
-    NwbfileKachery,
 )
 from spyglass.common.common_position import (
     IntervalLinearizationSelection,


### PR DESCRIPTION
# Description

PR #918 removed unused kachery tables from common.  This removes them from the __init__ file for common to avoid errors