### PR TITLE
Add logging of AnalysisNwbfile creation time and file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@
 - Avoid permission check on personnel tables. #903
 - Add documentation for `SpyglassMixin`. #903
 - Add helper to identify merge table by definition. #903
-- Prioritize datajoint filepath entry for defining abs_path of analysis nwbfile #918
+- Prioritize datajoint filepath entry for defining abs_path of analysis nwbfile
+    #918
 - Fix potential duplicate entries in Merge part tables #922
+- Add logging of AnalysisNwbfile creation time and size #937
 
 ### Pipelines
 

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -411,6 +411,7 @@ class LFP(SpyglassMixin, dj.Imported):
     def make(self, key):
         # get the NWB object with the data; FIX: change to fetch with
         # additional infrastructure
+        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])  # logged
 
         rawdata = Raw().nwb_object(key)
         sampling_rate, interval_list_name = (Raw() & key).fetch1(
@@ -465,8 +466,6 @@ class LFP(SpyglassMixin, dj.Imported):
         electrode_id_list = list(k["electrode_id"] for k in electrode_keys)
         electrode_id_list.sort()
 
-        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])  # logged
-
         lfp_file_abspath = AnalysisNwbfile().get_abs_path(lfp_file_name)
         (
             lfp_object_id,
@@ -502,7 +501,7 @@ class LFP(SpyglassMixin, dj.Imported):
             },
             replace=True,
         )
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
         self.insert1(key)
 
     def nwb_object(self, key):
@@ -667,6 +666,10 @@ class LFPBand(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        # create the analysis nwb file to store the results.
+        lfp_band_file_name = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
         # get the NWB object with the lfp data; FIX: change to fetch with additional infrastructure
         lfp_object = (
             LFP() & {"nwb_file_name": key["nwb_file_name"]}
@@ -775,10 +778,6 @@ class LFPBand(SpyglassMixin, dj.Computed):
             )
             return None
 
-        # create the analysis nwb file to store the results.
-        lfp_band_file_name = AnalysisNwbfile().create(  # logged
-            key["nwb_file_name"]
-        )
         lfp_band_file_abspath = AnalysisNwbfile().get_abs_path(
             lfp_band_file_name
         )
@@ -856,7 +855,7 @@ class LFPBand(SpyglassMixin, dj.Computed):
                 "previously saved lfp band times do not match current times"
             )
 
-        AnalysisNwbfile().log(lfp_band_file_name)
+        AnalysisNwbfile().log(lfp_band_file_name, table=self.full_table_name)
         self.insert1(key)
 
     def fetch1_dataframe(self, *attrs, **kwargs):

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -465,7 +465,7 @@ class LFP(SpyglassMixin, dj.Imported):
         electrode_id_list = list(k["electrode_id"] for k in electrode_keys)
         electrode_id_list.sort()
 
-        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
+        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])  # logged
 
         lfp_file_abspath = AnalysisNwbfile().get_abs_path(lfp_file_name)
         (
@@ -502,6 +502,7 @@ class LFP(SpyglassMixin, dj.Imported):
             },
             replace=True,
         )
+        AnalysisNwbfile().log(key)
         self.insert1(key)
 
     def nwb_object(self, key):
@@ -775,7 +776,9 @@ class LFPBand(SpyglassMixin, dj.Computed):
             return None
 
         # create the analysis nwb file to store the results.
-        lfp_band_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
+        lfp_band_file_name = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
         lfp_band_file_abspath = AnalysisNwbfile().get_abs_path(
             lfp_band_file_name
         )
@@ -853,6 +856,7 @@ class LFPBand(SpyglassMixin, dj.Computed):
                 "previously saved lfp band times do not match current times"
             )
 
+        AnalysisNwbfile().log(lfp_band_file_name)
         self.insert1(key)
 
     def fetch1_dataframe(self, *attrs, **kwargs):

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -187,6 +187,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         """
         # To allow some times to occur before create
         creation_time = self._creation_times.get("pre_create_time", time())
+        del self._creation_times["pre_create_time"]
 
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         alter_source_script = False

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -186,8 +186,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             The name of the new NWB file.
         """
         # To allow some times to occur before create
-        creation_time = self._creation_times.get("pre_create_time", time())
-        del self._creation_times["pre_create_time"]
+        creation_time = self._creation_times.pop("pre_create_time", time())
 
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         alter_source_script = False

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -225,7 +225,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         permissions = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
         os.chmod(analysis_file_abs_path, permissions)
 
-        self._file_creation_times[analysis_file_name] = creation_time
+        self._creation_times[analysis_file_name] = creation_time
 
         return analysis_file_name
 
@@ -678,14 +678,19 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         # during times when no other transactions are in progress.
         AnalysisNwbfile.cleanup(True)
 
