### PR TITLE
Speed up fetch_nwb 

### DIFF
--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -59,6 +59,8 @@ class Merge(dj.Manual):
     view rather than the master table itself.
     """
 
+    _dependencies_loaded = False
+
     def __init__(self):
         super().__init__()
         self._reserved_pk = RESERVED_PRIMARY_KEY
@@ -374,7 +376,9 @@ class Merge(dj.Manual):
 
         Otherwise parts returns none
         """
-        dj.conn.connection.dependencies.load()
+        if not cls._dependencies_loaded:
+            dj.conn.connection.dependencies.load()
+            cls._dependencies_loaded = True
 
     def insert(self, rows: list, **kwargs):
         """Merges table specific insert, ensuring data exists in part parents.


### PR DESCRIPTION
# Description

I noticed that data accesses through `fetch_nwb` were running slow, particularly with `SortedSpikesGroup.fetch_spike_data()` which has to access multiple nwb files. (for reference, was taking ~30s per epoch to load tertrode spike data)

Profiling with snakeviz found that 60% of the run time was from `Merge.ensure_dependencies_loaded()`
- add a class attribute `Merge._dependencies_loaded` to reduce executions of the cumulatively expensive line `dj.conn.connection.dependencies.load()`
- fraction of time spent on this function drops to .6%

Potential Further speedups:
- Avoid logging file access




# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] no This PR should be accompanied by a release: (yes/no/unsure)
- [X] n/a If release, I have updated the `CITATION.cff`
- [X] no This PR makes edits to table definitions: (yes/no)
- [X] n/a If table edits, I have included an `alter` snippet for release notes.
- [X] n/a If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [X] n/a I have added/edited docs/notebooks to reflect the changes
