### PR TITLE
Fix tests/doc build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Create class `SpyglassGroupPart` to aid delete propagations #899
 - Fix bug report template #955
+- Pin `mkdocstring-python` to `0.9.0`, fix existing docstrings. #967
 
 ## [0.5.2] (April 22, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Create class `SpyglassGroupPart` to aid delete propagations #899
 - Fix bug report template #955
-- Pin `mkdocstring-python` to `0.9.0`, fix existing docstrings. #967
+- Pin `mkdocstring-python` to `1.9.0`, fix existing docstrings. #967
 
 ## [0.5.2] (April 22, 2024)
 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -7,7 +7,7 @@
 cp ./CHANGELOG.md ./docs/src/
 cp ./LICENSE ./docs/src/LICENSE.md
 mkdir -p ./docs/src/notebooks
-rm -r ./docs/src/notebooks/*
+rm -fr ./docs/src/notebooks/*
 cp ./notebooks/*ipynb ./docs/src/notebooks/
 cp ./notebooks/*md ./docs/src/notebooks/
 mv ./docs/src/notebooks/README.md ./docs/src/notebooks/index.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - FigURL: misc/figurl_views.md
       - Session Groups: misc/session_groups.md
       - Insert Data: misc/insert_data.md
+      - Mixin: misc/mixin.md
       - Merge Tables: misc/merge_tables.md
       - Database Management: misc/database_management.md
       - Export: misc/export.md
@@ -100,11 +101,13 @@ plugins:
       default_handler: python
       handlers:
         python:
+          paths: [src]
           options:
             members_order: source
             group_by_category: false
             line_length: 80
             docstring_style: numpy
+            show_inheritance_diagram: true
   - literate-nav:
       nav_file: navigation.md
   - exclude-search:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -107,7 +107,6 @@ plugins:
             group_by_category: false
             line_length: 80
             docstring_style: numpy
-            show_inheritance_diagram: true
   - literate-nav:
       nav_file: navigation.md
   - exclude-search:

--- a/docs/src/misc/index.md
+++ b/docs/src/misc/index.md
@@ -3,7 +3,9 @@
 This folder contains miscellaneous supporting files documentation.
 
 - [Database Management](./database_management.md)
+- [Export](./export.md)
 - [figurl Views](./figurl_views.md)
-- [insert Data](./insert_data.md)
+- [Insert Data](./insert_data.md)
 - [Merge Tables](./merge_tables.md)
+- [Mixin Class](./mixin.md)
 - [Session Groups](./session_groups.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ docs = [
     "mkdocs-jupyter",        # Docs render notebooks
     "mkdocs-literate-nav",   # Dynamic page list for API docs
     "mkdocs-material",       # Docs theme
-    "mkdocstrings[python]",  # Docs API docstrings
+    "mkdocstrings[python]<=1.9.0",  # Docs API docstrings
 ]
 
 [tool.hatch.version]

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -256,14 +256,14 @@ def consolidate_intervals(interval_list):
 def interval_list_intersect(interval_list1, interval_list2, min_length=0):
     """Finds the intersections between two interval lists
 
+    Each interval is (start time, stop time)
+
     Parameters
     ----------
     interval_list1 : np.array, (N,2) where N = number of intervals
     interval_list2 : np.array, (N,2) where N = number of intervals
     min_length : float, optional.
         Minimum length of intervals to include, default 0
-
-    Each interval is (start time, stop time)
 
     Returns
     -------

--- a/src/spyglass/position/v1/dlc_reader.py
+++ b/src/spyglass/position/v1/dlc_reader.py
@@ -161,10 +161,15 @@ def read_yaml(fullpath, filename="*"):
 
     Parameters
     ----------
-    fullpath: String or pathlib path. Directory with yaml files
-    filename: String. Filename, no extension. Permits wildcards.
+    fullpath: Union[str, pathlib.Path]
+        Directory with yaml files
+    filename: str
+        Filename, no extension. Permits wildcards.
 
-    Returns filepath and contents as dict
+    Returns
+    -------
+    tuple
+        filepath and contents as dict
     """
     from deeplabcut.utils.auxiliaryfunctions import read_config
 

--- a/src/spyglass/settings.py
+++ b/src/spyglass/settings.py
@@ -20,7 +20,7 @@ class SpyglassConfig:
     facilitate testing.
     """
 
-    def __init__(self, base_dir: str = None, **kwargs):
+    def __init__(self, base_dir: str = None, **kwargs) -> None:
         """
         Initializes a new instance of the class.
 
@@ -103,7 +103,7 @@ class SpyglassConfig:
         force_reload=False,
         on_startup: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         """
         Loads the configuration settings for the object.
 
@@ -223,25 +223,25 @@ class SpyglassConfig:
 
         return self._config
 
-    def _load_env_vars(self):
+    def _load_env_vars(self) -> dict:
         loaded_dict = {}
         for var, val in self.env_defaults.items():
             loaded_dict[var] = os.getenv(var, val)
         return loaded_dict
 
-    def _set_env_with_dict(self, env_dict):
+    def _set_env_with_dict(self, env_dict) -> None:
         # NOTE: Kept for backwards compatibility. Should be removed in future
         # for custom paths. Keep self.env_defaults.
         for var, val in env_dict.items():
             os.environ[var] = str(val)
 
-    def _mkdirs_from_dict_vals(self, dir_dict):
+    def _mkdirs_from_dict_vals(self, dir_dict) -> None:
         if self._debug_mode:
             return
         for dir_str in dir_dict.values():
             Path(dir_str).mkdir(exist_ok=True)
 
-    def _set_dj_config_stores(self, check_match=True, set_stores=True):
+    def _set_dj_config_stores(self, check_match=True, set_stores=True) -> None:
         """
         Checks dj.config['stores'] match resolved dirs. Ensures stores set.
 
@@ -287,7 +287,7 @@ class SpyglassConfig:
 
         return
 
-    def dir_to_var(self, dir: str, dir_type: str = "spyglass"):
+    def dir_to_var(self, dir: str, dir_type: str = "spyglass") -> str:
         """Converts a dir string to an env variable name."""
         return f"{dir_type.upper()}_{dir.upper()}_DIR"
 
@@ -300,7 +300,7 @@ class SpyglassConfig:
         database_port: int = 3306,
         database_use_tls: bool = True,
         **kwargs,
-    ):
+    ) -> dict:
         """Generate a datajoint configuration file.
 
         Parameters
@@ -345,7 +345,7 @@ class SpyglassConfig:
         base_dir=None,
         set_password=True,
         **kwargs,
-    ):
+    ) -> None:
         """Set the dj.config parameters, set password, and save config to file.
 
         Parameters

--- a/tests/utils/test_mixin.py
+++ b/tests/utils/test_mixin.py
@@ -15,8 +15,6 @@ def Mixin():
 
     yield Mixin
 
-    Mixin().drop_quick()
-
 
 @pytest.mark.skipif(not VERBOSE, reason="No logging to test when quiet-spy.")
 def test_bad_prefix(caplog, dj_conn, Mixin):


### PR DESCRIPTION
# Description

1. Pytests were failing because of an unnecessary teardown line
2. Doc build was failing due to a bug(?) introduced in `mkdocstrings-python==0.9.1`. [Discussion](https://github.com/mkdocstrings/python/discussions/160). I pinned the requirement for now
3. Fixing the pin showed some cases of the build throwing warnings for existing docstrings. I fixec these cases.

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a If table edits, I have included an `alter` snippet for release notes.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