-    def log(self, analysis_file_name):
+    def log(self, analysis_file_name, table=None):
         """Passthrough to the AnalysisNwbfileLog table. Avoid new imports."""
         if isinstance(analysis_file_name, dict):
             analysis_file_name = analysis_file_name["analysis_file_name"]
         time_delta = time() - self._creation_times[analysis_file_name]
         file_size = os.path.getsize(self.get_abs_path(analysis_file_name))
 
-        AnalysisNwbfileLog().log(analysis_file_name, time_delta, file_size)
+        AnalysisNwbfileLog().log(
+            analysis_file_name=analysis_file_name,
+            time_delta=time_delta,
+            file_size=file_size,
+            table=table,
+        )
 
 
 @schema
@@ -701,7 +706,7 @@ class AnalysisNwbfileLog(dj.Manual):
     file_size=null: float
     """
 
-    def log(self, analysis_file_name, time_delta, file_size):
+    def log(self, analysis_file_name, time_delta, file_size, table=None):
         """Log the creation of an analysis NWB file.
 
         Parameters
@@ -715,5 +720,6 @@ class AnalysisNwbfileLog(dj.Manual):
                 "analysis_file_name": analysis_file_name,
                 "time_delta": time_delta,
                 "file_size": file_size,
+                "table": table,
             }
         )

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -185,7 +185,8 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         analysis_file_name : str
             The name of the new NWB file.
         """
-        creation_time = time()
+        # To allow some times to occur before create
+        creation_time = self._creation_times.get("pre_create_time", time())
 
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         alter_source_script = False
@@ -683,7 +684,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         if isinstance(analysis_file_name, dict):
             analysis_file_name = analysis_file_name["analysis_file_name"]
         time_delta = time() - self._creation_times[analysis_file_name]
-        file_size = os.path.getsize(self.get_abs_path(analysis_file_name))
+        file_size = Path(self.get_abs_path(analysis_file_name)).stat().st_size
 
         AnalysisNwbfileLog().log(
             analysis_file_name=analysis_file_name,

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -120,7 +120,7 @@ class IntervalPositionInfo(SpyglassMixin, dj.Computed):
 
         AnalysisNwbfile().add(key["nwb_file_name"], analysis_file_name)
 
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
 
         self.insert1(key)
 

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -91,7 +91,9 @@ class IntervalPositionInfo(SpyglassMixin, dj.Computed):
     def make(self, key):
         logger.info(f"Computing position for: {key}")
 
-        analysis_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
+        analysis_file_name = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
 
         raw_position = RawPosition.PosObject & key
         spatial_series = raw_position.fetch_nwb()[0]["raw_position"]
@@ -117,6 +119,8 @@ class IntervalPositionInfo(SpyglassMixin, dj.Computed):
         )
 
         AnalysisNwbfile().add(key["nwb_file_name"], analysis_file_name)
+
+        AnalysisNwbfile().log(key)
 
         self.insert1(key)
 

--- a/src/spyglass/common/common_usage.py
+++ b/src/spyglass/common/common_usage.py
@@ -37,3 +37,16 @@ class InsertError(dj.Manual):
     error_message: varchar(255)
     error_raw = null: blob
     """
+
+
+@schema
+class AnalysisNwbfileLog(dj.manual):
+    definition = """
+    id: int auto_increment
+    ---
+    dj_user: varchar(64)
+    analysis_file_name: varchar(64)
+    timestamp = CURRENT_TIMESTAMP : timestamp
+    creation_time=null: float
+    file_size=null: float
+    """

--- a/src/spyglass/decoding/v0/clusterless.py
+++ b/src/spyglass/decoding/v0/clusterless.py
@@ -135,6 +135,10 @@ class UnitMarks(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        # create a new AnalysisNwbfile and a timeseries for the marks and save
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
         # get the list of mark parameters
         mark_param = (MarkParameters & key).fetch1()
 
@@ -207,10 +211,6 @@ class UnitMarks(SpyglassMixin, dj.Computed):
                 timestamps, marks, mark_param["mark_param_dict"]
             )
 
-        # create a new AnalysisNwbfile and a timeseries for the marks and save
-        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
-            key["nwb_file_name"]
-        )
         nwb_object = pynwb.TimeSeries(
             name="marks",
             data=marks,
@@ -222,7 +222,7 @@ class UnitMarks(SpyglassMixin, dj.Computed):
             key["analysis_file_name"], nwb_object
         )
         AnalysisNwbfile().add(key["nwb_file_name"], key["analysis_file_name"])
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
         self.insert1(key)
 
     def fetch1_dataframe(self) -> pd.DataFrame:

--- a/src/spyglass/decoding/v0/clusterless.py
+++ b/src/spyglass/decoding/v0/clusterless.py
@@ -208,7 +208,7 @@ class UnitMarks(SpyglassMixin, dj.Computed):
             )
 
         # create a new AnalysisNwbfile and a timeseries for the marks and save
