### PR TITLE
Fix bug on empty delete in merge table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
     #918
 - Fix potential duplicate entries in Merge part tables #922
 - Add logging of AnalysisNwbfile creation time and size #937
-- Fix error on emty delete call in merge table. #940
+- Fix error on empty delete call in merge table. #940
 
 ### Pipelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     #918
 - Fix potential duplicate entries in Merge part tables #922
 - Add logging of AnalysisNwbfile creation time and size #937
+- Fix error on emty delete call in merge table. #940
 
 ### Pipelines
 

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -799,11 +799,16 @@ class Merge(dj.Manual):
 
     def delete(self, force_permission=False, *args, **kwargs):
         """Alias for cautious_delete, overwrites datajoint.table.Table.delete"""
-        for part in self.merge_get_part(
-            restriction=self.restriction,
-            multi_source=True,
-            return_empties=False,
+        if not (
+            parts := self.merge_get_part(
+                restriction=self.restriction,
+                multi_source=True,
+                return_empties=False,
+            )
         ):
+            return
+
+        for part in parts:
             part.delete(force_permission=force_permission, *args, **kwargs)
 
     def super_delete(self, warn=True, *args, **kwargs):


### PR DESCRIPTION
# Description

Fixes #932
- Prevent error when calling `Merge.delete()` with no entries in restriction

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] This PR should be accompanied by a release: no
- [X] N/A, If release, I have updated the `CITATION.cff`
- [X] This PR makes edits to table definitions: No
- [X] N/A, If table edits, I have included an `alter` snippet for release notes.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/A,I have added/edited docs/notebooks to reflect the changes
