### PR TITLE
remove problem key in DLCPosV1 fetch_nwb attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,13 @@
     - Raise `KeyError` for missing input parameters across helper funcs #966
     - `DLCPosVideo` table now inserts into self after `make` #966
     - Remove unused `PositionVideoSelection` and `PositionVideo` tables #1003
+    - Fix SQL query error in `DLCPosV1.fetch_nwb` #1011
 - Spikesorting
     - Allow user to set smoothing timescale in `SortedSpikesGroup.get_firing_rate`
         #994
     - Update docstrings #996
     - Remove unused `UnitInclusionParameters` table from `spikesorting.v0` #1003
     - Fix bug in identification of artifact samples to be zeroed out in `spikesorting.v1.SpikeSorting` #1009
-
 
 ## [0.5.2] (April 22, 2024)
 

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -180,6 +180,10 @@ class DLCPosV1(SpyglassMixin, dj.Computed):
             index=index,
         )
 
+    def fetch_nwb(self, **kwargs):
+        attrs = [a for a in self.heading.names if not a == "pose_eval_result"]
+        return super().fetch_nwb(*attrs, **kwargs)
+
     @classmethod
     def evaluate_pose_estimation(cls, key):
         likelihood_thresh = []


### PR DESCRIPTION
# Description

Resolves #1010 
- add class specific method for `DLCPosV1.fetch_nwb()`
- explicitly avoid the `pose_eval_result` from going into `attrs` of `SpyglassMixin.fetch_nwb()`
- this avoids the SQL error


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] no This PR should be accompanied by a release: (yes/no/unsure)
- [X] n/a If release, I have updated the `CITATION.cff`
- [X] no This PR makes edits to table definitions: (yes/no)
- [X] n/a If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] n/a I have added/edited docs/notebooks to reflect the changes
