### PR TITLE
`IntervalList` cautious insert

### DIFF
--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -90,16 +90,23 @@ class PositionSource(SpyglassMixin, dj.Manual):
         for epoch, epoch_list in all_pos.items():
             ind_key = dict(interval_list_name=cls.get_pos_interval_name(epoch))
 
-            sources.append(dict(**src_key, **ind_key))
-            intervals.append(
-                dict(
+            interval_exists, new_interval = IntervalList().key_exists(
+                key=dict(
                     **sess_key,
                     **ind_key,
                     valid_times=epoch_list[0]["valid_times"],
                     pipeline="position",
-                )
+                ),
+                approx_name="pos%valid times",
             )
+            if not interval_exists:
+                intervals.append(new_interval)
+            else:
+                ind_key.update(
+                    {"interval_list_name": new_interval["interval_list_name"]}
+                )
 
+            sources.append(dict(**src_key, **ind_key))
             for index, pdict in enumerate(epoch_list):
                 spat_series.append(
                     dict(

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -131,7 +131,11 @@ class IntervalList(SpyglassMixin, dj.Manual):
         for candidate in candidates:
             if time() - start_time > time_limit:
                 return False, key
-            if (not len(candidate["valid_times"]) == len( key["valid_times"])) or (not np.equal(candidate["valid_times"], key["valid_times"]).all()):
+            if (
+                not len(candidate["valid_times"]) == len(key["valid_times"])
+            ) or (
+                not np.equal(candidate["valid_times"], key["valid_times"]).all()
+            ):
                 continue
             logger.info(
                 "Interval valid times exist: "

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -131,7 +131,7 @@ class IntervalList(SpyglassMixin, dj.Manual):
         for candidate in candidates:
             if time() - start_time > time_limit:
                 return False, key
-            if not np.equal(candidate["valid_times"], key["valid_times"]).all():
+            if (not len(candidate["valid_times"]) == len( key["valid_times"])) or (not np.equal(candidate["valid_times"], key["valid_times"]).all()):
                 continue
             logger.info(
                 "Interval valid times exist: "

--- a/src/spyglass/lfp/analysis/v1/lfp_band.py
+++ b/src/spyglass/lfp/analysis/v1/lfp_band.py
@@ -367,10 +367,7 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
                 "previously saved lfp band times do not match current times"
             )
 
-        # - --------------------------------------------------------------
-
         AnalysisNwbfile().log(key, table=self.full_table_name)
-
         self.insert1(key)
 
     def fetch1_dataframe(self, *attrs, **kwargs):

--- a/src/spyglass/lfp/analysis/v1/lfp_band.py
+++ b/src/spyglass/lfp/analysis/v1/lfp_band.py
@@ -333,36 +333,16 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
             + str(lfp_band_sampling_rate)
             + "Hz"
         )
-        tmp_valid_times = (
-            IntervalList
-            & {
+        interval_key = IntervalList().cautious_insert1(
+            key={
                 "nwb_file_name": key["nwb_file_name"],
                 "interval_list_name": key["interval_list_name"],
-            }
-        ).fetch("valid_times")
-        if len(tmp_valid_times) == 0:
-            lfp_band_valid_times = interval_list_censor(
-                lfp_band_valid_times, new_timestamps
-            )
-            # add an interval list for the LFP valid times
-            IntervalList.insert1(
-                {
-                    "nwb_file_name": key["nwb_file_name"],
-                    "interval_list_name": key["interval_list_name"],
-                    "valid_times": lfp_band_valid_times,
-                    "pipeline": "lfp band",
-                }
-            )
-        else:
-            lfp_band_valid_times = interval_list_censor(
-                lfp_band_valid_times, new_timestamps
-            )
-            # check that the valid times are the same
-            assert np.isclose(
-                tmp_valid_times[0], lfp_band_valid_times
-            ).all(), (
-                "previously saved lfp band times do not match current times"
-            )
+                "valid_times": lfp_band_valid_times,
+                "pipeline": "lfp band",
+            },
+            approx_name="lfp band%Hz",
+        )
+        key.update(interval_key)
 
         AnalysisNwbfile().log(key, table=self.full_table_name)
         self.insert1(key)

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -162,28 +162,16 @@ class LFPV1(SpyglassMixin, dj.Computed):
                 "valid times",
             )
         )
-
-        tmp_valid_times = (
-            IntervalList
-            & {
+        interval_key = IntervalList().cautious_insert1(
+            key={
                 "nwb_file_name": key["nwb_file_name"],
                 "interval_list_name": key["interval_list_name"],
-            }
-        ).fetch("valid_times")
-        if len(tmp_valid_times) == 0:
-            IntervalList.insert1(
-                {
-                    "nwb_file_name": key["nwb_file_name"],
-                    "interval_list_name": key["interval_list_name"],
-                    "valid_times": lfp_valid_times,
-                    "pipeline": "lfp_v1",
-                },
-                replace=True,
-            )
-        elif not np.allclose(tmp_valid_times[0], lfp_valid_times):
-            raise ValueError(
-                "previously saved lfp times do not match current times"
-            )
+                "valid_times": lfp_valid_times,
+                "pipeline": "lfp_v1",
+            },
+            approx_name="lfp_" + key["lfp_electrode_group_name"],
+        )
+        key.update(interval_key)
         self.insert1(key)
 
         # finally, we insert this into the LFP output table.

--- a/src/spyglass/spikesorting/v0/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_recording.py
@@ -395,21 +395,20 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             folder=recording_path, chunk_duration="10000ms", n_jobs=8
         )
 