-        key["analysis_file_name"] = AnalysisNwbfile().create(
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
             key["nwb_file_name"]
         )
         nwb_object = pynwb.TimeSeries(
@@ -222,6 +222,7 @@ class UnitMarks(SpyglassMixin, dj.Computed):
             key["analysis_file_name"], nwb_object
         )
         AnalysisNwbfile().add(key["nwb_file_name"], key["analysis_file_name"])
+        AnalysisNwbfile().log(key)
         self.insert1(key)
 
     def fetch1_dataframe(self) -> pd.DataFrame:

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -1,5 +1,6 @@
 import os
 from itertools import chain
+from time import time
 
 import datajoint as dj
 import numpy as np
@@ -102,6 +103,7 @@ class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        AnalysisNwbfile()._creation_times["pre_create_time"] = time()
         # get the list of feature parameters
         params = (WaveformFeaturesParams & key).fetch1("params")
 
@@ -360,7 +362,7 @@ def _write_waveform_features_to_nwb(
     unit_ids = [int(i) for i in waveforms.sorting.get_unit_ids()]
 
     # create new analysis nwb file
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -360,7 +360,7 @@ def _write_waveform_features_to_nwb(
     unit_ids = [int(i) for i in waveforms.sorting.get_unit_ids()]
 
     # create new analysis nwb file
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,
@@ -389,5 +389,7 @@ def _write_waveform_features_to_nwb(
 
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
+
+    AnalysisNwbfile().log(analysis_nwb_file)
 
     return analysis_nwb_file, units_object_id

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -390,6 +390,9 @@ def _write_waveform_features_to_nwb(
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
 
-    AnalysisNwbfile().log(analysis_nwb_file)
+    AnalysisNwbfile().log(
+        analysis_nwb_file,
+        table="`decoding_waveform_features`.`__unit_waveform_features`",
+    )
 
     return analysis_nwb_file, units_object_id

--- a/src/spyglass/lfp/analysis/v1/lfp_band.py
+++ b/src/spyglass/lfp/analysis/v1/lfp_band.py
@@ -174,6 +174,10 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        # create the analysis nwb file to store the results.
+        lfp_band_file_name = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
         # get the NWB object with the lfp data; FIX: change to fetch with additional infrastructure
         lfp_key = {"merge_id": key["lfp_merge_id"]}
         lfp_object = (LFPOutput & lfp_key).fetch_nwb()[0]["lfp"]
@@ -276,10 +280,6 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
             )
             return None
 
-        # create the analysis nwb file to store the results.
-        lfp_band_file_name = AnalysisNwbfile().create(  # logged
-            key["nwb_file_name"]
-        )
         lfp_band_file_abspath = AnalysisNwbfile().get_abs_path(
             lfp_band_file_name
         )
@@ -364,7 +364,7 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
                 "previously saved lfp band times do not match current times"
             )
 
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
         self.insert1(key)
 
     def fetch1_dataframe(self, *attrs, **kwargs):

--- a/src/spyglass/lfp/analysis/v1/lfp_band.py
+++ b/src/spyglass/lfp/analysis/v1/lfp_band.py
@@ -277,7 +277,9 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
             return None
 
         # create the analysis nwb file to store the results.
-        lfp_band_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
+        lfp_band_file_name = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
         lfp_band_file_abspath = AnalysisNwbfile().get_abs_path(
             lfp_band_file_name
         )
@@ -362,6 +364,7 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
                 "previously saved lfp band times do not match current times"
             )
 
+        AnalysisNwbfile().log(key)
         self.insert1(key)
 
     def fetch1_dataframe(self, *attrs, **kwargs):

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -58,6 +58,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])  # logged
         # get the NWB object with the data
         nwbf_key = {"nwb_file_name": key["nwb_file_name"]}
         rawdata = (Raw & nwbf_key).fetch_nwb()[0]["raw"]
@@ -127,8 +128,6 @@ class LFPV1(SpyglassMixin, dj.Computed):
         electrode_id_list = list(k["electrode_id"] for k in electrode_keys)
         electrode_id_list.sort()
 
