### PR TITLE
Fix test fails related to #957

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Create class `SpyglassGroupPart` to aid delete propagations #899
 - Fix bug report template #955
-- Add rollback option to `populate_all_common` #957, #9XX
+- Add rollback option to `populate_all_common` #957, #971
 - Add long-distance restrictions via `<<` and `>>` operators. #943, #969
 - Fix relative pathing for `mkdocstring-python=>1.9.1`. #967, #968
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Create class `SpyglassGroupPart` to aid delete propagations #899
 - Fix bug report template #955
-- Add rollback option to `populate_all_common` #957
+- Add rollback option to `populate_all_common` #957, #9XX
 - Add long-distance restrictions via `<<` and `>>` operators. #943, #969
 - Fix relative pathing for `mkdocstring-python=>1.9.1`. #967, #968
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1,7 +1,7 @@
 import pathlib
 import re
 from functools import reduce
-from typing import Dict
+from typing import Dict, List, Union
 
 import datajoint as dj
 import ndx_franklab_novela
@@ -43,7 +43,7 @@ class PositionSource(SpyglassMixin, dj.Manual):
         name=null: varchar(32)       # name of spatial series
         """
 
-    def _no_transaction_make(self, keys=None):
+    def _no_transaction_make(self, keys: Union[List[Dict], dj.Table]):
         """Insert position source data from NWB file."""
         if not isinstance(keys, list):
             keys = [keys]
@@ -53,8 +53,7 @@ class PositionSource(SpyglassMixin, dj.Manual):
             nwb_file_name = key.get("nwb_file_name")
             if not nwb_file_name:
                 raise ValueError(
-                    "PositionSource.populate is an alias for a non-computed table "
-                    + "and must be passed a key with nwb_file_name"
+                    "PositionSource._no_transaction_make requires nwb_file_name"
                 )
             self.insert_from_nwbfile(nwb_file_name, skip_duplicates=True)
 
@@ -106,7 +105,7 @@ class PositionSource(SpyglassMixin, dj.Manual):
                     )
                 )
 
-        with cls.connection.transaction:
+        with cls._safe_context():
             IntervalList.insert(intervals, skip_duplicates=skip_duplicates)
             cls.insert(sources, skip_duplicates=skip_duplicates)
             cls.SpatialSeries.insert(
@@ -433,7 +432,9 @@ class VideoFile(SpyglassMixin, dj.Imported):
                             + "in CameraDevice table."
                         )
                     key["video_file_object_id"] = video_obj.object_id
-                    self.insert1(key)
+                    self.insert1(
+                        key, skip_duplicates=True, allow_direct_insert=True
+                    )
                     is_found = True
 
         if not is_found and verbose:
@@ -567,7 +568,7 @@ class PositionIntervalMap(SpyglassMixin, dj.Computed):
 
         # Insert into table
         key["position_interval_name"] = matching_pos_intervals[0]
-        self.insert1(key, allow_direct_insert=True)
+        self.insert1(key, skip_duplicates=True, allow_direct_insert=True)
         logger.info(
             "Populated PosIntervalMap for "
             + f'{nwb_file_name}, {key["interval_list_name"]}'
@@ -660,9 +661,10 @@ def populate_position_interval_map_session(nwb_file_name: str):
     for interval_name in (TaskEpoch & {"nwb_file_name": nwb_file_name}).fetch(
         "interval_list_name"
     ):
-        PositionIntervalMap.populate(
-            {
-                "nwb_file_name": nwb_file_name,
-                "interval_list_name": interval_name,
-            }
-        )
+        with PositionIntervalMap._safe_context():
+            PositionIntervalMap().make(
+                {
+                    "nwb_file_name": nwb_file_name,
+                    "interval_list_name": interval_name,
+                }
+            )

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -43,7 +43,14 @@ class PositionSource(SpyglassMixin, dj.Manual):
         name=null: varchar(32)       # name of spatial series
         """
 
-    def _no_transaction_make(self, keys: Union[List[Dict], dj.Table]):
+    def populate(self, *args, **kwargs):
+        logger.warning(
+            "PositionSource is a manual table with a custom `make`."
+            + " Use `make` instead."
+        )
+        self.make(*args, **kwargs)
+
+    def make(self, keys: Union[List[Dict], dj.Table]):
         """Insert position source data from NWB file."""
         if not isinstance(keys, list):
             keys = [keys]
@@ -52,9 +59,7 @@ class PositionSource(SpyglassMixin, dj.Manual):
         for key in keys:
             nwb_file_name = key.get("nwb_file_name")
             if not nwb_file_name:
-                raise ValueError(
-                    "PositionSource._no_transaction_make requires nwb_file_name"
-                )
+                raise ValueError("PositionSource.make requires nwb_file_name")
             self.insert_from_nwbfile(nwb_file_name, skip_duplicates=True)
 
     @classmethod
