### PR TITLE
Permit multiple restrict_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Create class `SpyglassGroupPart` to aid delete propagations #899
 - Fix bug report template #955
 - Add rollback option to `populate_all_common` #957
-- Add long-distance restrictions via `<<` and `>>` operators. #943
+- Add long-distance restrictions via `<<` and `>>` operators. #943, #969
 - Fix relative pathing for `mkdocstring-python=>1.9.1`. #967, #968
 
 ## [0.5.2] (April 22, 2024)

--- a/docs/src/misc/mixin.md
+++ b/docs/src/misc/mixin.md
@@ -78,7 +78,7 @@ Some caveats to this function:
 3. It's hard to determine the attributes in a mixed dictionary/string
     restriction. If you are having trouble, try using a pure string
     restriction.
-4. The most direct path to your restriction may not be the your data took,
+4. The most direct path to your restriction may not be the path your data took,
     especially when using Merge Tables. When the result is empty see the
     warning about the path used. Then, ban tables from the search to force a
     different path.

--- a/docs/src/misc/mixin.md
+++ b/docs/src/misc/mixin.md
@@ -59,37 +59,39 @@ key and `>>` as a shorthand for `restrict_by` a downstream key.
 ```python
 from spyglass.example import AnyTable
 
-AnyTable >> 'downsteam_attribute="value"'
-AnyTable << 'upstream_attribute="value"'
+AnyTable() << 'upstream_attribute="value"'
+AnyTable() >> 'downsteam_attribute="value"'
 
 # Equivalent to
-AnyTable.restrict_by('upstream_attribute="value"', direction="up")
-AnyTable.restrict_by('downsteam_attribute="value"', direction="down")
+AnyTable().restrict_by('downsteam_attribute="value"', direction="down")
+AnyTable().restrict_by('upstream_attribute="value"', direction="up")
 ```
 
 Some caveats to this function:
 
 1. 'Peripheral' tables, like `IntervalList` and `AnalysisNwbfile` make it hard
     to determine the correct parent/child relationship and have been removed
-    from this search.
+    from this search by default.
 2. This function will raise an error if it attempts to check a table that has
     not been imported into the current namespace. It is best used for exploring
     and debugging, not for production code.
 3. It's hard to determine the attributes in a mixed dictionary/string
     restriction. If you are having trouble, try using a pure string
     restriction.
-4. The most direct path to your restriction may not be the path took, especially
-    when using Merge Tables. When the result is empty see the warning about the
-    path used. Then, ban tables from the search to force a different path.
+4. The most direct path to your restriction may not be the your data took,
+    especially when using Merge Tables. When the result is empty see the
+    warning about the path used. Then, ban tables from the search to force a
+    different path.
 
 ```python
-my_table = MyTable()  # must be instantced
+my_table = MyTable()  # must be instanced
 my_table.ban_search_table(UnwantedTable1)
 my_table.ban_search_table([UnwantedTable2, UnwantedTable3])
 my_table.unban_search_table(UnwantedTable3)
 my_table.see_banned_tables()
 
 my_table << my_restriction
+my_table << upstream_restriction >> downstream_restriction
 ```
 
 When providing a restriction of the parent, use 'up' direction. When providing a

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -82,7 +82,7 @@ class WaveformFeaturesParams(SpyglassMixin, dj.Lookup):
 
 
 @schema
-class UnitWaveformFeaturesSelection(dj.Manual):
+class UnitWaveformFeaturesSelection(SpyglassMixin, dj.Manual):
     definition = """
     -> SpikeSortingOutput.proj(spikesorting_merge_id="merge_id")
     -> WaveformFeaturesParams

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -830,25 +830,7 @@ def delete_downstream_merge(
 ) -> list:
     """Given a table/restriction, id or delete relevant downstream merge entries
 
-    Parameters
-    ----------
-    table: dj.Table
-        DataJoint table or restriction thereof
-    restriction: str
-        Optional restriction to apply before deletion from merge/part
-        tables. If not provided, delete all downstream entries.
-    dry_run: bool
-        Default True. If true, return list of tuples, merge/part tables
-        downstream of table input. Otherwise, delete merge/part table entries.
-    disable_warning: bool
-        Default False. If True, don't warn about restrictions on table object.
-    kwargs: dict
-        Additional keyword arguments for DataJoint delete.
-
-    Returns
-    -------
-    List[Tuple[dj.Table, dj.Table]]
-        Entries in merge/part tables downstream of table input.
+    Passthrough to SpyglassMixin.delete_downstream_merge
     """
     logger.warning(
         "DEPRECATED: This function will be removed in `0.6`. "

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -886,7 +886,7 @@ class SpyglassMixin:
         if return_graph:
             return graph
 
-        ret = graph.leaf_ft[0]
+        ret = self & graph._get_restr(self.full_table_name)
         if len(ret) == len(self) or len(ret) == 0:
             logger.warning(
                 f"Failed to restrict with path: {graph.path_str}\n\t"


### PR DESCRIPTION
# Description

- Adds an edit to permit `Table << a << b`, by restricting self instead of returning free table
- Makes edits to docs to reflect instancing usage

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a If table edits, I have included an `alter` snippet for release notes.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] Yes I have added/edited docs/notebooks to reflect the changes
