### PR TITLE
Fix bug in change in analysis_file object_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Common
     - `PositionVideo` table now inserts into self after `make` #966
-    - Files created by `AnalysisNwbfile.create()` receive new object_id #999
+    - Files created by `AnalysisNwbfile.create()` receive new object_id #999, #1004
 - Decoding: Default values for classes on `ImportError` #966
 - DLC
     - Allow dlc without pre-existing tracking data #973, #975

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -225,7 +225,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             self._alter_spyglass_version(analysis_file_abs_path)
 
         # create a new object id for the file
-        with h5py.File(nwb_file_abspath, "a") as f:
+        with h5py.File(analysis_file_abs_path, "a") as f:
             f.attrs["object_id"] = str(uuid4())
 
         # change the permissions to only allow owner to write


### PR DESCRIPTION
# Description

#999 introduced an error to `AnalysisNwbfile.create()` by attempting to alter the object id of the incorrect file.  This fix corrects the alteration to be of the newly created analysis nwb file.

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] no This PR should be accompanied by a release: (yes/no/unsure)
- [X] n/a If release, I have updated the `CITATION.cff`
- [X] no This PR makes edits to table definitions: (yes/no)
- [X] n/a If table edits, I have included an `alter` snippet for release notes.
- [X] yes If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] n/a I have added/edited docs/notebooks to reflect the changes
