### PR TITLE
Group integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ PositionGroup.alter()
     `processes > 1` #1001
 - Speed up fetch_nwb calls through merge tables #1017
 - Allow `ModuleNotFoundError` or `ImportError` for optional dependencies #1023
+- Ensure integrity of group tables #1026
 
 ### Pipelines
 

--- a/src/spyglass/decoding/v1/core.py
+++ b/src/spyglass/decoding/v1/core.py
@@ -116,8 +116,10 @@ class PositionGroup(SpyglassMixin, dj.Manual):
             "position_group_name": group_name,
         }
         if self & group_key:
-            raise ValueError(f"Group {nwb_file_name}: {position_group_name} already exists",
-                             "please delete the group before creating a new one")
+            raise ValueError(
+                f"Group {nwb_file_name}: {position_group_name} already exists",
+                "please delete the group before creating a new one",
+            )
         self.insert1(
             {
                 **group_key,

--- a/src/spyglass/decoding/v1/core.py
+++ b/src/spyglass/decoding/v1/core.py
@@ -115,6 +115,9 @@ class PositionGroup(SpyglassMixin, dj.Manual):
             "nwb_file_name": nwb_file_name,
             "position_group_name": group_name,
         }
+        if self & group_key:
+            raise ValueError(f"Group {nwb_file_name}: {position_group_name} already exists",
+                             "please delete the group before creating a new one")
         self.insert1(
             {
                 **group_key,

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -70,8 +70,10 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
             "unit_filter_params_name": unit_filter_params_name,
         }
         if self & group_key:
-            raise ValueError(f"Group {nwb_file_name}: {group_name} already exists",
-                             "please delete the group before creating a new one")
+            raise ValueError(
+                f"Group {nwb_file_name}: {group_name} already exists",
+                "please delete the group before creating a new one",
+            )
 
         parts_insert = [{**key, **group_key} for key in keys]
 
@@ -160,7 +162,9 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
             nwb_field_name = (
                 "object_id"
                 if "object_id" in nwb_file
-                else "units" if "units" in nwb_file else None
+                else "units"
+                if "units" in nwb_file
+                else None
             )
             if nwb_field_name is None:
                 # case where no units found or curation removed all units

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -69,6 +69,10 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
             "nwb_file_name": nwb_file_name,
             "unit_filter_params_name": unit_filter_params_name,
         }
+        if self & group_key:
+            raise ValueError(f"Group {nwb_file_name}: {group_name} already exists",
+                             "please delete the group before creating a new one")
+
         parts_insert = [{**key, **group_key} for key in keys]
 
         self.insert1(

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -162,9 +162,7 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
             nwb_field_name = (
                 "object_id"
                 if "object_id" in nwb_file
-                else "units"
-                if "units" in nwb_file
-                else None
+                else "units" if "units" in nwb_file else None
             )
             if nwb_field_name is None:
                 # case where no units found or curation removed all units

--- a/src/spyglass/spikesorting/v0/spikesorting_populator.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_populator.py
@@ -194,16 +194,16 @@ def spikesorting_pipeline_populator(
         )
         SpikeSortingRecordingSelection.insert1(ssr_key, skip_duplicates=True)
 
-    SpikeSortingRecording.populate(interval_dict)
+    SpikeSortingRecording.populate(sort_dict)
 
     # Artifact detection
     logger.info("Running artifact detection")
     artifact_keys = [
         {**k, "artifact_params_name": artifact_parameters}
-        for k in (SpikeSortingRecordingSelection() & interval_dict).fetch("KEY")
+        for k in (SpikeSortingRecordingSelection() & sort_dict).fetch("KEY")
     ]
     ArtifactDetectionSelection().insert(artifact_keys, skip_duplicates=True)
-    ArtifactDetection.populate(interval_dict)
+    ArtifactDetection.populate(sort_dict)
 
     # Spike sorting
     logger.info("Running spike sorting")

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -73,7 +73,7 @@ class SortGroup(SpyglassMixin, dj.Manual):
             Optional. If True, no sort groups are defined for unitrodes.
         """
         # delete any current groups
-        # (SortGroup & {"nwb_file_name": nwb_file_name}).delete()
+        (SortGroup & {"nwb_file_name": nwb_file_name}).delete()
         # get the electrodes from this NWB file
         electrodes = (
             Electrode()


### PR DESCRIPTION
# Description

- Resolves #1022 
    - Adds checks to the create_group methods for several tables to prevent unintentional insertion of new parts after creation
        - `PositionGroup`
        - `SortedSpikesGroup`
        - `spikesorting.v1.SortGroup`

- minor change to `spikesorting_pipeline_populator` to restrict population to sort interval

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] no This PR should be accompanied by a release: (yes/no/unsure)
- [X] n/a If release, I have updated the `CITATION.cff`
- [X] no This PR makes edits to table definitions: (yes/no)
- [X] n/a If table edits, I have included an `alter` snippet for release notes.
- [X] n/a If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] n/a I have added/edited docs/notebooks to reflect the changes