@@ -222,9 +227,6 @@ class RawPosition(SpyglassMixin, dj.Imported):
             return column_names
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""
@@ -295,9 +297,6 @@ class StateScriptFile(SpyglassMixin, dj.Imported):
     _nwb_table = Nwbfile
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""

--- a/src/spyglass/common/common_dio.py
+++ b/src/spyglass/common/common_dio.py
@@ -27,9 +27,6 @@ class DIOEvents(SpyglassMixin, dj.Imported):
     _nwb_table = Nwbfile
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -190,8 +190,8 @@ class Electrode(SpyglassMixin, dj.Imported):
                     key.update(electrode_config_dicts[elect_id])
             electrode_inserts.append(key.copy())
 
-        self.insert1(
-            key,
+        self.insert(
+            electrode_inserts,
             skip_duplicates=True,
             allow_direct_insert=True,  # for no_transaction, pop_all_common
         )

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -45,9 +45,6 @@ class ElectrodeGroup(SpyglassMixin, dj.Imported):
     """
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""
@@ -101,9 +98,6 @@ class Electrode(SpyglassMixin, dj.Imported):
     """
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""
@@ -276,9 +270,6 @@ class Raw(SpyglassMixin, dj.Imported):
     _nwb_table = Nwbfile
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""
@@ -376,9 +367,6 @@ class SampleCount(SpyglassMixin, dj.Imported):
     _nwb_table = Nwbfile
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -52,9 +52,6 @@ class Session(SpyglassMixin, dj.Imported):
         """
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -97,12 +97,6 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
      """
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
-        """Make without transaction
-
-        Allows populate_all_common to work within a single transaction."""
         nwb_file_name = key["nwb_file_name"]
         nwb_file_abspath = Nwbfile().get_abs_path(nwb_file_name)
         nwbf = get_nwb_file(nwb_file_abspath)

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -60,7 +60,7 @@ def single_transaction_make(
     raise_err: bool = False,
     error_constants: dict = None,
 ):
-    """For each table, run the `_no_transaction_make` method.
+    """For each table, run the `make` method directly instead of `populate`.
 
     Requires `allow_direct_insert` set to True within each method. Uses
     nwb_file_name search table key_source for relevant key. Currently assumes
@@ -81,7 +81,7 @@ def single_transaction_make(
 
             for pop_key in (key_source & file_restr).fetch("KEY"):
                 try:
-                    table()._no_transaction_make(pop_key)
+                    table().make(pop_key)
                 except Exception as err:
                     if raise_err:
                         raise err

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -78,16 +78,16 @@ def single_transaction_make(
                 key_source = parents[0].proj()
                 for parent in parents[1:]:
                     key_source *= parent.proj()
-            pop_key = (key_source & file_restr).fetch1("KEY")
 
-            try:
-                table()._no_transaction_make(pop_key)
-            except Exception as err:
-                if raise_err:
-                    raise err
-                log_insert_error(
-                    table=table, err=err, error_constants=error_constants
-                )
+            for pop_key in (key_source & file_restr).fetch("KEY"):
+                try:
+                    table()._no_transaction_make(pop_key)
+                except Exception as err:
+                    if raise_err:
+                        raise err
+                    log_insert_error(
+                        table=table, err=err, error_constants=error_constants
+                    )
 
 
 def populate_all_common(
@@ -123,7 +123,6 @@ def populate_all_common(
         [  # Tables that can be inserted in a single transaction
             Session,
             ElectrodeGroup,  # Depends on Session
-            Electrode,  # Depends on ElectrodeGroup
             Raw,  # Depends on Session
             SampleCount,  # Depends on Session
             DIOEvents,  # Depends on Session
@@ -133,6 +132,7 @@ def populate_all_common(
             # SensorData, # Not used by default. Generates large files
         ],
         [  # Tables that depend on above transaction
+            Electrode,  # Depends on ElectrodeGroup
             PositionSource,  # Depends on Session
             VideoFile,  # Depends on TaskEpoch
             StateScriptFile,  # Depends on TaskEpoch

--- a/src/spyglass/spikesorting/imported.py
+++ b/src/spyglass/spikesorting/imported.py
@@ -37,7 +37,6 @@ class ImportedSpikeSorting(SpyglassMixin, dj.Imported):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""
-        raise RuntimeError("TEMP: This is a test error. Please ignore.")
         orig_key = copy.deepcopy(key)
 
         nwb_file_abs_path = Nwbfile.get_abs_path(key["nwb_file_name"])

--- a/src/spyglass/spikesorting/imported.py
+++ b/src/spyglass/spikesorting/imported.py
@@ -31,9 +31,6 @@ class ImportedSpikeSorting(SpyglassMixin, dj.Imported):
         """
 
     def make(self, key):
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -1,4 +1,3 @@
-from contextlib import nullcontext
 from inspect import getmodule
 from itertools import chain as iter_chain
 from pprint import pprint
@@ -368,15 +367,6 @@ class Merge(dj.Manual):
             super().insert(cls(), master_entries, **kwargs)
             for part, part_entries in parts_entries.items():
                 part.insert(part_entries, **kwargs)
-
-    @classmethod
-    def _safe_context(cls):
-        """Return transaction if not already in one."""
-        return (
-            cls.connection.transaction
-            if not cls.connection.in_transaction
-            else nullcontext()
-        )
 
     @classmethod
     def _ensure_dependencies_loaded(cls) -> None:

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -1,6 +1,7 @@
 from atexit import register as exit_register
 from atexit import unregister as exit_unregister
 from collections import OrderedDict
+from contextlib import nullcontext
 from functools import cached_property
 from inspect import stack as inspect_stack
 from os import environ
@@ -120,6 +121,15 @@ class SpyglassMixin:
             logger.error(f"No file-like field found in {self.full_table_name}")
             return
         return self & f"{attr} LIKE '%{name}%'"
+
+    @classmethod
+    def _safe_context(cls):
+        """Return transaction if not already in one."""
+        return (
+            cls.connection.transaction
+            if not cls.connection.in_transaction
+            else nullcontext()
+        )
 
     # ------------------------------- fetch_nwb -------------------------------
 

--- a/tests/common/test_behav.py
+++ b/tests/common/test_behav.py
@@ -22,15 +22,15 @@ def test_valid_epoch_num(common):
     assert epoch_num == 1, "PositionSource get_epoch_num failed"
 
 
-def test_invalid_populate(common):
+def test_possource_make(common):
+    """Test custom populate"""
+    common.PositionSource()._no_transaction_make(common.Session())
+
+
+def test_possource_make_invalid(common):
     """Test invalid populate"""
     with pytest.raises(ValueError):
-        common.PositionSource.populate(dict())
-
-
-def test_custom_populate(common):
-    """Test custom populate"""
-    common.PositionSource.populate(common.Session())
+        common.PositionSource()._no_transaction_make(dict())
 
 
 def test_raw_position_fetchnwb(common, mini_pos, mini_pos_interval_dict):

--- a/tests/common/test_behav.py
+++ b/tests/common/test_behav.py
@@ -24,13 +24,13 @@ def test_valid_epoch_num(common):
 
 def test_possource_make(common):
     """Test custom populate"""
-    common.PositionSource()._no_transaction_make(common.Session())
+    common.PositionSource().make(common.Session())
 
 
 def test_possource_make_invalid(common):
     """Test invalid populate"""
     with pytest.raises(ValueError):
-        common.PositionSource()._no_transaction_make(dict())
+        common.PositionSource().make(dict())
 
 
 def test_raw_position_fetchnwb(common, mini_pos, mini_pos_interval_dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,7 +316,7 @@ def mini_insert(
     if len(Nwbfile()) != 0:
         dj_logger.warning("Skipping insert, use existing data.")
     else:
-        insert_sessions(mini_path.name)
+        insert_sessions(mini_path.name, raise_err=True)
 
     if len(Session()) == 0:
         raise ValueError("No sessions inserted.")

--- a/tests/position/test_trodes.py
+++ b/tests/position/test_trodes.py
@@ -59,8 +59,3 @@ def test_fetch_df(trodes_pos_v1, trodes_params):
     )
     hash_exp = "5296e74dea2e5e68d39f81bc81723a12"
     assert hash_df == hash_exp, "Dataframe differs from expected"
-
-
-def test_null_video(sgp):
-    """Note: This will change if video is added to the test data."""
-    sgp.v1.TrodesPosVideo().populate()  # no longer raises error

--- a/tests/position/test_trodes.py
+++ b/tests/position/test_trodes.py
@@ -63,5 +63,4 @@ def test_fetch_df(trodes_pos_v1, trodes_params):
 
 def test_null_video(sgp):
     """Note: This will change if video is added to the test data."""
-    with pytest.raises(FileNotFoundError):
-        sgp.v1.TrodesPosVideo().populate()
+    sgp.v1.TrodesPosVideo().populate()  # no longer raises error


### PR DESCRIPTION
# Description

- A subset of tests were failing due to partial import from #957 
- These fails have been fixed by removing the previous PR's assumption of 1:1 relationships between populated and parent table
- This PR also removes `_no_transaction_make` for bare `make`, which is less explicit, but allows easier expansion of `populate_all_common` in the future

# Checklist:

- [x] NO. This PR should be accompanied by a release: (yes/no/unsure)
- [x] N/A If release, I have updated the `CITATION.cff`
- [x] NO. This PR makes edits to table definitions: (yes/no)
- [x] N/A If table edits, I have included an `alter` snippet for release notes.
- [x] YES I have updated the `CHANGELOG.md` with PR number and description.
- [x] N/A I have added/edited docs/notebooks to reflect the changes
