### PR TITLE
Fix improper uses of strip

### DIFF
--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -139,7 +139,7 @@ class IntervalList(SpyglassMixin, dj.Manual):
                 ax.text(
                     interval[0] + np.diff(interval)[0] / 2,
                     interval_y,
-                    epoch.strip(" valid times"),
+                    epoch.replace(" valid times", ""),
                     ha="center",
                     va="bottom",
                 )

--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -247,7 +247,7 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
         # Insert results
         # in future use https://github.com/rly/ndx-xarray and analysis nwb file?
 
-        nwb_file_name = key["nwb_file_name"].strip("_.nwb")
+        nwb_file_name = key["nwb_file_name"].replace("_.nwb", "")
 
         # Generate a unique path for the results file
         path_exists = True

--- a/src/spyglass/decoding/v1/sorted_spikes.py
+++ b/src/spyglass/decoding/v1/sorted_spikes.py
@@ -211,7 +211,7 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
         # Insert results
         # in future use https://github.com/rly/ndx-xarray and analysis nwb file?
 
-        nwb_file_name = key["nwb_file_name"].strip("_.nwb")
+        nwb_file_name = key["nwb_file_name"].replace("_.nwb", "")
 
         # Generate a unique path for the results file
         path_exists = True


### PR DESCRIPTION
Strip will remove leading characters in any order.

Thanks to @gillespielab for finding this bug.