-        IntervalList.insert1(
-            {
+        interval_key = IntervalList().cautious_insert1(
+            key={
                 "nwb_file_name": key["nwb_file_name"],
                 "interval_list_name": recording_name,
                 "valid_times": sort_interval_valid_times,
                 "pipeline": "spikesorting_recording_v0",
             },
-            replace=True,
-        )
+            approx_name=True,
+        )  # removed replace=True 2024-04-22
 
         self.insert1(
             {
-                **key,
-                # store the list of valid times for the sort
-                "sort_interval_list_name": recording_name,
+                **key,  # store the list of valid times for the sort
+                "sort_interval_list_name": interval_key["interval_list_name"],
                 "recording_path": recording_path,
             }
         )

--- a/src/spyglass/spikesorting/v1/artifact.py
+++ b/src/spyglass/spikesorting/v1/artifact.py
@@ -148,7 +148,7 @@ class ArtifactDetection(SpyglassMixin, dj.Computed):
 
         # INSERT
         # - into IntervalList
-        IntervalList.insert1(
+        actual_interval = IntervalList().cautious_insert1(
             dict(
                 nwb_file_name=(
                     SpikeSortingRecordingSelection * ArtifactDetectionSelection
@@ -158,8 +158,11 @@ class ArtifactDetection(SpyglassMixin, dj.Computed):
                 valid_times=artifact_removed_valid_times,
                 pipeline="spikesorting_artifact_v1",
             ),
+            approx_name="artifact_removed_valid_times",
             skip_duplicates=True,
         )
+        key.update(actual_interval)
+
         # - into ArtifactRemovedInterval
         self.insert1(key)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,6 +418,7 @@ def trodes_pos_v1(teardown, sgp, trodes_sel_keys):
 def pos_merge_tables(dj_conn):
     """Return the merge tables as activated."""
     from spyglass.common.common_position import TrackGraph
+    from spyglass.lfp.lfp_merge import LFPOutput
     from spyglass.linearization.merge import LinearizedPositionOutput
     from spyglass.position.position_merge import PositionOutput
 

--- a/tests/utils/test_mixin.py
+++ b/tests/utils/test_mixin.py
@@ -20,7 +20,7 @@ def Mixin():
 
 @pytest.mark.skipif(not VERBOSE, reason="No logging to test when quiet-spy.")
 def test_bad_prefix(caplog, dj_conn, Mixin):
-    schema_bad = dj.Schema("badprefix", {}, connection=dj_conn)
+    schema_bad = dj.Schema("badprefix_", {}, connection=dj_conn)
     schema_bad(Mixin)
     assert "Schema prefix not in SHARED_MODULES" in caplog.text
 
@@ -33,6 +33,8 @@ def test_nwb_table_missing(schema_test, Mixin):
 
 def test_merge_detect(Nwbfile, pos_merge_tables):
     """Test that the mixin can detect merge children of merge."""
+    from spyglass.lfp.lfp_merge import LFPOutput
+
     merges_found = set(Nwbfile._merge_chains.keys())
     merges_expected = set([t.full_table_name for t in pos_merge_tables])
     assert merges_expected.issubset(


### PR DESCRIPTION
# Description

We have previously discussed redundancy in `IntervalList` in #778. This PR makes pervasive edits to the codebase to check existing entries before inserting new ones. This comes with the drawback of future mismatches between substrings of `interval_list_name` and other features of a given key. I would argue that substrings should not be used in this manner, and the confusion presented will be minor, as the other contents of the key takes precedence. The use of `nwb_file_name` in `IntervalList` prevents cross-session reuse of keys, so confusion should be minimized in that respect.

I've marked as draft pending the addition of documentation on this change. I welcome feedback on the structure of `cautious_insert` and its inclusion across the codebase

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] If release, I have updated the `CITATION.cff`
- [ ] This PR makes edits to table definitions: (yes/no)
- [ ] If table edits, I have included an `alter` snippet for release notes.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] I have added/edited docs/notebooks to reflect the changes