-        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])  # logged
-
         lfp_file_abspath = AnalysisNwbfile().get_abs_path(lfp_file_name)
         (
             lfp_object_id,
@@ -193,7 +192,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
         orig_key["analysis_file_name"] = lfp_file_name
         orig_key["lfp_object_id"] = lfp_object_id
         LFPOutput.insert1(orig_key)
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch1_dataframe(self, *attrs, **kwargs):
         nwb_lfp = self.fetch_nwb()[0]

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -127,7 +127,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
         electrode_id_list = list(k["electrode_id"] for k in electrode_keys)
         electrode_id_list.sort()
 
-        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
+        lfp_file_name = AnalysisNwbfile().create(key["nwb_file_name"])  # logged
 
         lfp_file_abspath = AnalysisNwbfile().get_abs_path(lfp_file_name)
         (
@@ -193,6 +193,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
         orig_key["analysis_file_name"] = lfp_file_name
         orig_key["lfp_object_id"] = lfp_object_id
         LFPOutput.insert1(orig_key)
+        AnalysisNwbfile().log(key)
 
     def fetch1_dataframe(self, *attrs, **kwargs):
         nwb_lfp = self.fetch_nwb()[0]

--- a/src/spyglass/linearization/v0/main.py
+++ b/src/spyglass/linearization/v0/main.py
@@ -184,7 +184,7 @@ class IntervalLinearizedPosition(SpyglassMixin, dj.Computed):
 
         self.insert1(key)
 
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch1_dataframe(self):
         return self.fetch_nwb()[0]["linearized_position"].set_index("time")

--- a/src/spyglass/linearization/v0/main.py
+++ b/src/spyglass/linearization/v0/main.py
@@ -121,7 +121,7 @@ class IntervalLinearizedPosition(SpyglassMixin, dj.Computed):
     def make(self, key):
         logger.info(f"Computing linear position for: {key}")
 
-        key["analysis_file_name"] = AnalysisNwbfile().create(
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
             key["nwb_file_name"]
         )
 
@@ -183,6 +183,8 @@ class IntervalLinearizedPosition(SpyglassMixin, dj.Computed):
         )
 
         self.insert1(key)
+
+        AnalysisNwbfile().log(key)
 
     def fetch1_dataframe(self):
         return self.fetch_nwb()[0]["linearized_position"].set_index("time")

--- a/src/spyglass/linearization/v1/main.py
+++ b/src/spyglass/linearization/v1/main.py
@@ -181,7 +181,7 @@ class LinearizedPositionV1(SpyglassMixin, dj.Computed):
             [orig_key], part_name=part_name, skip_duplicates=True
         )
 
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch1_dataframe(self):
         return self.fetch_nwb()[0]["linearized_position"].set_index("time")

--- a/src/spyglass/linearization/v1/main.py
+++ b/src/spyglass/linearization/v1/main.py
@@ -120,7 +120,7 @@ class LinearizedPositionV1(SpyglassMixin, dj.Computed):
         position_nwb = PositionOutput().fetch_nwb(
             {"merge_id": key["pos_merge_id"]}
         )[0]
-        key["analysis_file_name"] = AnalysisNwbfile().create(
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
             position_nwb["nwb_file_name"]
         )
         position = np.asarray(
@@ -180,6 +180,8 @@ class LinearizedPositionV1(SpyglassMixin, dj.Computed):
         LinearizedPositionOutput._merge_insert(
             [orig_key], part_name=part_name, skip_duplicates=True
         )
+
+        AnalysisNwbfile().log(key)
 
     def fetch1_dataframe(self):
         return self.fetch_nwb()[0]["linearized_position"].set_index("time")

--- a/src/spyglass/position/v1/position_dlc_centroid.py
+++ b/src/spyglass/position/v1/position_dlc_centroid.py
@@ -299,7 +299,9 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
                 comments="no comments",
             )
             # Add to Analysis NWB file
-            analysis_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
+            analysis_file_name = AnalysisNwbfile().create(  # logged
+                key["nwb_file_name"]
+            )
             nwb_analysis_file = AnalysisNwbfile()
             key.update(
                 {
@@ -319,6 +321,7 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
             )
             self.insert1(key)
             logger.logger.info("inserted entry into DLCCentroid")
+            AnalysisNwbfile().log(key)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_dlc_centroid.py
+++ b/src/spyglass/position/v1/position_dlc_centroid.py
@@ -141,6 +141,10 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
             path=f"{output_dir.as_posix()}/log.log",
             print_console=False,
         ) as logger:
+            # Add to Analysis NWB file
+            analysis_file_name = AnalysisNwbfile().create(  # logged
+                key["nwb_file_name"]
+            )
             logger.logger.info("-----------------------")
             logger.logger.info("Centroid Calculation")
 
@@ -298,10 +302,6 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
                 description="video_frame_ind",
                 comments="no comments",
             )
-            # Add to Analysis NWB file
-            analysis_file_name = AnalysisNwbfile().create(  # logged
-                key["nwb_file_name"]
-            )
             nwb_analysis_file = AnalysisNwbfile()
             key.update(
                 {
@@ -321,7 +321,7 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
             )
             self.insert1(key)
             logger.logger.info("inserted entry into DLCCentroid")
-            AnalysisNwbfile().log(key)
+            AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_dlc_orient.py
+++ b/src/spyglass/position/v1/position_dlc_orient.py
@@ -130,7 +130,7 @@ class DLCOrientation(SpyglassMixin, dj.Computed):
         final_df = pd.DataFrame(
             orientation, columns=["orientation"], index=pos_df.index
         )
-        key["analysis_file_name"] = AnalysisNwbfile().create(
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
             key["nwb_file_name"]
         )
         spatial_series = (RawPosition() & key).fetch_nwb()[0]["raw_position"]
@@ -155,6 +155,7 @@ class DLCOrientation(SpyglassMixin, dj.Computed):
         )
 
         self.insert1(key)
