### PR TITLE
Merge table efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ PositionGroup.alter()
 - `cautious_delete` now checks `IntervalList` and externals tables. #1002
 - Allow mixin tables with parallelization in `make` to run populate with
     `processes > 1` #1001
+- Speed up fetch_nwb calls through merge tables #1017
 
 ### Pipelines
 

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -150,8 +150,9 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
 
         # get the spike times for each merge_id
         spike_times = []
-        for merge_id in merge_ids:
-            nwb_file = SpikeSortingOutput().fetch_nwb({"merge_id": merge_id})[0]
+        merge_keys = [dict(merge_id=merge_id) for merge_id in merge_ids]
+        nwb_file_list = (SpikeSortingOutput & merge_keys).fetch_nwb()
+        for nwb_file in nwb_file_list:
             nwb_field_name = (
                 "object_id"
                 if "object_id" in nwb_file

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -532,12 +532,12 @@ class Merge(dj.Manual):
         sources = set((self & restriction).fetch(self._reserved_sk))
         nwb_list = []
         for source in sources:
-            restriction_i = (
+            source_restr = (
                 self & {self._reserved_sk: source} & restriction
             ).fetch("KEY")
             nwb_list.extend(
                 self.merge_restrict_class(
-                    restriction_i, permit_multiple_rows=True
+                    source_restr, permit_multiple_rows=True
                 ).fetch_nwb()
             )
         return nwb_list


### PR DESCRIPTION
# Description

Changes to help speed up fetching nwb data through merge tables

- allow `Merge.fetch_nwb` to work with a restriction containing multiple entries and sources
- pre-check dependencies loaded to in `_ensure_dependencies_loaded`
    - Avoid the overhead of the load call
- avoid redundant calls to `merge_get_parent` in `merge_restrict_class`
- refactor to single fetch_nwb call in `SortedSpikesGroup.fetch_spike_data`
    - avoids repeatedly running the merge table restriction process to find source tables

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] no This PR should be accompanied by a release: (yes/no/unsure)
- [X] n/a If release, I have updated the `CITATION.cff`
- [X] no This PR makes edits to table definitions: (yes/no)
- [X] n/a If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] n/a I have added/edited docs/notebooks to reflect the changes
