### PR TITLE
Fix bug report template html

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ Steps to reproduce the behavior:
 3. Scroll down to '....'
 4. See error
 
-</details><summary>Error Stack</summary>
+<details><summary>Error Stack</summary>
 
 ```python
 # Paste the error stack trace here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Infrastructure
 
 - Create class `SpyglassGroupPart` to aid delete propagations #899
+- Fix bug report template #XXX
 
 ## [0.5.2] (April 22, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Infrastructure
 
 - Create class `SpyglassGroupPart` to aid delete propagations #899
-- Fix bug report template #XXX
+- Fix bug report template #955
 
 ## [0.5.2] (April 22, 2024)
 


### PR DESCRIPTION
# Description

Bug report template started it's `details` section with an end marker. Removing.

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/A. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/A. If table edits, I have included an `alter` snippet for release notes.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/A. I have added/edited docs/notebooks to reflect the changes