+        AnalysisNwbfile().log(key)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_dlc_orient.py
+++ b/src/spyglass/position/v1/position_dlc_orient.py
@@ -85,6 +85,9 @@ class DLCOrientation(SpyglassMixin, dj.Computed):
 
     def make(self, key):
         # Get labels to smooth from Parameters table
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
         cohort_entries = DLCSmoothInterpCohort.BodyPart & key
         pos_df = pd.concat(
             {
@@ -130,9 +133,6 @@ class DLCOrientation(SpyglassMixin, dj.Computed):
         final_df = pd.DataFrame(
             orientation, columns=["orientation"], index=pos_df.index
         )
-        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
-            key["nwb_file_name"]
-        )
         spatial_series = (RawPosition() & key).fetch_nwb()[0]["raw_position"]
         orientation = pynwb.behavior.CompassDirection()
         orientation.create_spatial_series(
@@ -155,7 +155,7 @@ class DLCOrientation(SpyglassMixin, dj.Computed):
         )
 
         self.insert1(key)
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_dlc_pose_estimation.py
+++ b/src/spyglass/position/v1/position_dlc_pose_estimation.py
@@ -276,15 +276,15 @@ class DLCPoseEstimation(SpyglassMixin, dj.Computed):
             idx = pd.IndexSlice
             for body_part, part_df in body_parts_df.items():
                 logger.logger.info("converting to cm")
+                key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
+                    key["nwb_file_name"]
+                )
                 part_df = convert_to_cm(part_df, meters_per_pixel)
                 logger.logger.info("adding timestamps to DataFrame")
                 part_df = add_timestamps(
                     part_df, pos_time=pos_time, video_time=video_time
                 )
                 key["bodypart"] = body_part
-                key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
-                    key["nwb_file_name"]
-                )
                 position = pynwb.behavior.Position()
                 likelihood = pynwb.behavior.BehavioralTimeSeries()
                 position.create_spatial_series(
@@ -330,7 +330,7 @@ class DLCPoseEstimation(SpyglassMixin, dj.Computed):
                     analysis_file_name=key["analysis_file_name"],
                 )
                 self.BodyPart.insert1(key)
-                AnalysisNwbfile().log(key)
+                AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch_dataframe(self, *attrs, **kwargs):
         entries = (self.BodyPart & self).fetch("KEY")

--- a/src/spyglass/position/v1/position_dlc_pose_estimation.py
+++ b/src/spyglass/position/v1/position_dlc_pose_estimation.py
@@ -282,7 +282,7 @@ class DLCPoseEstimation(SpyglassMixin, dj.Computed):
                     part_df, pos_time=pos_time, video_time=video_time
                 )
                 key["bodypart"] = body_part
-                key["analysis_file_name"] = AnalysisNwbfile().create(
+                key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
                     key["nwb_file_name"]
                 )
                 position = pynwb.behavior.Position()
@@ -330,6 +330,7 @@ class DLCPoseEstimation(SpyglassMixin, dj.Computed):
                     analysis_file_name=key["analysis_file_name"],
                 )
                 self.BodyPart.insert1(key)
+                AnalysisNwbfile().log(key)
 
     def fetch_dataframe(self, *attrs, **kwargs):
         entries = (self.BodyPart & self).fetch("KEY")

--- a/src/spyglass/position/v1/position_dlc_position.py
+++ b/src/spyglass/position/v1/position_dlc_position.py
@@ -167,6 +167,9 @@ class DLCSmoothInterp(SpyglassMixin, dj.Computed):
             path=f"{output_dir.as_posix()}/log.log",
             print_console=False,
         ) as logger:
+            key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
+                key["nwb_file_name"]
+            )
             logger.logger.info("-----------------------")
             idx = pd.IndexSlice
             # Get labels to smooth from Parameters table
@@ -224,9 +227,6 @@ class DLCSmoothInterp(SpyglassMixin, dj.Computed):
                 .fetch_nwb()[0]["dlc_pose_estimation_position"]
                 .get_spatial_series()
             )
-            key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
-                key["nwb_file_name"]
-            )
             # Add dataframe to AnalysisNwbfile
             nwb_analysis_file = AnalysisNwbfile()
             position = pynwb.behavior.Position()
@@ -267,7 +267,7 @@ class DLCSmoothInterp(SpyglassMixin, dj.Computed):
             )
             self.insert1(key)
             logger.logger.info("inserted entry into DLCSmoothInterp")
