### PR TITLE
Check existence of optional fields during `Electrode` table population

### DIFF
--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -88,7 +88,7 @@ class Electrode(SpyglassMixin, dj.Imported):
     x = NULL: float                         # the x coordinate of the electrode position in the brain
     y = NULL: float                         # the y coordinate of the electrode position in the brain
     z = NULL: float                         # the z coordinate of the electrode position in the brain
-    filtering: varchar(2000)                # description of the signal filtering
+    filtering: = "unfiltered": varchar(2000)      # description of the signal filtering
     impedance = NULL: float                 # electrode impedance
     bad_channel = "False": enum("True", "False")  # if electrode is "good" or "bad" as observed during recording
     x_warped = NULL: float                  # x coordinate of electrode position warped to common template brain

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -101,6 +101,8 @@ class Electrode(SpyglassMixin, dj.Imported):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""
+
+
         nwb_file_name = key["nwb_file_name"]
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         nwbf = get_nwb_file(nwb_file_abspath)
@@ -113,6 +115,9 @@ class Electrode(SpyglassMixin, dj.Imported):
             }
         else:
             electrode_config_dicts = dict()
+
+        # properties that are optional when creating NWB file but not part of trodes_to_nwb
+        optional_fields = ['x', 'y', 'z', 'filtering', 'impedance']
 
         electrode_constants = {
             "x_warped": 0,
@@ -132,14 +137,13 @@ class Electrode(SpyglassMixin, dj.Imported):
                     "region_id": BrainRegion.fetch_add(
                         region_name=elect_data.group.location
                     ),
-                    "x": elect_data.x,
-                    "y": elect_data.y,
-                    "z": elect_data.z,
-                    "filtering": elect_data.filtering,
-                    "impedance": elect_data.get("imp"),
                     **electrode_constants,
                 }
             )
+
+            for f in optional_fields:
+                if f in elect_data:
+                    key.update({f: elect_data.get(f)})
 
             # rough check of whether the electrodes table was created by
             # rec_to_nwb and has the appropriate custom columns used by

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -102,7 +102,6 @@ class Electrode(SpyglassMixin, dj.Imported):
 
         Allows populate_all_common to work within a single transaction."""
 
-
         nwb_file_name = key["nwb_file_name"]
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         nwbf = get_nwb_file(nwb_file_abspath)
@@ -117,7 +116,7 @@ class Electrode(SpyglassMixin, dj.Imported):
             electrode_config_dicts = dict()
 
         # properties that are optional when creating NWB file but not part of trodes_to_nwb
-        optional_fields = ['x', 'y', 'z', 'filtering', 'impedance']
+        optional_fields = ["x", "y", "z", "filtering", "impedance"]
 
         electrode_constants = {
             "x_warped": 0,

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -88,7 +88,7 @@ class Electrode(SpyglassMixin, dj.Imported):
     x = NULL: float                         # the x coordinate of the electrode position in the brain
     y = NULL: float                         # the y coordinate of the electrode position in the brain
     z = NULL: float                         # the z coordinate of the electrode position in the brain
-    filtering: = "unfiltered": varchar(2000)      # description of the signal filtering
+    filtering: varchar(2000)                # description of the signal filtering
     impedance = NULL: float                 # electrode impedance
     bad_channel = "False": enum("True", "False")  # if electrode is "good" or "bad" as observed during recording
     x_warped = NULL: float                  # x coordinate of electrode position warped to common template brain
@@ -115,9 +115,6 @@ class Electrode(SpyglassMixin, dj.Imported):
         else:
             electrode_config_dicts = dict()
 
-        # properties that are optional when creating NWB file but not part of trodes_to_nwb
-        optional_fields = ["x", "y", "z", "filtering", "impedance"]
-
         electrode_constants = {
             "x_warped": 0,
             "y_warped": 0,
@@ -136,13 +133,14 @@ class Electrode(SpyglassMixin, dj.Imported):
                     "region_id": BrainRegion.fetch_add(
                         region_name=elect_data.group.location
                     ),
+                    "x": elect_data.get("x"),
+                    "y": elect_data.get("y"),
+                    "z": elect_data.get("z"),
+                    "filtering": elect_data.get("filtering", "unfiltered"),
+                    "impedance": elect_data.get("imp"),
                     **electrode_constants,
                 }
             )
-
-            for f in optional_fields:
-                if f in elect_data:
-                    key.update({f: elect_data.get(f)})
 
             # rough check of whether the electrodes table was created by
             # rec_to_nwb and has the appropriate custom columns used by


### PR DESCRIPTION
# Description

The only required fields for `nwbfile.add_electrode` are location and electrode group (https://pynwb.readthedocs.io/en/stable/pynwb.file.html#pynwb.file.NWBFile.add_electrode). Therefore some NWB files may not other fields such as `filtering`. Spyglass should check if these exist before trying to populate them; otherwise they should get the default value (e.g. `NULL`)

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] If release, I have updated the `CITATION.cff`
- [ ] This PR makes edits to table definitions: (yes/no)
- [ ] If table edits, I have included an `alter` snippet for release notes.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] I have added/edited docs/notebooks to reflect the changes
