### PR TITLE
Fix relative pathing for mkdocstrings>=1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Create class `SpyglassGroupPart` to aid delete propagations #899
 - Fix bug report template #955
-- Pin `mkdocstring-python` to `1.9.0`, fix existing docstrings. #967
+- Fix relative pathing for `mkdocstring-python=>1.9.1`. #967, #968
 
 ## [0.5.2] (April 22, 2024)
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -101,12 +101,12 @@ plugins:
       default_handler: python
       handlers:
         python:
-          paths: [src]
           options:
             members_order: source
             group_by_category: false
             line_length: 80
             docstring_style: numpy
+          paths: [../src]
   - literate-nav:
       nav_file: navigation.md
   - exclude-search:

--- a/docs/src/api/make_pages.py
+++ b/docs/src/api/make_pages.py
@@ -16,8 +16,11 @@ for path in sorted(Path("src/spyglass/").glob("**/*.py")):
     if path.stem in ignored_stems or "cython" in path.stem:
         continue
     rel_path = path.relative_to("src/spyglass")
+
+    # parts[0] is the src directory, ignore as of mkdocstrings-python 1.9.1
+    module_path = ".".join([p for p in path.with_suffix("").parts[1:]])
+
     with mkdocs_gen_files.open(f"api/{rel_path.with_suffix('')}.md", "w") as f:
-        module_path = ".".join([p for p in path.with_suffix("").parts])
         print(f"::: {module_path}", file=f)
     nav[rel_path.parts] = f"{rel_path.with_suffix('')}.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ docs = [
     "mkdocs-literate-nav",   # Dynamic page list for API docs
     "mkdocs-material",       # Docs theme
     "mkdocstrings[python]",  # Docs API docstrings
-    "mkdocstrings-python<=1.9.0" # Pinned #976
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
# Description

Received guidance from `mkdocstrings` developer [here](https://github.com/mkdocstrings/python/discussions/160) to allow us to unpin.

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a If table edits, I have included an `alter` snippet for release notes.
- [X] Yes I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a I have added/edited docs/notebooks to reflect the changes
