### PR TITLE
Fix name parsing

### DIFF
--- a/src/spyglass/common/common_lab.py
+++ b/src/spyglass/common/common_lab.py
@@ -290,7 +290,14 @@ def decompose_name(full_name: str) -> tuple:
 
     parts = full_trimmed.split(delim)
 
-    if delim is None or len(parts) != 2:  # catch unsupported format
+    # the name is separated by a comma ({last, first})
+    if delim == ", ":
+        last, first = parts
+    # the name is separated by a space ({first last}) with no space within either first or last
+    elif delim == " ":
+        first, last = parts
+    # the name is not separated by a comma or a space OR the name is separated by a space but has additional spaces within either first or last
+    elif delim is None or len(parts) != 2:
         raise ValueError(
             f"Name has unsupported format for {full_name}. \n\t"
             + "Must use exactly one comma+space (i.e., ', ') or space.\n\t"
@@ -299,7 +306,6 @@ def decompose_name(full_name: str) -> tuple:
             + "if name(s) includes spaces."
         )
 
-    first, last = parts if delim == " " else parts[::-1]
     full = f"{first} {last}"
 
     return full, first, last


### PR DESCRIPTION
# Description

My name is not parsed correctly when it is given by the NWB file as `Lee, Kyu Hyun` because there is a space within my first name. This change tells the code to use whatever is on the left of `, ` as the last name and whatever is on the right as the first name, regardless of the presence of space within the first or the last name. 

# Checklist:


- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] If release, I have updated the `CITATION.cff`
- [ ] This PR makes edits to table definitions: (yes/no)
- [ ] If table edits, I have included an `alter` snippet for release notes.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] I have added/edited docs/notebooks to reflect the changes
