### PR TITLE
Replace old `join` call with `cascade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@
 - Add rollback option to `populate_all_common` #957, #971
 - Add long-distance restrictions via `<<` and `>>` operators. #943, #969
 - Fix relative pathing for `mkdocstring-python=>1.9.1`. #967, #968
+- Clean up old `TableChain.join` call in mixin delete. #982
 
 ### Pipelines
 
 - DLC
-   - Allow dlc without pre-existing tracking data #973, #975
+    - Allow dlc without pre-existing tracking data #973, #975
 
 ## [0.5.2] (April 22, 2024)
 

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -476,7 +476,7 @@ class SpyglassMixin:
         format = dj.U(self._session_pk, self._member_pk)
 
         restr = self.restriction or True
-        sess_link = self._session_connection.join(restr, reverse_order=True)
+        sess_link = self._session_connection.cascade(restr, direction="up")
 
         exp_missing = format & (sess_link - SesExp).proj(**empty_pk)
         exp_present = format & (sess_link * SesExp - exp_missing).proj()


### PR DESCRIPTION
# Description

#949 replaced `TableChain.join` with `cascade` to align with other `dj_graph` classes. This PR fixes a holdover instaces within `cautious_delete`

# Checklist:

- [X] NO This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/A If release, I have updated the `CITATION.cff`
- [X] NO This PR makes edits to table definitions: (yes/no)
- [X] N/A If table edits, I have included an `alter` snippet for release notes.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/A I have added/edited docs/notebooks to reflect the changes
