### PR TITLE
Fix artifact `list_triggers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
         #994
     - Update docstrings #996
     - Remove unused `UnitInclusionParameters` table from `spikesorting.v0` #1003
+    - Fix bug in identification of artifact samples to be zeroed out in `spikesorting.v1.SpikeSorting` #1009
+
 
 ## [0.5.2] (April 22, 2024)
 

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -212,8 +212,8 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
             if artifact_removed_intervals_ind[-1][1] < len(timestamps):
                 list_triggers.append(
                     np.arange(
-                            artifact_removed_intervals_ind[-1][1],
-                            len(timestamps) - 1,
+                        artifact_removed_intervals_ind[-1][1],
+                        len(timestamps) - 1,
                     )
                 )
 

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -171,15 +171,15 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
         sorter, sorter_params = (
             SpikeSorterParameters * SpikeSortingSelection & key
         ).fetch1("sorter", "sorter_params")
+        recording_analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(
+            recording_key["analysis_file_name"]
+        )
 
         # DO:
         # - load recording
         # - concatenate artifact removed intervals
         # - run spike sorting
         # - save output to NWB file
-        recording_analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(
-            recording_key["analysis_file_name"]
-        )
         recording = se.read_nwb_recording(
             recording_analysis_nwb_file_abs_path, load_time_vector=True
         )
@@ -200,7 +200,7 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
             list_triggers = []
             if artifact_removed_intervals_ind[0][0] > 0:
                 list_triggers.append(
-                    np.array([0, artifact_removed_intervals_ind[0][0]])
+                    np.arange(0, artifact_removed_intervals_ind[0][0])
                 )
             for interval_ind in range(len(artifact_removed_intervals_ind) - 1):
                 list_triggers.append(
@@ -211,11 +211,9 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
                 )
             if artifact_removed_intervals_ind[-1][1] < len(timestamps):
                 list_triggers.append(
-                    np.array(
-                        [
+                    np.arange(
                             artifact_removed_intervals_ind[-1][1],
                             len(timestamps) - 1,
-                        ]
                     )
                 )
 


### PR DESCRIPTION
# Description

This fixes a bug in artifact masking step in the spike sorting pipeline. The artifact masking function expects to get as input the index of every sample to be zeroed, but the code was providing an interval of the indices instead for the artifacts that take place before the first artifact-free interval or after the last artifact-free interval.

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] If release, I have updated the `CITATION.cff`
- [ ] This PR makes edits to table definitions: (yes/no)
- [ ] If table edits, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] I have added/edited docs/notebooks to reflect the changes