-            AnalysisNwbfile().log(key)
+            AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_dlc_position.py
+++ b/src/spyglass/position/v1/position_dlc_position.py
@@ -224,7 +224,7 @@ class DLCSmoothInterp(SpyglassMixin, dj.Computed):
                 .fetch_nwb()[0]["dlc_pose_estimation_position"]
                 .get_spatial_series()
             )
-            key["analysis_file_name"] = AnalysisNwbfile().create(
+            key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
                 key["nwb_file_name"]
             )
             # Add dataframe to AnalysisNwbfile
@@ -267,6 +267,7 @@ class DLCSmoothInterp(SpyglassMixin, dj.Computed):
             )
             self.insert1(key)
             logger.logger.info("inserted entry into DLCSmoothInterp")
+            AnalysisNwbfile().log(key)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -57,6 +57,10 @@ class DLCPosV1(SpyglassMixin, dj.Computed):
 
     def make(self, key):
         orig_key = copy.deepcopy(key)
+        # Add to Analysis NWB file
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
         key["pose_eval_result"] = self.evaluate_pose_estimation(key)
 
         pos_nwb = (DLCCentroid & key).fetch_nwb()[0]
@@ -110,10 +114,6 @@ class DLCPosV1(SpyglassMixin, dj.Computed):
             comments=vid_frame_obj.comments,
         )
 
-        # Add to Analysis NWB file
-        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
-            key["nwb_file_name"]
-        )
         nwb_analysis_file = AnalysisNwbfile()
         key["orientation_object_id"] = nwb_analysis_file.add_nwb_object(
             key["analysis_file_name"], orientation
@@ -138,7 +138,7 @@ class DLCPosV1(SpyglassMixin, dj.Computed):
         PositionOutput._merge_insert(
             [orig_key], part_name=part_name, skip_duplicates=True
         )
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -111,7 +111,7 @@ class DLCPosV1(SpyglassMixin, dj.Computed):
         )
 
         # Add to Analysis NWB file
