### PR TITLE
Non-daemon parallel populate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add pytests for position pipeline, various `test_mode` exceptions #966
 - Migrate `pip` dependencies from `environment.yml`s to `pyproject.toml` #966
 - Add documentation for common error messages #997
+- Allow mixin tables with parallelization in `make` to run populate with `processes > 1` #1001
 
 ### Pipelines
 

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -102,10 +102,7 @@ class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
     object_id: varchar(40) # the NWB object that stores the waveforms
     """
 
-    @property
-    def parallel_make(self):
-        """Indicate table is parallelized in make function"""
-        return True
+    _parallel_make = True
 
     def make(self, key):
         AnalysisNwbfile()._creation_times["pre_create_time"] = time()

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -104,7 +104,7 @@ class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
 
     @property
     def parallel_make(self):
-        """If table is parallelized in make function, overide this function with True."""
+        """Indicate table is parallelized in make function"""
         return True
 
     def make(self, key):

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -102,6 +102,11 @@ class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
     object_id: varchar(40) # the NWB object that stores the waveforms
     """
 
+    @property
+    def parallel_make(self):
+        """If table is parallelized in make function, overide this function with True."""
+        return True
+
     def make(self, key):
         AnalysisNwbfile()._creation_times["pre_create_time"] = time()
         # get the list of feature parameters

--- a/src/spyglass/spikesorting/v0/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_recording.py
@@ -381,6 +381,8 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
     -> IntervalList.proj(sort_interval_list_name='interval_list_name')
     """
 
+    _parallel_make = True
+
     def make(self, key):
         sort_interval_valid_times = self._get_sort_interval_valid_times(key)
         recording = self._get_filtered_recording(key)

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -216,6 +216,8 @@ class SpikeSortingRecordingSelection(SpyglassMixin, dj.Manual):
     -> LabTeam
     """
 
+    _parallel_make = True
+
     @classmethod
     def insert_selection(cls, key: dict):
         """Insert a row into SpikeSortingRecordingSelection with an

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -488,6 +488,10 @@ class NonDaemonPool(multiprocessing.pool.Pool):
     which are required for parallel populate operations in DataJoint.
     """
 
+    # Explicitly set the start method to 'fork'
+    # Allows the pool to be used in MacOS, where the default start method is 'spawn'
+    multiprocessing.set_start_method("fork", force=True)
+
     def Process(self, *args, **kwds):
         proc = super(NonDaemonPool, self).Process(*args, **kwds)
 

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -1,6 +1,7 @@
 """Helper functions for manipulating information from DataJoint fetch calls."""
 
 import inspect
+import multiprocessing.pool
 import os
 from pathlib import Path
 from typing import List, Type, Union

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -467,6 +467,7 @@ def make_file_obj_id_unique(nwb_path: str):
     _resolve_external_table(nwb_path, nwb_path.split("/")[-1])
     return new_id
 
+
 def populate_pass_function(value):
     """Pass function for parallel populate.
 
@@ -476,20 +477,23 @@ def populate_pass_function(value):
     Parameters
     ----------
     value : (table, key, kwargs)
-       Class of table to populate, key to populate, and kwargs fro populate
+       Class of table to populate, key to populate, and kwargs for populate
     """
     table, key, kwargs = value
     return table.populate(key, **kwargs)
+
 
 class NonDaemonPool(multiprocessing.pool.Pool):
     """NonDaemonPool. Used to create a pool of non-daemonized processes,
     which are required for parallel populate operations in DataJoint.
     """
+
     def Process(self, *args, **kwds):
         proc = super(NonDaemonPool, self).Process(*args, **kwds)
 
         class NonDaemonProcess(proc.__class__):
             """Monkey-patch process to ensure it is never daemonized"""
+
             @property
             def daemon(self):
                 return False

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -78,6 +78,7 @@ class SpyglassMixin:
     _member_pk = None  # LabMember primary key. Mixin ambivalent table structure
 
     _banned_search_tables = set()  # Tables to avoid in restrict_by
+    _parallel_make = False  # Tables that use parallel processing in make
 
     def __init__(self, *args, **kwargs):
         """Initialize SpyglassMixin.
@@ -136,8 +137,6 @@ class SpyglassMixin:
             if not cls.connection.in_transaction
             else nullcontext()
         )
-
-    _parallel_make = False
 
     # ------------------------------- fetch_nwb -------------------------------
 

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -20,7 +20,12 @@ from networkx import NetworkXError
 from pymysql.err import DataError
 
 from spyglass.utils.database_settings import SHARED_MODULES
-from spyglass.utils.dj_helper_fn import fetch_nwb, get_nwb_table, populate_pass_function, NonDaemonPool
+from spyglass.utils.dj_helper_fn import (
+    fetch_nwb,
+    get_nwb_table,
+    populate_pass_function,
+    NonDaemonPool,
+)
 from spyglass.utils.dj_merge_tables import RESERVED_PRIMARY_KEY as MERGE_PK
 from spyglass.utils.dj_merge_tables import Merge, is_merge_table
 from spyglass.utils.logging import logger
@@ -134,7 +139,7 @@ class SpyglassMixin:
 
     @property
     def parallel_make(self):
-        """If table is parallelized in make function, overide this function with True."""
+        """If table is parallelized in make function, override this function with True."""
         return False
 
     # ------------------------------- fetch_nwb -------------------------------
@@ -158,7 +163,9 @@ class SpyglassMixin:
         resolved = getattr(self, "_nwb_table", None) or (
             AnalysisNwbfile
             if "-> AnalysisNwbfile" in self.definition
-            else Nwbfile if "-> Nwbfile" in self.definition else None
+            else Nwbfile
+            if "-> Nwbfile" in self.definition
+            else None
         )
 
         if not resolved:
@@ -665,7 +672,7 @@ class SpyglassMixin:
     def populate(self, *restrictions, **kwargs):
         """Populate table in parallel.
 
-        Superceeds datajoint.table.Table.populate for classes with that
+        Supersedes datajoint.table.Table.populate for classes with that
         spawn processes in their make function
         """
 


### PR DESCRIPTION
# Description

Changes to allow populate with `processes > 1` for tables that use parallel processing within their make function

Resolves #1000 
- Adds the property `parallel_make` to the mixin class
    - By default = False
    - Overwrite for in classes which spawn parallel processes within their `make` function
- Intercept populate calls in the `SpyglassMixin` class
    - If multiple populate processes and  `parallel_make = True`
    - Create non-daemonic pool of processes, each of which call `super().populate` for a single entry


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] This PR should be accompanied by a release: no
- [X] N/A If release, I have updated the `CITATION.cff`
- [X] This PR makes edits to table definitions: no
- [X] N/A  If table edits, I have included an `alter` snippet for release notes.
- [X] N/A If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/A I have added/edited docs/notebooks to reflect the changes

ToDo:
- [ ] Identify other tables that use parallel processing in their make function and overwrite their `parallel_make` property

