### PR TITLE
Add ability to set smoothing sigma in get_firing_rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
     - `DLCPosVideo` table now inserts into self after `make` #966
 - Common
     - Don't insert lab member when creating lab team #983
+- Spikesorting
+    - Allow user to set smoothing timescale in `SortedSpikesGroup.get_firing_rate` #994
 
 ## [0.5.2] (April 22, 2024)
 

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -189,7 +189,11 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
 
     @classmethod
     def get_firing_rate(
-        cls, key: dict, time: np.ndarray, multiunit: bool = False
+        cls,
+        key: dict,
+        time: np.ndarray,
+        multiunit: bool = False,
+        smoothing_sigma: float = 0.015,
     ) -> np.ndarray:
         spike_indicator = cls.get_spike_indicator(key, time)
         if spike_indicator.ndim == 1:
@@ -202,7 +206,9 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
         return np.stack(
             [
                 get_multiunit_population_firing_rate(
-                    indicator[:, np.newaxis], sampling_frequency
+                    indicator[:, np.newaxis],
+                    sampling_frequency,
+                    smoothing_sigma,
                 )
                 for indicator in spike_indicator.T
             ],


### PR DESCRIPTION
# Description

Small utility change.
- Currently `SortedSpikesGroup.get_firing_rate()` results in a default smoothing of the firing rate with a gaussian filter with 15ms sigma.
-  This PR adds argument `smoothing_sigma` to the function to allow user to choose different scale.
- No change to default functionality

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] This PR should be accompanied by a release: no
- [X] N/A If release, I have updated the `CITATION.cff`
- [X] This PR makes edits to table definitions: no
- [X] N/A If table edits, I have included an `alter` snippet for release notes.
- [X] N/A If this PR makes changes to positon, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/A I have added/edited docs/notebooks to reflect the changes