-        key["analysis_file_name"] = AnalysisNwbfile().create(
+        key["analysis_file_name"] = AnalysisNwbfile().create(  # logged
             key["nwb_file_name"]
         )
         nwb_analysis_file = AnalysisNwbfile()
@@ -138,6 +138,7 @@ class DLCPosV1(SpyglassMixin, dj.Computed):
         PositionOutput._merge_insert(
             [orig_key], part_name=part_name, skip_duplicates=True
         )
+        AnalysisNwbfile().log(key)
 
     def fetch1_dataframe(self):
         nwb_data = self.fetch_nwb()[0]

--- a/src/spyglass/position/v1/position_trodes_position.py
+++ b/src/spyglass/position/v1/position_trodes_position.py
@@ -160,7 +160,9 @@ class TrodesPosV1(SpyglassMixin, dj.Computed):
         logger.info(f"Computing position for: {key}")
         orig_key = copy.deepcopy(key)
 
-        analysis_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
+        analysis_file_name = AnalysisNwbfile().create(  # logged
+            key["nwb_file_name"]
+        )
 
         raw_position = RawPosition.PosObject & key
         spatial_series = raw_position.fetch_nwb()[0]["raw_position"]
@@ -201,6 +203,7 @@ class TrodesPosV1(SpyglassMixin, dj.Computed):
         PositionOutput._merge_insert(
             [orig_key], part_name=part_name, skip_duplicates=True
         )
+        AnalysisNwbfile().log(key)
 
     @staticmethod
     def generate_pos_components(*args, **kwargs):

--- a/src/spyglass/position/v1/position_trodes_position.py
+++ b/src/spyglass/position/v1/position_trodes_position.py
@@ -203,7 +203,7 @@ class TrodesPosV1(SpyglassMixin, dj.Computed):
         PositionOutput._merge_insert(
             [orig_key], part_name=part_name, skip_duplicates=True
         )
-        AnalysisNwbfile().log(key)
+        AnalysisNwbfile().log(key, table=self.full_table_name)
 
     @staticmethod
     def generate_pos_components(*args, **kwargs):

--- a/src/spyglass/spikesorting/v1/curation.py
+++ b/src/spyglass/spikesorting/v1/curation.py
@@ -1,3 +1,4 @@
+from time import time
 from typing import Dict, List, Union
 
 import datajoint as dj
@@ -74,6 +75,8 @@ class CurationV1(SpyglassMixin, dj.Manual):
         -------
         curation_key : dict
         """
+        AnalysisNwbfile()._creation_times["pre_create_time"] = time()
+
         sort_query = cls & {"sorting_id": sorting_id}
         parent_curation_id = max(parent_curation_id, -1)
         if parent_curation_id == -1:
@@ -296,7 +299,7 @@ def _write_sorting_to_nwb_with_curation(
     nwb_file_name = (SpikeSortingSelection & {"sorting_id": sorting_id}).fetch1(
         "nwb_file_name"
     )
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
 
     # get sorting
     sorting_analysis_file_abs_path = AnalysisNwbfile.get_abs_path(

--- a/src/spyglass/spikesorting/v1/curation.py
+++ b/src/spyglass/spikesorting/v1/curation.py
@@ -296,6 +296,7 @@ def _write_sorting_to_nwb_with_curation(
     nwb_file_name = (SpikeSortingSelection & {"sorting_id": sorting_id}).fetch1(
         "nwb_file_name"
     )
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
 
     # get sorting
     sorting_analysis_file_abs_path = AnalysisNwbfile.get_abs_path(
@@ -324,7 +325,6 @@ def _write_sorting_to_nwb_with_curation(
     unit_ids = list(units_dict.keys())
 
     # create new analysis nwb file
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,
@@ -381,7 +381,9 @@ def _write_sorting_to_nwb_with_curation(
 
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
-    AnalysisNwbfile().log(analysis_nwb_file)
+    AnalysisNwbfile().log(
+        analysis_nwb_file, table="`spikesorting_v1_sorting`.`__spike_sorting`"
+    )
     return analysis_nwb_file, units_object_id
 
 

--- a/src/spyglass/spikesorting/v1/curation.py
+++ b/src/spyglass/spikesorting/v1/curation.py
@@ -324,7 +324,7 @@ def _write_sorting_to_nwb_with_curation(
     unit_ids = list(units_dict.keys())
 
     # create new analysis nwb file
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,
@@ -381,6 +381,7 @@ def _write_sorting_to_nwb_with_curation(
 
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
+    AnalysisNwbfile().log(analysis_nwb_file)
     return analysis_nwb_file, units_object_id
 
 

--- a/src/spyglass/spikesorting/v1/metric_curation.py
+++ b/src/spyglass/spikesorting/v1/metric_curation.py
@@ -527,7 +527,7 @@ def _write_metric_curation_to_nwb(
     unit_ids = [int(i) for i in waveforms.sorting.get_unit_ids()]
 
     # create new analysis nwb file
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,
@@ -584,4 +584,5 @@ def _write_metric_curation_to_nwb(
 
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
+    AnalysisNwbfile().log(analysis_nwb_file)
     return analysis_nwb_file, units_object_id

--- a/src/spyglass/spikesorting/v1/metric_curation.py
+++ b/src/spyglass/spikesorting/v1/metric_curation.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from time import time
 from typing import Any, Dict, List, Union
 
 import datajoint as dj
@@ -203,6 +204,7 @@ class MetricCuration(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        AnalysisNwbfile()._creation_times["pre_create_time"] = time()
         # FETCH
         nwb_file_name = (
             SpikeSortingSelection * MetricCurationSelection & key
@@ -524,7 +526,7 @@ def _write_metric_curation_to_nwb(
         object_id of the units table in the analysis NWB file
     """
     # create new analysis nwb file
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
 
     unit_ids = [int(i) for i in waveforms.sorting.get_unit_ids()]

--- a/src/spyglass/spikesorting/v1/metric_curation.py
+++ b/src/spyglass/spikesorting/v1/metric_curation.py
@@ -523,12 +523,12 @@ def _write_metric_curation_to_nwb(
     object_id : str
         object_id of the units table in the analysis NWB file
     """
-
-    unit_ids = [int(i) for i in waveforms.sorting.get_unit_ids()]
-
     # create new analysis nwb file
     analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
+
+    unit_ids = [int(i) for i in waveforms.sorting.get_unit_ids()]
+
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,
         mode="a",
@@ -584,5 +584,8 @@ def _write_metric_curation_to_nwb(
 
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
-    AnalysisNwbfile().log(analysis_nwb_file)
+    AnalysisNwbfile().log(
+        analysis_nwb_file,
+        table="`spikesorting_v1_metric_curation`.`__metric_curation`",
+    )
     return analysis_nwb_file, units_object_id

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -649,7 +649,10 @@ def _write_recording_to_nwb(
             "ProcessedElectricalSeries"
         ].object_id
         io.write(nwbfile)
-    AnalysisNwbfile().log(analysis_nwb_file)
+    AnalysisNwbfile().log(
+        analysis_nwb_file,
+        table="`spikesorting_v1_sorting`.`__spike_sorting_recording`",
+    )
     return analysis_nwb_file, recording_object_id
 
 

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -617,7 +617,7 @@ def _write_recording_to_nwb(
         name of analysis NWB file containing the preprocessed recording
     """
 
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,
@@ -649,6 +649,7 @@ def _write_recording_to_nwb(
             "ProcessedElectricalSeries"
         ].object_id
         io.write(nwbfile)
+    AnalysisNwbfile().log(analysis_nwb_file)
     return analysis_nwb_file, recording_object_id
 
 

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -1,4 +1,5 @@
 import uuid
+from time import time
 from typing import Iterable, List, Optional, Tuple, Union
 
 import datajoint as dj
@@ -250,6 +251,7 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        AnalysisNwbfile()._creation_times["pre_create_time"] = time()
         # DO:
         # - get valid times for sort interval
         # - proprocess recording
@@ -617,7 +619,7 @@ def _write_recording_to_nwb(
         name of analysis NWB file containing the preprocessed recording
     """
 
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -400,5 +400,7 @@ def _write_sorting_to_nwb(
                 )
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
-    AnalysisNwbfile().log(analysis_nwb_file)
+    AnalysisNwbfile().log(
+        analysis_nwb_file, table="`spikesorting_v1_curation`.`curation_v1`"
+    )
     return analysis_nwb_file, units_object_id

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import time
 import uuid
@@ -22,7 +23,6 @@ from spyglass.spikesorting.v1.recording import (  # noqa: F401
     _consolidate_intervals,
 )
 from spyglass.utils import SpyglassMixin, logger
-import os
 
 schema = dj.schema("spikesorting_v1_sorting")
 
@@ -368,7 +368,7 @@ def _write_sorting_to_nwb(
         Name of analysis NWB file containing the sorting
     """
 
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,
@@ -400,4 +400,5 @@ def _write_sorting_to_nwb(
                 )
         units_object_id = nwbf.units.object_id
         io.write(nwbf)
+    AnalysisNwbfile().log(analysis_nwb_file)
     return analysis_nwb_file, units_object_id

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -152,6 +152,7 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
         # - information about the recording
         # - artifact free intervals
         # - spike sorter and sorter params
+        AnalysisNwbfile()._creation_times["pre_create_time"] = time.time()
 
         recording_key = (
             SpikeSortingRecording * SpikeSortingSelection & key
@@ -368,7 +369,7 @@ def _write_sorting_to_nwb(
         Name of analysis NWB file containing the sorting
     """
 
-    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)  # logged
+    analysis_nwb_file = AnalysisNwbfile().create(nwb_file_name)
     analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(analysis_nwb_file)
     with pynwb.NWBHDF5IO(
         path=analysis_nwb_file_abs_path,

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -793,7 +793,7 @@ class Merge(dj.Manual):
         Added to support MRO of SpyglassMixin"""
         logger.warning("!! Using super_delete. Bypassing cautious_delete !!")
 
-        self._log_use(start=time(), super_delete=True)
+        self._log_delete(start=time(), super_delete=True)
         super().delete(*args, **kwargs)
 
 

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -445,7 +445,7 @@ class SpyglassMixin:
 
         return CautiousDelete()
 
-    def _log_use(self, start, merge_deletes=None, super_delete=False):
+    def _log_delete(self, start, merge_deletes=None, super_delete=False):
         """Log use of cautious_delete."""
         if isinstance(merge_deletes, QueryExpression):
             merge_deletes = merge_deletes.fetch(as_dict=True)
@@ -515,12 +515,12 @@ class SpyglassMixin:
                 self._commit_merge_deletes(merge_deletes, **kwargs)
             else:
                 logger.info("Delete aborted.")
-                self._log_use(start)
+                self._log_delete(start)
                 return
 
         super().delete(*args, **kwargs)  # Additional confirm here
 
-        self._log_use(start=start, merge_deletes=merge_deletes)
+        self._log_delete(start=start, merge_deletes=merge_deletes)
 
     def cdel(self, force_permission=False, *args, **kwargs):
         """Alias for cautious_delete."""
@@ -533,5 +533,5 @@ class SpyglassMixin:
     def super_delete(self, *args, **kwargs):
         """Alias for datajoint.table.Table.delete."""
         logger.warning("!! Using super_delete. Bypassing cautious_delete !!")
-        self._log_use(start=time(), super_delete=True)
+        self._log_delete(start=time(), super_delete=True)
         super().delete(*args, **kwargs)


### PR DESCRIPTION
 # Description

Resolves #907 with changes across many make funcs.

Our full solve for #861 may involve skipping some files that we can readily recompute. This PR adds a table to `common_nwbfile` to track how long it takes between `AnalysisNwbfile.create` and the end of the func that initiated this process. This will support decision making around recompute efforts.

The spikesorting v1 pipeline was unique for running `create` after the output had been generated... I think. This data is not going to be as accurate. Is it worth my time to find a new strategy to get the full processing time?

Currently, file size is in bytes, would we prefer MB?

# Checklist:

- [X] This PR should be accompanied by a release: Yes? I'd like to get this pushed out to folks
- [ ] (If release) I have updated the `CITATION.cff`
- [X] I have updated the `CHANGELOG.md`
- [X] n/a I have added/edited docs/notebooks to reflect the changes