### PR TITLE
Reduce duplication 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ PositionGroup.alter()
 - Speed up fetch_nwb calls through merge tables #1017
 - Allow `ModuleNotFoundError` or `ImportError` for optional dependencies #1023
 - Ensure integrity of group tables #1026
+- Merge duplicate functions in decoding and spikesorting #1050
 
 ### Pipelines
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -519,7 +519,7 @@ class PositionIntervalMap(SpyglassMixin, dj.Computed):
         # epoch/pos intervals
 
         if not self.connection.in_transaction:
-            # if not called in the context of a make function, call its own make function
+            # if called w/o transaction, call add via `populate`
             self.populate(key)
             return
         if self & key:

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -505,7 +505,7 @@ class PositionIntervalMap(SpyglassMixin, dj.Computed):
     definition = """
     -> IntervalList
     ---
-    position_interval_name="": varchar(200)  # name of the corresponding interval
+    position_interval_name="": varchar(200)  # corresponding interval name
     """
 
     # #849 - Insert null to avoid rerun
@@ -574,8 +574,9 @@ class PositionIntervalMap(SpyglassMixin, dj.Computed):
         # Check that each pos interval was matched to only one epoch
         if len(matching_pos_intervals) != 1:
             logger.warning(
-                f"{no_pop_msg}. Found {len(matching_pos_intervals)} pos intervals for "
-                + f"\n\t{key}\n\tMatching intervals: {matching_pos_intervals}"
+                f"{no_pop_msg}. Found {len(matching_pos_intervals)} pos "
+                + f"intervals for\n\t{key}\n\t"
+                + f"Matching intervals: {matching_pos_intervals}"
             )
             self.insert1(null_key, **insert_opts)
             return

--- a/src/spyglass/common/common_dandi.py
+++ b/src/spyglass/common/common_dandi.py
@@ -101,7 +101,7 @@ class DandiPath(SpyglassMixin, dj.Manual):
         dandi_api_key : str, optional
             API key for the dandi server. Optional if the environment variable
             DANDI_API_KEY is set.
-        dandi_instance : What instance of Dandi the dandiset is on. Defaults to the dev server
+        dandi_instance : dandiset's Dandi instance. Defaults to the dev server
         """
         key = (Export & key).fetch1("KEY")
         paper_id = (Export & key).fetch1("paper_id")
@@ -118,7 +118,8 @@ class DandiPath(SpyglassMixin, dj.Manual):
         destination_dir = f"{paper_dir}/dandiset_{paper_id}"
         dandiset_dir = f"{paper_dir}/{dandiset_id}"
 
-        # check if pre-existing directories for dandi export exist. Remove if so to continue
+        # check if pre-existing directories for dandi export exist.
+        # Remove if so to continue
         for dandi_dir in destination_dir, dandiset_dir:
             if os.path.exists(dandi_dir):
                 from datajoint.utils import user_choice
@@ -134,7 +135,8 @@ class DandiPath(SpyglassMixin, dj.Manual):
                     shutil.rmtree(dandi_dir)
                     continue
                 raise RuntimeError(
-                    f"Directory must be removed prior to dandi export to ensure dandi-compatability: {dandi_dir}"
+                    "Directory must be removed prior to dandi export to ensure "
+                    + f"dandi-compatability: {dandi_dir}"
                 )
 
         os.makedirs(destination_dir, exist_ok=False)
@@ -196,7 +198,7 @@ def _get_metadata(path):
 def translate_name_to_dandi(folder):
     """Uses dandi.organize to translate filenames to dandi paths
 
-    *Note* The name for a given file is dependent on that of all files in the folder
+    NOTE: The name for a given file depends on all files in the folder
 
     Parameters
     ----------
@@ -232,7 +234,8 @@ def validate_dandiset(
     folder : str
         location of dandiset to be validated
     min_severity : str
-        minimum severity level for errors to be reported, threshold for failed Dandi upload is "ERROR"
+        minimum severity level for errors to be reported, threshold for failed
+        Dandi upload is "ERROR"
     ignore_external_files : bool
         whether to ignore external file errors. Used if validating
         before the organize step

--- a/src/spyglass/common/common_dandi.py
+++ b/src/spyglass/common/common_dandi.py
@@ -75,7 +75,7 @@ class DandiPath(SpyglassMixin, dj.Manual):
         # create a cache to save downloaded data to disk (optional)
         fsspec_file = CachingFileSystem(
             fs=fs,
-            cache_storage=f"{export_dir}/nwb-cache",  # Local folder for the cache
+            cache_storage=f"{export_dir}/nwb-cache",  # Local folder for cache
         )
 
         # Open and return the file
@@ -150,7 +150,10 @@ class DandiPath(SpyglassMixin, dj.Manual):
         validate_dandiset(destination_dir, ignore_external_files=True)
 
         # given dandiset_id, download the dandiset to the export_dir
-        url = f"{known_instances[dandi_instance].gui}/dandiset/{dandiset_id}/draft"
+        url = (
+            f"{known_instances[dandi_instance].gui}"
+            + f"/dandiset/{dandiset_id}/draft"
+        )
         dandi.download.download(url, output_dir=paper_dir)
 
         # organize the files in the dandiset directory

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -607,11 +607,13 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
         """
         # Error checks on parameters
         # electrode_list
+
         query = LFPSelection().LFPElectrode() & {"nwb_file_name": nwb_file_name}
         available_electrodes = query.fetch("electrode_id")
         if not np.all(np.isin(electrode_list, available_electrodes)):
             raise ValueError(
-                "All elements in electrode_list must be valid electrode_ids in the LFPSelection table"
+                "All elements in electrode_list must be valid electrode_ids in "
+                + "the LFPSelection table"
             )
         # sampling rate
         lfp_sampling_rate = (LFP() & {"nwb_file_name": nwb_file_name}).fetch1(
@@ -620,8 +622,8 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
         decimation = lfp_sampling_rate // lfp_band_sampling_rate
         if lfp_sampling_rate // decimation != lfp_band_sampling_rate:
             raise ValueError(
-                f"lfp_band_sampling rate {lfp_band_sampling_rate} is not an integer divisor of lfp "
-                f"sampling rate {lfp_sampling_rate}"
+                f"lfp_band_sampling rate {lfp_band_sampling_rate} is not an "
+                f"integer divisor of lfp sampling rate {lfp_sampling_rate}"
             )
         # filter
         query = FirFilterParameters() & {
@@ -630,7 +632,8 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
         }
         if not query:
             raise ValueError(
-                f"filter {filter_name}, sampling rate {lfp_sampling_rate} is not in the FirFilterParameters table"
+                f"filter {filter_name}, sampling rate {lfp_sampling_rate} is "
+                + "not in the FirFilterParameters table"
             )
         # interval_list
         query = IntervalList() & {
@@ -639,34 +642,36 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
         }
         if not query:
             raise ValueError(
-                f"interval list {interval_list_name} is not in the IntervalList table; the list must be "
-                "added before this function is called"
+                f"interval list {interval_list_name} is not in the IntervalList "
+                + "table; the list must be added before this function is called"
             )
         # reference_electrode_list
         if len(reference_electrode_list) != 1 and len(
             reference_electrode_list
         ) != len(electrode_list):
             raise ValueError(
-                "reference_electrode_list must contain either 1 or len(electrode_list) elements"
+                "reference_electrode_list must contain either 1 or "
+                + "len(electrode_list) elements"
             )
         # add a -1 element to the list to allow for the no reference option
         available_electrodes = np.append(available_electrodes, [-1])
         if not np.all(np.isin(reference_electrode_list, available_electrodes)):
             raise ValueError(
-                "All elements in reference_electrode_list must be valid electrode_ids in the LFPSelection "
-                "table"
+                "All elements in reference_electrode_list must be valid "
+                + "electrode_ids in the LFPSelection table"
             )
 
         # make a list of all the references
         ref_list = np.zeros((len(electrode_list),))
         ref_list[:] = reference_electrode_list
 
-        key = dict()
-        key["nwb_file_name"] = nwb_file_name
-        key["filter_name"] = filter_name
-        key["filter_sampling_rate"] = lfp_sampling_rate
-        key["target_interval_list_name"] = interval_list_name
-        key["lfp_band_sampling_rate"] = lfp_sampling_rate // decimation
+        key = dict(
+            nwb_file_name=nwb_file_name,
+            filter_name=filter_name,
+            filter_sampling_rate=lfp_sampling_rate,
+            target_interval_list_name=interval_list_name,
+            lfp_band_sampling_rate=lfp_sampling_rate // decimation,
+        )
         # insert an entry into the main LFPBandSelectionTable
         self.insert1(key, skip_duplicates=True)
 

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -53,7 +53,7 @@ class ElectrodeGroup(SpyglassMixin, dj.Imported):
         nwbf = get_nwb_file(nwb_file_abspath)
         for electrode_group in nwbf.electrode_groups.values():
             key["electrode_group_name"] = electrode_group.name
-            # add electrode group location if it does not exist, and fetch the row
+            # add electrode group location if it not exist, and fetch the row
             key["region_id"] = BrainRegion.fetch_add(
                 region_name=electrode_group.location
             )
@@ -189,7 +189,7 @@ class Electrode(SpyglassMixin, dj.Imported):
 
     @classmethod
     def create_from_config(cls, nwb_file_name: str):
-        """Create or update Electrode entries from what is specified in the config YAML file.
+        """Create/update Electrode entries using config YAML file.
 
         Parameters
         ----------
@@ -433,7 +433,7 @@ class LFP(SpyglassMixin, dj.Imported):
     -> IntervalList             # the valid intervals for the data
     -> FirFilterParameters      # the filter used for the data
     -> AnalysisNwbfile          # the name of the nwb file with the lfp data
-    lfp_object_id: varchar(40)  # the NWB object ID for loading this object from the file
+    lfp_object_id: varchar(40)  # the ID for loading this object from the file
     lfp_sampling_rate: float    # the sampling rate, in HZ
     """
 
@@ -517,7 +517,7 @@ class LFP(SpyglassMixin, dj.Imported):
         key["lfp_object_id"] = lfp_object_id
         key["lfp_sampling_rate"] = sampling_rate // decimation
 
-        # finally, we need to censor the valid times to account for the downsampling
+        # finally, censor the valid times to account for the downsampling
         lfp_valid_times = interval_list_censor(valid_times, timestamp_interval)
         # add an interval list for the LFP valid times, skipping duplicates
         key["interval_list_name"] = "lfp valid times"
@@ -570,7 +570,6 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
         -> LFPBandSelection
         -> LFPSelection.LFPElectrode  # the LFP electrode to be filtered
         reference_elect_id = -1: int  # the reference electrode to use; -1 for no reference
-        ---
         """
 
     def set_lfp_band_electrodes(
@@ -601,7 +600,8 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
             The name of the interval list (from the IntervalList table).
         reference_electrode_list : list
             A single electrode id corresponding to the reference to use for all
-            electrodes or a list with one element per entry in the electrode_list
+            electrodes. Or a list with one element per entry in the
+            electrode_list
         lfp_band_sampling_rate : int
             The output sampling rate to be used for the filtered data; must be
             an integer divisor of the LFP sampling rate.
@@ -647,8 +647,8 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
         }
         if not query:
             raise ValueError(
-                f"interval list {interval_list_name} is not in the IntervalList "
-                + "table; the list must be added before this function is called"
+                f"Item not in IntervalList: {interval_list_name}\n"
+                + "Item must be added before this function is called."
             )
         # reference_electrode_list
         if len(reference_electrode_list) != 1 and len(
@@ -717,7 +717,9 @@ class LFPBand(SpyglassMixin, dj.Computed):
         lfp_band_file_name = AnalysisNwbfile().create(  # logged
             key["nwb_file_name"]
         )
-        # get the NWB object with the lfp data; FIX: change to fetch with additional infrastructure
+
+        # get the NWB object with the lfp data;
+        # FIX: change to fetch with additional infrastructure
         lfp_object = (
             LFP() & {"nwb_file_name": key["nwb_file_name"]}
         ).fetch_nwb()[0]["lfp"]

--- a/src/spyglass/common/common_filter.py
+++ b/src/spyglass/common/common_filter.py
@@ -345,7 +345,6 @@ class FirFilterParameters(SpyglassMixin, dj.Manual):
             io.write(nwbf)
 
         # Reload NWB file to get h5py objects for data/timestamps
-        # NOTE: CBroz - why io context within io context? Unindenting
         with pynwb.NWBHDF5IO(
             path=analysis_file_abs_path, mode="a", load_namespaces=True
         ) as io:

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -5,11 +5,11 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from pynwb import NWBFile
 
+from spyglass.common.common_session import Session  # noqa: F401
 from spyglass.utils import SpyglassMixin, logger
 from spyglass.utils.dj_helper_fn import get_child_tables
-
-from .common_session import Session  # noqa: F401
 
 schema = dj.schema("common_interval")
 
@@ -30,7 +30,7 @@ class IntervalList(SpyglassMixin, dj.Manual):
     # See #630, #664. Excessive key length.
 
     @classmethod
-    def insert_from_nwbfile(cls, nwbf, *, nwb_file_name):
+    def insert_from_nwbfile(cls, nwbf: NWBFile, *, nwb_file_name: str):
         """Add each entry in the NWB file epochs table to the IntervalList.
 
         The interval list name for each epoch is set to the first tag for the
@@ -54,20 +54,23 @@ class IntervalList(SpyglassMixin, dj.Manual):
 
         epochs = nwbf.epochs.to_dataframe()
 
-        for _, epoch_data in epochs.iterrows():
-            epoch_dict = {
+        # Create a list of dictionaries to insert
+        epoch_inserts = epochs.apply(
+            lambda epoch_data: {
                 "nwb_file_name": nwb_file_name,
                 "interval_list_name": (
                     epoch_data.tags[0]
                     if epoch_data.tags
-                    else f"interval_{epoch_data[0]}"
+                    else f"interval_{epoch_data.name}"
                 ),
                 "valid_times": np.asarray(
                     [[epoch_data.start_time, epoch_data.stop_time]]
                 ),
-            }
+            },
+            axis=1,
+        ).tolist()
 
-            cls.insert1(epoch_dict, skip_duplicates=True)
+        cls.insert(epoch_inserts, skip_duplicates=True)
 
     def plot_intervals(self, figsize=(20, 5), return_fig=False):
         interval_list = pd.DataFrame(self)

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -24,7 +24,7 @@ class IntervalList(SpyglassMixin, dj.Manual):
     interval_list_name: varchar(170)  # descriptive name of this interval list
     ---
     valid_times: longblob  # numpy array with start/end times for each interval
-    pipeline = "": varchar(64)  # type of interval list (e.g. 'position', 'spikesorting_recording_v1')
+    pipeline = "": varchar(64)  # type of interval list
     """
 
     # See #630, #664. Excessive key length.

--- a/src/spyglass/common/common_lab.py
+++ b/src/spyglass/common/common_lab.py
@@ -224,8 +224,8 @@ class LabTeam(SpyglassMixin, dj.Manual):
             )
             if not query:
                 logger.info(
-                    "To help manage permissions in LabMemberInfo, please add Google "
-                    + f"user ID for {team_member}"
+                    "To help manage permissions in LabMemberInfo, please add "
+                    + f"Google user ID for {team_member}"
                 )
             labteammember_dict = {
                 "team_name": team_name,
@@ -260,7 +260,8 @@ class Institution(SpyglassMixin, dj.Manual):
         Returns
         -------
         institution_name : string
-            The name of the institution found in the NWB or config file, or None.
+            The name of the institution found in the NWB or config file,
+            or None.
         """
         config = config or dict()
         inst_list = config.get("Institution", [{}])
@@ -307,7 +308,7 @@ class Lab(SpyglassMixin, dj.Manual):
         lab_list = config.get("Lab", [{}])
         if len(lab_list) > 1:
             logger.info(
-                "Multiple lab entries not allowed. Using the first entry only.\n"
+                "Multiple lab entries not allowed. Using the first entry only."
             )
         lab_name = lab_list[0].get("lab_name") or getattr(nwbf, "lab", None)
         if not lab_name:

--- a/src/spyglass/common/common_lab.py
+++ b/src/spyglass/common/common_lab.py
@@ -1,6 +1,7 @@
 """Schema for institution, lab team/name/members. Session-independent."""
 
 import datajoint as dj
+
 from spyglass.utils import SpyglassMixin, logger
 
 from ..utils.nwb_helper_fn import get_nwb_file
@@ -265,7 +266,8 @@ class Institution(SpyglassMixin, dj.Manual):
         inst_list = config.get("Institution", [{}])
         if len(inst_list) > 1:
             logger.info(
-                "Multiple institution entries not allowed. Using the first entry only.\n"
+                "Multiple institution entries not allowed. "
+                + "Using the first entry only.\n"
             )
         inst_name = inst_list[0].get("institution_name") or getattr(
             nwbf, "institution", None

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -51,13 +51,13 @@ class Nwbfile(SpyglassMixin, dj.Manual):
     nwb_file_abs_path: filepath@raw
     INDEX (nwb_file_abs_path)
     """
-    # NOTE the INDEX above is implicit from filepath@... above but needs to be explicit
-    # so that alter() can work
+    # NOTE the INDEX above is implicit from filepath@... above but needs to be
+    # explicit so that alter() can work
 
     # NOTE: See #630, #664. Excessive key length.
 
     @classmethod
-    def insert_from_relative_file_name(cls, nwb_file_name):
+    def insert_from_relative_file_name(cls, nwb_file_name: str) -> None:
         """Insert a new session from an existing NWB file.
 
         Parameters
@@ -95,7 +95,7 @@ class Nwbfile(SpyglassMixin, dj.Manual):
         return {"nwb_file_name": cls._get_file_name(nwb_file_name)}
 
     @classmethod
-    def get_abs_path(cls, nwb_file_name, new_file=False) -> str:
+    def get_abs_path(cls, nwb_file_name: str, new_file: bool = False) -> str:
         """Return absolute path for a stored raw NWB file given file name.
 
         The SPYGLASS_BASE_DIR must be set, either as an environment or part of
@@ -120,28 +120,27 @@ class Nwbfile(SpyglassMixin, dj.Manual):
         return raw_dir + "/" + cls._get_file_name(nwb_file_name)
 
     @staticmethod
-    def add_to_lock(nwb_file_name):
-        """Add the specified NWB file to the file with the list of NWB files to be locked.
+    def add_to_lock(nwb_file_name: str) -> None:
+        """Add the specified NWB file to the list of locked items.
 
-        The NWB_LOCK_FILE environment variable must be set.
+        The NWB_LOCK_FILE environment variable must be set to the path of the
+        lock file, listing locked NWB files.
 
         Parameters
         ----------
         nwb_file_name : str
-            The name of an NWB file that has been inserted into the Nwbfile() schema.
+            The name of an NWB file that has been inserted into the Nwbfile table.
         """
-        key = {"nwb_file_name": nwb_file_name}
-        # check to make sure the file exists
-        assert (
-            len((Nwbfile() & key).fetch()) > 0
-        ), f"Error adding {nwb_file_name} to lock file, not in Nwbfile() schema"
+        if not (Nwbfile() & {"nwb_file_name": nwb_file_name}):
+            raise FileNotFoundError(
+                f"File not found in Nwbfile table. Cannot lock {nwb_file_name}"
+            )
 
-        lock_file = open(os.getenv("NWB_LOCK_FILE"), "a+")
-        lock_file.write(f"{nwb_file_name}\n")
-        lock_file.close()
+        with open(os.getenv("NWB_LOCK_FILE"), "a+") as lock_file:
+            lock_file.write(f"{nwb_file_name}\n")
 
     @staticmethod
-    def cleanup(delete_files=False):
+    def cleanup(delete_files: bool = False) -> None:
         """Remove the filepath entries for NWB files that are not in use.
 
         This does not delete the files themselves unless delete_files=True is specified
@@ -150,8 +149,11 @@ class Nwbfile(SpyglassMixin, dj.Manual):
         schema.external["raw"].delete(delete_external_files=delete_files)
 
 
-# TODO: add_to_kachery will not work because we can't update the entry after it's been used in another table.
-# We therefore need another way to keep track of the
+# TODO: add_to_kachery will not work because we can't update the entry after
+# it's been used in another table. We therefore need another way to keep track
+# of the file here
+
+
 @schema
 class AnalysisNwbfile(SpyglassMixin, dj.Manual):
     definition = """
@@ -172,10 +174,11 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
 
     _creation_times = {}
 
-    def create(self, nwb_file_name):
-        """Open the NWB file, create a copy, write the copy to disk and return the name of the new file.
+    def create(self, nwb_file_name: str) -> str:
+        """Open the NWB file, create copy, write to disk and return new name.
 
-        Note that this does NOT add the file to the schema; that needs to be done after data are written to it.
+        Note that this does NOT add the file to the schema; that needs to be
+        done after data are written to it.
 
         Parameters
         ----------
@@ -237,13 +240,13 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         return analysis_file_name
 
     @staticmethod
-    def _alter_spyglass_version(nwb_file_path):
+    def _alter_spyglass_version(nwb_file_path: str) -> None:
         """Change the source script to the current version of spyglass"""
         with h5py.File(nwb_file_path, "a") as f:
             f["/general/source_script"][()] = f"spyglass={sg_version}"
 
     @classmethod
-    def __get_new_file_name(cls, nwb_file_name):
+    def __get_new_file_name(cls, nwb_file_name: str) -> str:
         # each file ends with a random string of 10 digits, so we generate that
         # string and redo if by some miracle it's already there
         file_in_table = True
@@ -262,15 +265,16 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         return analysis_file_name
 
     @classmethod
-    def __get_analysis_file_dir(cls, analysis_file_name: str):
-        # strip off everything after and including the final underscore and return the result
+    def __get_analysis_file_dir(cls, analysis_file_name: str) -> str:
+        """Strip off final underscore and remaining chars, return the result."""
         return analysis_file_name[0 : analysis_file_name.rfind("_")]
 
     @classmethod
-    def copy(cls, nwb_file_name):
+    def copy(cls, nwb_file_name: str):
         """Make a copy of an analysis NWB file.
 
-        Note that this does NOT add the file to the schema; that needs to be done after data are written to it.
+        Note that this does NOT add the file to the schema; that needs to be
+        done after data are written to it.
 
         Parameters
         ----------
@@ -304,7 +308,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
 
         return analysis_file_name
 
-    def add(self, nwb_file_name, analysis_file_name):
+    def add(self, nwb_file_name: str, analysis_file_name: str) -> None:
         """Add the specified file to AnalysisNWBfile table.
 
         Parameters
@@ -325,15 +329,15 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         self.insert1(key)
 
     @classmethod
-    def get_abs_path(cls, analysis_nwb_file_name):
-        """Return the absolute path for a stored analysis NWB file given just the file name.
+    def get_abs_path(cls, analysis_nwb_file_name: str) -> str:
+        """Return the absolute path for an analysis NWB file given the name.
 
         The spyglass config from settings.py must be set.
 
         Parameters
         ----------
         analysis_nwb_file_name : str
-            The name of the NWB file that has been inserted into the AnalysisNwbfile() schema
+            The name of the NWB file that has been inserted into AnalysisNwbfile.
 
         Returns
         -------
@@ -367,11 +371,16 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             return str(analysis_file_base_path / analysis_nwb_file_name)
 
     def add_nwb_object(
-        self, analysis_file_name, nwb_object, table_name="pandas_table"
+        self,
+        analysis_file_name: str,
+        nwb_object: pynwb.core.NWBDataInterface,
+        table_name: str = "pandas_table",
     ):
         # TODO: change to add_object with checks for object type and a name
         # parameter, which should be specified if it is not an NWB container
-        """Add an NWB object to the analysis file in the scratch area and returns the NWB object ID
+        """Add an NWB object to the analysis file and return the NWB object ID
+
+        Adds object to the scratch space of the NWB file.
 
         Parameters
         ----------
@@ -379,8 +388,9 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             The name of the analysis NWB file.
         nwb_object : pynwb.core.NWBDataInterface
             The NWB object created by PyNWB.
-        table_name : str (optional, defaults to 'pandas_table')
-            The name of the DynamicTable made from a dataframe.
+        table_name : str, optional
+            The name of the DynamicTable made from a dataframe. Defaults to
+            'pandas_table'.
 
         Returns
         -------
@@ -394,26 +404,22 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         ) as io:
             nwbf = io.read()
             if isinstance(nwb_object, pd.DataFrame):
-                dt_object = DynamicTable.from_dataframe(
+                nwb_object = DynamicTable.from_dataframe(
                     name=table_name, df=nwb_object
                 )
-                nwbf.add_scratch(dt_object)
-                io.write(nwbf)
-                return dt_object.object_id
-            else:
-                nwbf.add_scratch(nwb_object)
-                io.write(nwbf)
-                return nwb_object.object_id
+            nwbf.add_scratch(nwb_object)
+            io.write(nwbf)
+            return nwb_object.object_id
 
     def add_units(
         self,
-        analysis_file_name,
-        units,
-        units_valid_times,
-        units_sort_interval,
-        metrics=None,
-        units_waveforms=None,
-        labels=None,
+        analysis_file_name: str,
+        units: dict,
+        units_valid_times: dict,
+        units_sort_interval: dict,
+        metrics: dict = None,
+        units_waveforms: dict = None,
+        labels: dict = None,
     ):
         """Add units to analysis NWB file
 
@@ -437,7 +443,8 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         Returns
         -------
         units_object_id, waveforms_object_id : str, str
-            The NWB object id of the Units object and the object id of the waveforms object ('' if None)
+            The NWB object id of the Units object and the object id of the
+            waveforms object ('' if None)
         """
         with pynwb.NWBHDF5IO(
             path=self.get_abs_path(analysis_file_name),
@@ -446,82 +453,83 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         ) as io:
             nwbf = io.read()
             sort_intervals = list()
-            if len(units.keys()):
-                # Add spike times and valid time range for the sort
-                for id in units.keys():
-                    nwbf.add_unit(
-                        spike_times=units[id],
-                        id=id,
-                        # waveform_mean = units_templates[id],
-                        obs_intervals=units_valid_times[id],
-                    )
-                    sort_intervals.append(units_sort_interval[id])
-                # Add a column for the sort interval (subset of valid time)
-                nwbf.add_unit_column(
-                    name="sort_interval",
-                    description="the interval used for spike sorting",
-                    data=sort_intervals,
-                )
-                # If metrics were specified, add one column per metric
-                if metrics is not None:
-                    for metric in metrics:
-                        if metrics[metric]:
-                            unit_ids = np.array(list(metrics[metric].keys()))
-                            metric_values = np.array(
-                                list(metrics[metric].values())
-                            )
 
-                            # sort by unit_ids and apply that sorting to values
-                            # to ensure that things go in the right order
-
-                            metric_values = metric_values[np.argsort(unit_ids)]
-                            logger.info(
-                                f"Adding metric {metric} : {metric_values}"
-                            )
-                            nwbf.add_unit_column(
-                                name=metric,
-                                description=f"{metric} metric",
-                                data=metric_values,
-                            )
-                if labels is not None:
-                    unit_ids = np.array(list(units.keys()))
-                    for unit in unit_ids:
-                        if unit not in labels:
-                            labels[unit] = ""
-                    label_values = np.array(list(labels.values()))
-                    label_values = label_values[np.argsort(unit_ids)].tolist()
-                    nwbf.add_unit_column(
-                        name="label",
-                        description="label given during curation",
-                        data=label_values,
-                    )
-                # If the waveforms were specified, add them as a dataframe to scratch
-                waveforms_object_id = ""
-                if units_waveforms is not None:
-                    waveforms_df = pd.DataFrame.from_dict(
-                        units_waveforms, orient="index"
-                    )
-                    waveforms_df.columns = ["waveforms"]
-                    nwbf.add_scratch(
-                        waveforms_df,
-                        name="units_waveforms",
-                        notes="spike waveforms for each unit",
-                    )
-                    waveforms_object_id = nwbf.scratch[
-                        "units_waveforms"
-                    ].object_id
-
-                io.write(nwbf)
-                return nwbf.units.object_id, waveforms_object_id
-            else:
+            if not len(units.keys()):
                 return ""
+
+            # Add spike times and valid time range for the sort
+            for id in units.keys():
+                nwbf.add_unit(
+                    spike_times=units[id],
+                    id=id,
+                    # waveform_mean = units_templates[id],
+                    obs_intervals=units_valid_times[id],
+                )
+                sort_intervals.append(units_sort_interval[id])
+
+            # Add a column for the sort interval (subset of valid time)
+            nwbf.add_unit_column(
+                name="sort_interval",
+                description="the interval used for spike sorting",
+                data=sort_intervals,
+            )
+
+            # If metrics were specified, add one column per metric
+            metrics = metrics or []  # do nothing if metrics is None
+            for metric in metrics:
+                if not metrics.get(metric):
+                    continue
+
+                unit_ids = np.array(list(metrics[metric].keys()))
+                metric_values = np.array(list(metrics[metric].values()))
+
+                # sort by unit_ids and apply that sorting to values
+                # to ensure that things go in the right order
+
+                metric_values = metric_values[np.argsort(unit_ids)]
+                logger.info(f"Adding metric {metric} : {metric_values}")
+                nwbf.add_unit_column(
+                    name=metric,
+                    description=f"{metric} metric",
+                    data=metric_values,
+                )
+
+            if labels is not None:
+                unit_ids = np.array(list(units.keys()))
+                labels.update(
+                    {unit: "" for unit in unit_ids if unit not in labels}
+                )
+                label_values = np.array(list(labels.values()))
+                label_values = label_values[np.argsort(unit_ids)].tolist()
+                nwbf.add_unit_column(
+                    name="label",
+                    description="label given during curation",
+                    data=label_values,
+                )
+
+            # If the waveforms were specified, add them as a dataframe to scratch
+            waveforms_object_id = ""
+            if units_waveforms is not None:
+                waveforms_df = pd.DataFrame.from_dict(
+                    units_waveforms, orient="index"
+                )
+                waveforms_df.columns = ["waveforms"]
+                nwbf.add_scratch(
+                    waveforms_df,
+                    name="units_waveforms",
+                    notes="spike waveforms for each unit",
+                )
+                waveforms_object_id = nwbf.scratch["units_waveforms"].object_id
+
+            io.write(nwbf)
+            return nwbf.units.object_id, waveforms_object_id
 
     def add_units_waveforms(
         self,
-        analysis_file_name,
+        analysis_file_name: str,
         waveform_extractor: si.WaveformExtractor,
-        metrics=None,
-        labels=None,
+        metrics: dict = None,
+        labels: dict = None,
     ):
         """Add units to analysis NWB file along with the waveforms
 
@@ -584,8 +592,10 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             #             [1, 2, 3]   # spike 4
             #         ]
             # ]
-            # elecs = ... # DynamicTableRegion referring to three electrodes (rows) of the electrodes table
-            # nwbfile.add_unit(spike_times=[1, 2, 3], electrodes=elecs, waveforms=wfs)
+            # elecs = ... # DynamicTableRegion referring to three electrodes
+            #               (rows) of the electrodes table
+            # nwbfile.add_unit(spike_times=[1, 2, 3], electrodes=elecs,
+            #                  waveforms=wfs)
 
             # If metrics were specified, add one column per metric
             if metrics is not None:
@@ -607,14 +617,14 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             io.write(nwbf)
             return nwbf.units.object_id
 
-    def add_units_metrics(self, analysis_file_name, metrics):
+    def add_units_metrics(self, analysis_file_name: str, metrics: dict):
         """Add units to analysis NWB file along with the waveforms
 
         Parameters
         ----------
         analysis_file_name : str
             The name of the analysis NWB file.
-        metrics : dict, optional
+        metrics : dict
             Cluster metrics.
 
         Returns
@@ -644,8 +654,10 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             return nwbf.units.object_id
 
     @classmethod
-    def get_electrode_indices(cls, analysis_file_name, electrode_ids):
-        """Given an analysis NWB file name, returns the indices of the specified electrode_ids.
+    def get_electrode_indices(
+        cls, analysis_file_name: str, electrode_ids: np.array
+    ):
+        """Returns indices of the specified electrode_ids for an analysis file.
 
         Parameters
         ----------

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -129,7 +129,7 @@ class Nwbfile(SpyglassMixin, dj.Manual):
         Parameters
         ----------
         nwb_file_name : str
-            The name of an NWB file that has been inserted into the Nwbfile table.
+            The name of an NWB file in the Nwbfile table.
         """
         if not (Nwbfile() & {"nwb_file_name": nwb_file_name}):
             raise FileNotFoundError(
@@ -143,8 +143,8 @@ class Nwbfile(SpyglassMixin, dj.Manual):
     def cleanup(delete_files: bool = False) -> None:
         """Remove the filepath entries for NWB files that are not in use.
 
-        This does not delete the files themselves unless delete_files=True is specified
-        Run this after deleting the Nwbfile() entries themselves.
+        This does not delete the files themselves unless delete_files=True is
+        specified. Run this after deleting the Nwbfile() entries themselves.
         """
         schema.external["raw"].delete(delete_external_files=delete_files)
 
@@ -157,7 +157,7 @@ class Nwbfile(SpyglassMixin, dj.Manual):
 @schema
 class AnalysisNwbfile(SpyglassMixin, dj.Manual):
     definition = """
-    # Table for holding the NWB files that contain results of analysis, such as spike sorting.
+    # Table for NWB files that contain results of analysis.
     analysis_file_name: varchar(64)                # name of the file
     ---
     -> Nwbfile                                     # name of the parent NWB file. Used for naming and metadata copy
@@ -337,7 +337,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         Parameters
         ----------
         analysis_nwb_file_name : str
-            The name of the NWB file that has been inserted into AnalysisNwbfile.
+            The name of the NWB file in AnalysisNwbfile.
 
         Returns
         -------
@@ -507,7 +507,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
                     data=label_values,
                 )
 
-            # If the waveforms were specified, add them as a dataframe to scratch
+            # If the waveforms were specified, add them as a df to scratch
             waveforms_object_id = ""
             if units_waveforms is not None:
                 waveforms_df = pd.DataFrame.from_dict(
@@ -570,9 +570,10 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
                 )
 
             # The following is a rough sketch of AnalysisNwbfile().add_waveforms
-            # analysis_file_name = AnalysisNwbfile().create(key['nwb_file_name'])
-            # or
-            # nwbfile = pynwb.NWBFile(...)
+            # analysis_file_name =
+            #   AnalysisNwbfile().create(key['nwb_file_name'])
+            #   or
+            #   nwbfile = pynwb.NWBFile(...)
             # (channels, spikes, samples)
             # wfs = [
             #         [     # elec 1
@@ -669,7 +670,8 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
         Returns
         -------
         electrode_indices : numpy array
-            Array of indices in the electrodes table for the given electrode IDs.
+            Array of indices in the electrodes table for the given electrode
+            IDs.
         """
         nwbf = get_nwb_file(cls.get_abs_path(analysis_file_name))
         return get_electrode_indices(nwbf.electrodes, electrode_ids)
@@ -678,8 +680,8 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
     def cleanup(delete_files=False):
         """Remove the filepath entries for NWB files that are not in use.
 
-        Does not delete the files themselves unless delete_files=True is specified.
-        Run this after deleting the Nwbfile() entries themselves.
+        Does not delete the files themselves unless delete_files=True is
+        specified. Run this after deleting the Nwbfile() entries themselves.
 
         Parameters
         ----------

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -522,7 +522,11 @@ class PositionVideo(SpyglassMixin, dj.Computed):
 
         nwb_dict = dict(nwb_file_name=key["nwb_file_name"])
 
-        raw_position_df = (RawPosition() & nwb_dict).fetch1_dataframe()
+        raw_position_df = (
+            RawPosition()
+            & nwb_dict
+            & {"interval_list_name": key["interval_list_name"]}
+        ).fetch1_dataframe()
         position_info_df = (
             IntervalPositionInfo()
             & {

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -604,7 +604,7 @@ class PositionVideo(SpyglassMixin, dj.Computed):
         self.insert1(key)
 
     @staticmethod
-    def convert_to_pixels(data, frame_size, cm_to_pixels=1.0):
+    def convert_to_pixels(data, frame_size=None, cm_to_pixels=1.0):
         """Converts from cm to pixels and flips the y-axis.
         Parameters
         ----------

--- a/src/spyglass/common/common_region.py
+++ b/src/spyglass/common/common_region.py
@@ -21,7 +21,10 @@ class BrainRegion(SpyglassMixin, dj.Lookup):
 
     @classmethod
     def fetch_add(
-        cls, region_name, subregion_name=None, subsubregion_name=None
+        cls,
+        region_name: str,
+        subregion_name: str = None,
+        subsubregion_name: str = None,
     ):
         """Return the region ID for names. If no match, add to the BrainRegion.
 

--- a/src/spyglass/common/common_ripple.py
+++ b/src/spyglass/common/common_ripple.py
@@ -59,12 +59,13 @@ class RippleLFPSelection(SpyglassMixin, dj.Manual):
         group_name: str = "CA1",
         **kwargs,
     ):
-        """Removes all electrodes for the specified nwb file and then adds back the electrodes in the list
+        """Replaces all electrodes for an nwb file with specified electrodes.
 
         Parameters
         ----------
         key : dict
-            dictionary corresponding to the LFPBand entry to use for ripple detection
+            dictionary corresponding to the LFPBand entry to use for ripple
+            detection
         electrode_list : list
             list of electrodes from LFPBandSelection.LFPBandElectrode
             to be used as the ripple LFP during detection

--- a/src/spyglass/common/common_ripple.py
+++ b/src/spyglass/common/common_ripple.py
@@ -2,6 +2,7 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlig.axes import Axes
 from ripple_detection import Karlsson_ripple_detector, Kay_ripple_detector
 from ripple_detection.core import gaussian_smooth, get_envelope
 
@@ -54,8 +55,8 @@ class RippleLFPSelection(SpyglassMixin, dj.Manual):
     @staticmethod
     def set_lfp_electrodes(
         key,
-        electrode_list=None,
-        group_name="CA1",
+        electrode_list: list = None,
+        group_name: str = "CA1",
         **kwargs,
     ):
         """Removes all electrodes for the specified nwb file and then adds back the electrodes in the list
@@ -267,7 +268,7 @@ class RippleTimes(SpyglassMixin, dj.Computed):
 
     @staticmethod
     def get_Kay_ripple_consensus_trace(
-        ripple_filtered_lfps, sampling_frequency, smoothing_sigma=0.004
+        ripple_filtered_lfps, sampling_frequency, smoothing_sigma: float = 0.004
     ):
         ripple_consensus_trace = np.full_like(ripple_filtered_lfps, np.nan)
         not_null = np.all(pd.notnull(ripple_filtered_lfps), axis=1)
@@ -289,10 +290,10 @@ class RippleTimes(SpyglassMixin, dj.Computed):
     def plot_ripple_consensus_trace(
         ripple_consensus_trace,
         ripple_times,
-        ripple_label=1,
-        offset=0.100,
-        relative=True,
-        ax=None,
+        ripple_label: int = 1,
+        offset: float = 0.100,
+        relative: bool = True,
+        ax: Axes = None,
     ):
         ripple_start = ripple_times.loc[ripple_label].start_time
         ripple_end = ripple_times.loc[ripple_label].end_time
@@ -319,7 +320,12 @@ class RippleTimes(SpyglassMixin, dj.Computed):
 
     @staticmethod
     def plot_ripple(
-        lfps, ripple_times, ripple_label=1, offset=0.100, relative=True, ax=None
+        lfps,
+        ripple_times,
+        ripple_label: int = 1,
+        offset: float = 0.100,
+        relative: bool = True,
+        ax: Axes = None,
     ):
         lfp_labels = lfps.columns
         n_lfps = len(lfp_labels)

--- a/src/spyglass/common/common_ripple.py
+++ b/src/spyglass/common/common_ripple.py
@@ -2,7 +2,7 @@ import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from matplotlig.axes import Axes
+from matplotlib.axes import Axes
 from ripple_detection import Karlsson_ripple_detector, Kay_ripple_detector
 from ripple_detection.core import gaussian_smooth, get_envelope
 

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -19,8 +19,8 @@ schema = dj.schema("common_session")
 class Session(SpyglassMixin, dj.Imported):
     definition = """
     # Table for holding experimental sessions.
-    # Note that each session can have multiple experimenters and data acquisition devices. See DataAcquisitionDevice
-    # and Experimenter part tables below.
+    # Note that each session can have multiple experimenters and data acquisition
+    # devices. See DataAcquisitionDevice and Experimenter part tables below.
     -> Nwbfile
     ---
     -> [nullable] Subject
@@ -35,7 +35,7 @@ class Session(SpyglassMixin, dj.Imported):
 
     class DataAcquisitionDevice(SpyglassMixin, dj.Part):
         definition = """
-        # Part table that allows a Session to be associated with multiple DataAcquisitionDevice entries.
+        # Part table linking Session to multiple DataAcquisitionDevice entries.
         -> Session
         -> DataAcquisitionDevice
         """
@@ -46,7 +46,7 @@ class Session(SpyglassMixin, dj.Imported):
 
     class Experimenter(SpyglassMixin, dj.Part):
         definition = """
-        # Part table that allows a Session to be associated with multiple LabMember entries.
+        # Part table linking Session to multiple LabMember entries.
         -> Session
         -> LabMember
         """
@@ -115,8 +115,9 @@ class Session(SpyglassMixin, dj.Imported):
         logger.info("Skipping Apparatus for now...")
         # Apparatus().insert_from_nwbfile(nwbf)
 
-        # interval lists depend on Session (as a primary key) but users may want to add these manually so this is
-        # a manual table that is also populated from NWB files
+        # interval lists depend on Session (as a primary key) but users may
+        # want to add these manually so this is a manual table that is also
+        # populated from NWB files
 
         logger.info("Session populates IntervalList...")
         IntervalList().insert_from_nwbfile(nwbf, nwb_file_name=nwb_file_name)

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -40,8 +40,8 @@ class Session(SpyglassMixin, dj.Imported):
         -> DataAcquisitionDevice
         """
 
-        # NOTE: as a Part table, it is generally advised not to delete entries directly
-        # (see https://docs.datajoint.org/python/computation/03-master-part.html),
+        # NOTE: as a Part table, it is ill advised to delete entries directly
+        # (https://docs.datajoint.org/python/computation/03-master-part.html),
         # but you can use `delete(force=True)`.
 
     class Experimenter(SpyglassMixin, dj.Part):
@@ -52,9 +52,6 @@ class Session(SpyglassMixin, dj.Imported):
         """
 
     def make(self, key):
-        """Make without transaction
-
-        Allows populate_all_common to work within a single transaction."""
         # These imports must go here to avoid cyclic dependencies
         # from .common_task import Task, TaskEpoch
         from .common_interval import IntervalList
@@ -152,8 +149,11 @@ class Session(SpyglassMixin, dj.Imported):
             key["data_acquisition_device_name"] = device_name
             Session.DataAcquisitionDevice.insert1(key)
 
-    def _add_experimenter_part(self, nwb_file_name, nwbf, config={}):
+    def _add_experimenter_part(
+        self, nwb_file_name: str, nwbf, config: dict = None
+    ):
         # Use config file over nwb file
+        config = config or dict()
         if members := config.get("LabMember"):
             experimenter_list = [
                 member["lab_member_name"] for member in members

--- a/src/spyglass/common/common_subject.py
+++ b/src/spyglass/common/common_subject.py
@@ -1,4 +1,5 @@
 import datajoint as dj
+from pynwb import NWBFile
 
 from spyglass.utils import SpyglassMixin, logger
 
@@ -18,14 +19,14 @@ class Subject(SpyglassMixin, dj.Manual):
     """
 
     @classmethod
-    def insert_from_nwbfile(cls, nwbf, config=None):
+    def insert_from_nwbfile(cls, nwbf: NWBFile, config: dict = None):
         """Get the subject info from the NWBFile, insert into the Subject.
 
         Parameters
         ----------
         nwbf: pynwb.NWBFile
             The NWB file with subject information.
-        config : dict
+        config : dict, optional
             Dictionary read from a user-defined YAML file containing values to
             replace in the NWB file.
 

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -23,7 +23,7 @@ class Task(SpyglassMixin, dj.Manual):
      """
 
     @classmethod
-    def insert_from_nwbfile(cls, nwbf):
+    def insert_from_nwbfile(cls, nwbf: pynwb.NWBFile):
         """Insert tasks from an NWB file.
 
         Parameters
@@ -40,7 +40,7 @@ class Task(SpyglassMixin, dj.Manual):
                 cls.insert_from_task_table(task)
 
     @classmethod
-    def insert_from_task_table(cls, task_table):
+    def insert_from_task_table(cls, task_table: pynwb.core.DynamicTable):
         """Insert tasks from a pynwb DynamicTable containing task metadata.
 
         Duplicate tasks will not be added.
@@ -51,19 +51,23 @@ class Task(SpyglassMixin, dj.Manual):
             The table representing task metadata.
         """
         taskdf = task_table.to_dataframe()
-        for task_entry in taskdf.iterrows():
-            task_dict = dict()
-            task_dict["task_name"] = task_entry[1].task_name
-            task_dict["task_description"] = task_entry[1].task_description
-            cls.insert1(task_dict, skip_duplicates=True)
+
+        task_dicts = taskdf.apply(
+            lambda row: dict(
+                task_name=row.task_name,
+                task_description=row.task_description,
+            ),
+            axis=1,
+        ).tolist()
+
+        cls.insert1(task_dicts, skip_duplicates=True)
 
     @classmethod
-    def check_task_table(cls, task_table):
-        """Check whether the pynwb DynamicTable containing task metadata conforms to the expected format.
+    def check_task_table(cls, task_table: pynwb.core.DynamicTable) -> bool:
+        """Check format of pynwb DynamicTable containing task metadata.
 
-
-        The table should be an instance of pynwb.core.DynamicTable and contain the columns 'task_name' and
-        'task_description'.
+        The table should be an instance of pynwb.core.DynamicTable and contain
+        the columns 'task_name' and 'task_description'.
 
         Parameters
         ----------
@@ -73,7 +77,8 @@ class Task(SpyglassMixin, dj.Manual):
         Returns
         -------
         bool
-            Whether the DynamicTable conforms to the expected format for loading data into the Task table.
+            Whether the DynamicTable conforms to the expected format for loading
+            data into the Task table.
         """
         return (
             isinstance(task_table, pynwb.core.DynamicTable)
@@ -174,7 +179,7 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
         self.insert(task_inserts, allow_direct_insert=True)
 
     @classmethod
-    def update_entries(cls, restrict={}):
+    def update_entries(cls, restrict=True):
         existing_entries = (cls & restrict).fetch("KEY")
         for row in existing_entries:
             if (cls & row).fetch1("camera_names"):
@@ -185,9 +190,8 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
             cls.update1(row=row)
 
     @classmethod
-    def check_task_table(cls, task_table) -> bool:
-        """Check whether the pynwb DynamicTable containing task metadata
-        conforms to the expected format.
+    def check_task_table(cls, task_table: pynwb.core.DynamicTable) -> bool:
+        """Check format of pynwb DynamicTable containing task metadata.
 
         The table should be an instance of pynwb.core.DynamicTable and contain
         the columns 'task_name', 'task_description', 'camera_id', 'and

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -60,7 +60,7 @@ class Task(SpyglassMixin, dj.Manual):
             axis=1,
         ).tolist()
 
-        cls.insert1(task_dicts, skip_duplicates=True)
+        cls.insert(task_dicts, skip_duplicates=True)
 
     @classmethod
     def check_task_table(cls, task_table: pynwb.core.DynamicTable) -> bool:

--- a/src/spyglass/common/prepopulate/prepopulate.py
+++ b/src/spyglass/common/prepopulate/prepopulate.py
@@ -77,10 +77,11 @@ def populate_from_yaml(yaml_path: str):
                 )
 
 
-def _get_table_cls(table_name):
+def _get_table_cls(table_name: str):
     """Get the spyglass.common class associated with a given table name.
 
-    Also works for part tables one level deep."""
+    Also works for part tables one level deep.
+    """
 
     if "." in table_name:  # part table
         master_table_name = table_name[0 : table_name.index(".")]

--- a/src/spyglass/common/signal_processing.py
+++ b/src/spyglass/common/signal_processing.py
@@ -2,6 +2,8 @@ import numpy as np
 import pynwb
 import scipy.signal as signal
 
+from spyglass.common.common_usage import ActivityLog
+
 
 def hilbert_decomp(lfp_band_object, sampling_rate=1):
     """Generates analytical decomposition of signals in the lfp_band_object
@@ -21,6 +23,8 @@ def hilbert_decomp(lfp_band_object, sampling_rate=1):
     envelope : pynwb.ecephys.ElectricalSeries
         envelope of the signal
     """
+    ActivityLog().deprecate_log("common.signal_processing.hilbert_decomp")
+
     analytical_signal = signal.hilbert(lfp_band_object.data, axis=0)
 
     eseries_name = "envelope"

--- a/src/spyglass/data_import/insert_sessions.py
+++ b/src/spyglass/data_import/insert_sessions.py
@@ -138,8 +138,9 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
         ) as export_io:
             export_io.export(input_io, nwbf)
 
-    # add link from new file back to raw ephys data in raw data file using fresh build manager and container cache
-    # where the acquisition electricalseries objects have not been removed
+    # add link from new file back to raw ephys data in raw data file using
+    # fresh build manager and container cache where the acquisition
+    # electricalseries objects have not been removed
     with pynwb.NWBHDF5IO(
         path=nwb_file_abs_path, mode="r", load_namespaces=True
     ) as input_io:

--- a/src/spyglass/decoding/decoding_merge.py
+++ b/src/spyglass/decoding/decoding_merge.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import datajoint as dj
 import numpy as np
-from datajoint.utils import to_camel_case
 from non_local_detector.visualization.figurl_1D import create_1D_decode_view
 from non_local_detector.visualization.figurl_2D import create_2D_decode_view
 

--- a/src/spyglass/decoding/utils.py
+++ b/src/spyglass/decoding/utils.py
@@ -1,0 +1,43 @@
+import numpy as np
+import spikeinterface as si
+
+
+def _get_peak_amplitude(
+    waveform_extractor: si.WaveformExtractor,
+    unit_id: int,
+    peak_sign: str = "neg",
+    estimate_peak_time: bool = False,
+) -> np.ndarray:
+    """Returns the amplitudes of all channels at the time of the peak
+    amplitude across channels.
+
+    Parameters
+    ----------
+    waveform : array-like, shape (n_spikes, n_time, n_channels)
+    peak_sign : ('pos', 'neg', 'both'), optional
+        Direction of the peak in the waveform
+    estimate_peak_time : bool, optional
+        Find the peak times for each spike because some spikesorters do not
+        align the spike time (at index n_time // 2) to the peak
+
+    Returns
+    -------
+    peak_amplitudes : array-like, shape (n_spikes, n_channels)
+
+    """
+    waveforms = waveform_extractor.get_waveforms(unit_id)
+    if estimate_peak_time:
+        if peak_sign == "neg":
+            peak_inds = np.argmin(np.min(waveforms, axis=2), axis=1)
+        elif peak_sign == "pos":
+            peak_inds = np.argmax(np.max(waveforms, axis=2), axis=1)
+        elif peak_sign == "both":
+            peak_inds = np.argmax(np.max(np.abs(waveforms), axis=2), axis=1)
+
+        # Get mode of peaks to find the peak time
+        values, counts = np.unique(peak_inds, return_counts=True)
+        spike_peak_ind = values[counts.argmax()]
+    else:
+        spike_peak_ind = waveforms.shape[1] // 2
+
+    return waveforms[:, spike_peak_ind]

--- a/src/spyglass/decoding/v0/clusterless.py
+++ b/src/spyglass/decoding/v0/clusterless.py
@@ -1,5 +1,6 @@
-"""Pipeline for decoding the animal's mental position and some category of interest
-from unclustered spikes and spike waveform features. See [1] for details.
+"""Pipeline for decoding the animal's mental position and some category of
+interest from unclustered spikes and spike waveform features. See [1] for
+details.
 
 References
 ----------

--- a/src/spyglass/decoding/v0/core.py
+++ b/src/spyglass/decoding/v0/core.py
@@ -26,8 +26,10 @@ from spyglass.common.common_interval import (
 def get_valid_ephys_position_times_from_interval(
     interval_list_name: str, nwb_file_name: str
 ) -> np.ndarray:
-    """Finds the intersection of the valid times for the interval list, the valid times for the ephys data,
-    and the valid times for the position data.
+    """Returns the intersection of valid times across ephys and position data.
+
+    Finds the intersection of the valid times for the interval list, the
+    valid times for the ephys data, and the valid times for the position data.
 
     Parameters
     ----------
@@ -135,7 +137,7 @@ def get_valid_ephys_position_times_by_epoch(
 
 
 def convert_valid_times_to_slice(valid_times: np.ndarray) -> list[slice]:
-    """Converts the valid times to a list of slices so that arrays can be indexed easily.
+    """Converts valid times to a list of slices for easy indexing.
 
     Parameters
     ----------
@@ -153,7 +155,8 @@ def convert_valid_times_to_slice(valid_times: np.ndarray) -> list[slice]:
 def create_model_for_multiple_epochs(
     epoch_names: list[str], env_kwargs: dict
 ) -> tuple[list[ObservationModel], list[Environment], list[list[object]]]:
-    """Creates the observation model, environment, and continuous transition types for multiple epochs for decoding
+    """Creates the observation model, environment, and continuous transition
+    types for multiple epochs for decoding
 
     Parameters
     ----------

--- a/src/spyglass/decoding/v0/sorted_spikes.py
+++ b/src/spyglass/decoding/v0/sorted_spikes.py
@@ -1,5 +1,5 @@
-"""Pipeline for decoding the animal's mental position and some category of interest
-from clustered spikes times. See [1] for details.
+"""Pipeline for decoding the animal's mental position and some category of
+interest from clustered spikes times. See [1] for details.
 
 References
 ----------
@@ -201,7 +201,7 @@ class SortedSpikesClassifierParameters(SpyglassMixin, dj.Manual):
 def get_spike_indicator(
     key: dict, time_range: tuple[float, float], sampling_rate: float = 500.0
 ) -> pd.DataFrame:
-    """For a given key, returns a dataframe with the spike indicator for each unit
+    """Returns a dataframe with the spike indicator for each unit
 
     Parameters
     ----------

--- a/src/spyglass/decoding/v0/sorted_spikes.py
+++ b/src/spyglass/decoding/v0/sorted_spikes.py
@@ -52,6 +52,7 @@ from spyglass.decoding.v0.dj_decoder_conversion import (
     convert_classes_to_dict,
     restore_classes,
 )
+from spyglass.decoding.v0.utils import make_default_decoding_params
 from spyglass.spikesorting.v0.spikesorting_curation import CuratedSpikeSorting
 from spyglass.utils import SpyglassMixin, logger
 
@@ -174,51 +175,6 @@ class SortedSpikesIndicator(SpyglassMixin, dj.Computed):
         )
 
 
-def make_default_decoding_parameters_cpu():
-    classifier_parameters = dict(
-        environments=[_DEFAULT_ENVIRONMENT],
-        observation_models=None,
-        continuous_transition_types=_DEFAULT_CONTINUOUS_TRANSITIONS,
-        discrete_transition_type=DiagonalDiscrete(0.98),
-        initial_conditions_type=UniformInitialConditions(),
-        infer_track_interior=True,
-        knot_spacing=10,
-        spike_model_penalty=1e1,
-    )
-
-    predict_parameters = {
-        "is_compute_acausal": True,
-        "use_gpu": False,
-        "state_names": ["Continuous", "Fragmented"],
-    }
-    fit_parameters = dict()
-
-    return classifier_parameters, fit_parameters, predict_parameters
-
-
-def make_default_decoding_parameters_gpu():
-    classifier_parameters = dict(
-        environments=[_DEFAULT_ENVIRONMENT],
-        observation_models=None,
-        continuous_transition_types=_DEFAULT_CONTINUOUS_TRANSITIONS,
-        discrete_transition_type=DiagonalDiscrete(0.98),
-        initial_conditions_type=UniformInitialConditions(),
-        infer_track_interior=True,
-        sorted_spikes_algorithm="spiking_likelihood_kde",
-        sorted_spikes_algorithm_params=_DEFAULT_SORTED_SPIKES_MODEL_KWARGS,
-    )
-
-    predict_parameters = {
-        "is_compute_acausal": True,
-        "use_gpu": True,
-        "state_names": ["Continuous", "Fragmented"],
-    }
-
-    fit_parameters = dict()
-
-    return classifier_parameters, fit_parameters, predict_parameters
-
-
 @schema
 class SortedSpikesClassifierParameters(SpyglassMixin, dj.Manual):
     """Stores parameters for decoding with sorted spikes"""
@@ -232,33 +188,11 @@ class SortedSpikesClassifierParameters(SpyglassMixin, dj.Manual):
     """
 
     def insert_default(self):
-        (
-            classifier_parameters,
-            fit_parameters,
-            predict_parameters,
-        ) = make_default_decoding_parameters_cpu()
-        self.insert1(
-            {
-                "classifier_param_name": "default_decoding_cpu",
-                "classifier_params": classifier_parameters,
-                "fit_params": fit_parameters,
-                "predict_params": predict_parameters,
-            },
-            skip_duplicates=True,
-        )
-
-        (
-            classifier_parameters,
-            fit_parameters,
-            predict_parameters,
-        ) = make_default_decoding_parameters_gpu()
-        self.insert1(
-            {
-                "classifier_param_name": "default_decoding_gpu",
-                "classifier_params": classifier_parameters,
-                "fit_params": fit_parameters,
-                "predict_params": predict_parameters,
-            },
+        self.insert(
+            [
+                make_default_decoding_params(),
+                make_default_decoding_params(use_gpu=True),
+            ],
             skip_duplicates=True,
         )
 

--- a/src/spyglass/decoding/v0/sorted_spikes.py
+++ b/src/spyglass/decoding/v0/sorted_spikes.py
@@ -52,7 +52,10 @@ from spyglass.decoding.v0.dj_decoder_conversion import (
     convert_classes_to_dict,
     restore_classes,
 )
-from spyglass.decoding.v0.utils import make_default_decoding_params
+from spyglass.decoding.v0.utils import (
+    get_time_bins_from_interval,
+    make_default_decoding_params,
+)
 from spyglass.spikesorting.v0.spikesorting_curation import CuratedSpikeSorting
 from spyglass.utils import SpyglassMixin, logger
 
@@ -96,7 +99,7 @@ class SortedSpikesIndicator(SpyglassMixin, dj.Computed):
             "sampling_rate"
         )
 
-        time = self.get_time_bins_from_interval(interval_times, sampling_rate)
+        time = get_time_bins_from_interval(interval_times, sampling_rate)
 
         spikes_nwb = (CuratedSpikeSorting & key).fetch_nwb()
         # restrict to cases with units
@@ -153,14 +156,6 @@ class SortedSpikesIndicator(SpyglassMixin, dj.Computed):
             )
 
             self.insert1(key)
-
-    @staticmethod
-    def get_time_bins_from_interval(interval_times, sampling_rate):
-        """Gets the superset of the interval."""
-        start_time, end_time = interval_times[0][0], interval_times[-1][-1]
-        n_samples = int(np.ceil((end_time - start_time) * sampling_rate)) + 1
-
-        return np.linspace(start_time, end_time, n_samples)
 
     def fetch1_dataframe(self):
         return self.fetch_dataframe()[0]

--- a/src/spyglass/decoding/v0/utils.py
+++ b/src/spyglass/decoding/v0/utils.py
@@ -90,18 +90,10 @@ def make_default_decoding_params(clusterless=False, use_gpu=False):
             if use_gpu
             else "multiunit_likelihood_integer"
         )
-        clusterless_algorithm_params = (
-            {
-                "mark_std": 24.0,
-                "position_std": 6.0,
-            }
-            if use_gpu
-            else _DEFAULT_CLUSTERLESS_MODEL_KWARGS
-        )
         classifier_params.update(
             dict(
                 clusterless_algorithm=clusterless_algorithm,
-                clusterless_algorithm_params=clusterless_algorithm_params,
+                clusterless_algorithm_params=_DEFAULT_CLUSTERLESS_MODEL_KWARGS,
             )
         )
     else:

--- a/src/spyglass/decoding/v0/utils.py
+++ b/src/spyglass/decoding/v0/utils.py
@@ -1,6 +1,32 @@
 import numpy as np
 import xarray as xr
 
+from spyglass.utils import logger
+
+try:
+    from replay_trajectory_classification.classifier import (
+        _DEFAULT_CLUSTERLESS_MODEL_KWARGS,
+        _DEFAULT_CONTINUOUS_TRANSITIONS,
+        _DEFAULT_ENVIRONMENT,
+        _DEFAULT_SORTED_SPIKES_MODEL_KWARGS,
+    )
+    from replay_trajectory_classification.discrete_state_transitions import (
+        DiagonalDiscrete,
+    )
+    from replay_trajectory_classification.initial_conditions import (
+        UniformInitialConditions,
+    )
+except (ImportError, ModuleNotFoundError) as e:
+    (
+        _DEFAULT_CLUSTERLESS_MODEL_KWARGS,
+        _DEFAULT_CONTINUOUS_TRANSITIONS,
+        _DEFAULT_ENVIRONMENT,
+        _DEFAULT_SORTED_SPIKES_MODEL_KWARGS,
+        DiagonalDiscrete,
+        UniformInitialConditions,
+    ) = [None] * 6
+    logger.warning(e)
+
 
 def discretize_and_trim(series: xr.DataArray, ndims=2) -> xr.DataArray:
     """Discretizes a continuous series and trims the zeros.
@@ -26,3 +52,70 @@ def discretize_and_trim(series: xr.DataArray, ndims=2) -> xr.DataArray:
     discretized = np.multiply(series, 255).astype(np.uint8)  # type: ignore
     stacked = discretized.stack(unified_index=index)
     return stacked.where(stacked > 0, drop=True).astype(np.uint8)
+
+
+def make_default_decoding_params(clusterless=False, use_gpu=False):
+    """Default parameters for decoding
+
+    Returns
+    -------
+    classifier_parameters : dict
+    fit_parameters : dict
+    predict_parameters : dict
+    """
+
+    classifier_params = dict(
+        environments=[_DEFAULT_ENVIRONMENT],
+        observation_models=None,
+        continuous_transition_types=_DEFAULT_CONTINUOUS_TRANSITIONS,
+        discrete_transition_type=DiagonalDiscrete(0.98),
+        initial_conditions_type=UniformInitialConditions(),
+        infer_track_interior=True,
+    )
+
+    if clusterless:
+        clusterless_algorithm = (
+            "multiunit_likelihood_integer_gpu"
+            if use_gpu
+            else "multiunit_likelihood_integer"
+        )
+        clusterless_algorithm_params = (
+            {
+                "mark_std": 24.0,
+                "position_std": 6.0,
+            }
+            if use_gpu
+            else _DEFAULT_CLUSTERLESS_MODEL_KWARGS
+        )
+        classifier_params.update(
+            dict(
+                clusterless_algorithm=clusterless_algorithm,
+                clusterless_algorithm_params=clusterless_algorithm_params,
+            )
+        )
+    else:
+        extra_params = (
+            dict(
+                sorted_spikes_algorithm="spiking_likelihood_kde",
+                sorted_spikes_algorithm_params=_DEFAULT_SORTED_SPIKES_MODEL_KWARGS,
+            )
+            if use_gpu
+            else dict(knot_spacing=10, spike_model_penalty=1e1)
+        )
+        classifier_params.update(extra_params)
+
+    predict_params = {
+        "is_compute_acausal": True,
+        "use_gpu": use_gpu,
+        "state_names": ["Continuous", "Fragmented"],
+    }
+    fit_params = dict()
+
+    return dict(
+        classifier_params_name=(
+            "default_decoding_gpu" if use_gpu else "default_decoding_cpu"
+        ),
+        classifier_params=classifier_params,
+        fit_params=fit_params,
+        predict_params=predict_params,
+    )

--- a/src/spyglass/decoding/v0/utils.py
+++ b/src/spyglass/decoding/v0/utils.py
@@ -1,0 +1,28 @@
+import numpy as np
+import xarray as xr
+
+
+def discretize_and_trim(series: xr.DataArray, ndims=2) -> xr.DataArray:
+    """Discretizes a continuous series and trims the zeros.
+
+    Parameters
+    ----------
+    series : xr.DataArray, shape (n_time, n_position_bins)
+        Continuous series to be discretized
+    ndims : int, optional
+        Number of dimensions of the series. Default is 2 for 1D series (time,
+        position), 3 for 2D series (time, y_position, x_position)
+
+    Returns
+    -------
+    discretized : xr.DataArray, shape (n_time, n_position_bins)
+        Discretized and trimmed series
+    """
+    index = (
+        ["time", "position"]
+        if ndims == 2
+        else ["time", "y_position", "x_position"]
+    )
+    discretized = np.multiply(series, 255).astype(np.uint8)  # type: ignore
+    stacked = discretized.stack(unified_index=index)
+    return stacked.where(stacked > 0, drop=True).astype(np.uint8)

--- a/src/spyglass/decoding/v0/utils.py
+++ b/src/spyglass/decoding/v0/utils.py
@@ -28,6 +28,14 @@ except (ImportError, ModuleNotFoundError) as e:
     logger.warning(e)
 
 
+def get_time_bins_from_interval(interval_times: np.array, sampling_rate: int):
+    """Gets the superset of the interval."""
+    start_time, end_time = interval_times[0][0], interval_times[-1][-1]
+    n_samples = int(np.ceil((end_time - start_time) * sampling_rate)) + 1
+
+    return np.linspace(start_time, end_time, n_samples)
+
+
 def discretize_and_trim(series: xr.DataArray, ndims=2) -> xr.DataArray:
     """Discretizes a continuous series and trims the zeros.
 

--- a/src/spyglass/decoding/v0/utils.py
+++ b/src/spyglass/decoding/v0/utils.py
@@ -36,7 +36,7 @@ def get_time_bins_from_interval(interval_times: np.array, sampling_rate: int):
     return np.linspace(start_time, end_time, n_samples)
 
 
-def discretize_and_trim(series: xr.DataArray, ndims=2) -> xr.DataArray:
+def discretize_and_trim(series: xr.DataArray, ndims=1) -> xr.DataArray:
     """Discretizes a continuous series and trims the zeros.
 
     Parameters
@@ -44,17 +44,20 @@ def discretize_and_trim(series: xr.DataArray, ndims=2) -> xr.DataArray:
     series : xr.DataArray, shape (n_time, n_position_bins)
         Continuous series to be discretized
     ndims : int, optional
-        Number of dimensions of the series. Default is 2 for 1D series (time,
-        position), 3 for 2D series (time, y_position, x_position)
+        Number of spatial dimensions of the series. Default is 1 for 1D series
+        (time, position), 2 for 2D series (time, y_position, x_position)
 
     Returns
     -------
     discretized : xr.DataArray, shape (n_time, n_position_bins)
         Discretized and trimmed series
     """
+    if ndims not in [1, 2]:
+        raise ValueError("ndims must be 1 or 2 spatial dimensions.")
+
     index = (
         ["time", "position"]
-        if ndims == 2
+        if ndims == 1
         else ["time", "y_position", "x_position"]
     )
     discretized = np.multiply(series, 255).astype(np.uint8)  # type: ignore

--- a/src/spyglass/decoding/v0/visualization_1D_view.py
+++ b/src/spyglass/decoding/v0/visualization_1D_view.py
@@ -55,7 +55,7 @@ def create_1D_decode_view(
     if linear_position is not None:
         linear_position = np.asarray(linear_position).squeeze()
 
-    trimmed_posterior = discretize_and_trim(posterior, ndims=2)
+    trimmed_posterior = discretize_and_trim(posterior, ndims=1)
     observations_per_time = get_observations_per_time(
         trimmed_posterior, posterior
     )

--- a/src/spyglass/decoding/v0/visualization_1D_view.py
+++ b/src/spyglass/decoding/v0/visualization_1D_view.py
@@ -12,7 +12,9 @@ def get_observations_per_time(
 ) -> np.ndarray:
     times, counts = np.unique(trimmed_posterior.time.values, return_counts=True)
     indexed_counts = xr.DataArray(counts, coords={"time": times})
-    _, good_counts = xr.align(base_data.time, indexed_counts, join="left", fill_value=0)  # type: ignore
+    _, good_counts = xr.align(
+        base_data.time, indexed_counts, join="left", fill_value=0
+    )  # type: ignore
 
     return good_counts.values.astype(np.uint8)
 

--- a/src/spyglass/decoding/v0/visualization_1D_view.py
+++ b/src/spyglass/decoding/v0/visualization_1D_view.py
@@ -4,11 +4,7 @@ import numpy as np
 import sortingview.views.franklab as vvf
 import xarray as xr
 
-
-def discretize_and_trim(series: xr.DataArray) -> xr.DataArray:
-    discretized = np.multiply(series, 255).astype(np.uint8)  # type: ignore
-    stacked = discretized.stack(unified_index=["time", "position"])
-    return stacked.where(stacked > 0, drop=True).astype(np.uint8)
+from spyglass.decoding.v0.utils import discretize_and_trim
 
 
 def get_observations_per_time(
@@ -57,7 +53,7 @@ def create_1D_decode_view(
     if linear_position is not None:
         linear_position = np.asarray(linear_position).squeeze()
 
-    trimmed_posterior = discretize_and_trim(posterior)
+    trimmed_posterior = discretize_and_trim(posterior, ndims=2)
     observations_per_time = get_observations_per_time(
         trimmed_posterior, posterior
     )

--- a/src/spyglass/decoding/v0/visualization_2D_view.py
+++ b/src/spyglass/decoding/v0/visualization_2D_view.py
@@ -132,7 +132,7 @@ def get_observations_per_frame(i_trim: xr.DataArray, base_slice: xr.DataArray):
 def extract_slice_data(
     base_slice: xr.DataArray, location_fn: Callable[[Tuple[float, float]], int]
 ):
-    i_trim = discretize_and_trim(base_slice, ndim=2)
+    i_trim = discretize_and_trim(base_slice, ndims=2)
 
     positions = get_positions(i_trim, location_fn)
     observations_per_frame = get_observations_per_frame(i_trim, base_slice)

--- a/src/spyglass/decoding/v0/visualization_2D_view.py
+++ b/src/spyglass/decoding/v0/visualization_2D_view.py
@@ -4,6 +4,8 @@ import numpy as np
 import sortingview.views.franklab as vvf
 import xarray as xr
 
+from spyglass.decoding.v0.utils import discretize_and_trim
+
 
 def create_static_track_animation(
     *,
@@ -109,13 +111,6 @@ def generate_linearization_function(
     return inner
 
 
-def discretize_and_trim(base_slice: xr.DataArray):
-    i = np.multiply(base_slice, 255).astype(np.uint8)
-    i_stack = i.stack(unified_index=["time", "y_position", "x_position"])
-
-    return i_stack.where(i_stack > 0, drop=True).astype(np.uint8)
-
-
 def get_positions(
     i_trim: xr.Dataset, linearization_fn: Callable[[Tuple[float, float]], int]
 ):
@@ -137,7 +132,7 @@ def get_observations_per_frame(i_trim: xr.DataArray, base_slice: xr.DataArray):
 def extract_slice_data(
     base_slice: xr.DataArray, location_fn: Callable[[Tuple[float, float]], int]
 ):
-    i_trim = discretize_and_trim(base_slice)
+    i_trim = discretize_and_trim(base_slice, ndim=3)
 
     positions = get_positions(i_trim, location_fn)
     observations_per_frame = get_observations_per_frame(i_trim, base_slice)

--- a/src/spyglass/decoding/v0/visualization_2D_view.py
+++ b/src/spyglass/decoding/v0/visualization_2D_view.py
@@ -158,10 +158,14 @@ def process_decoded_data(posterior: xr.DataArray):
     total_frame_count = len(posterior.time)
     final_frame_bounds = np.zeros(total_frame_count, dtype=np.uint8)
     # intentionally oversized preallocation--will trim later
-    # Note: By definition there can't be more than 255 observations per frame (since we drop any observation
-    # lower than 1/255 and the probabilities for any frame sum to 1). However, this preallocation may be way
-    # too big for memory for long recordings. We could use a smaller one, but would need to include logic
-    # to expand the length of the array if its actual allocated bounds are exceeded.
+
+    # Note: By definition there can't be more than 255 observations per frame
+    # (since we drop any observation lower than 1/255 and the probabilities for
+    # any frame sum to 1). However, this preallocation may be way too big for
+    # memory for long recordings. We could use a smaller one, but would need to
+    # include logic to expand the length of the array if its actual allocated
+    # bounds are exceeded.
+
     final_values = np.zeros(total_frame_count * 255, dtype=np.uint8)
     final_locations = np.zeros(total_frame_count * 255, dtype=np.uint16)
 
@@ -185,7 +189,10 @@ def process_decoded_data(posterior: xr.DataArray):
         ] = positions
         total_observations += len(observations)
         frames_done += frame_step_size
-    # These were intentionally oversized in preallocation; trim to the number of actual values.
+
+    # These were intentionally oversized in preallocation; trim to the number
+    # of actual values.
+
     final_values.resize(total_observations)
     final_locations.resize(total_observations)
 
@@ -296,8 +303,11 @@ def create_2D_decode_view(
 
     track_bin_width = place_bin_size[0]
     track_bin_height = place_bin_size[1]
+
     # NOTE: We expect caller to have converted from fortran ordering already
-    # i.e. somewhere upstream, centers = env.place_bin_centers_[env.is_track_interior_.ravel(order="F")]
+    # i.e. somewhere upstream, centers =
+    # env.place_bin_centers_[env.is_track_interior_.ravel(order="F")]
+
     upper_left_points = get_ul_corners(
         track_bin_width, track_bin_height, interior_place_bin_centers
     )

--- a/src/spyglass/decoding/v0/visualization_2D_view.py
+++ b/src/spyglass/decoding/v0/visualization_2D_view.py
@@ -132,7 +132,7 @@ def get_observations_per_frame(i_trim: xr.DataArray, base_slice: xr.DataArray):
 def extract_slice_data(
     base_slice: xr.DataArray, location_fn: Callable[[Tuple[float, float]], int]
 ):
-    i_trim = discretize_and_trim(base_slice, ndim=3)
+    i_trim = discretize_and_trim(base_slice, ndim=2)
 
     positions = get_positions(i_trim, location_fn)
     observations_per_frame = get_observations_per_frame(i_trim, base_slice)

--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -1,5 +1,6 @@
-"""Pipeline for decoding the animal's mental position and some category of interest
-from unclustered spikes and spike waveform features. See [1] for details.
+"""Pipeline for decoding the animal's mental position and some category of
+interest from unclustered spikes and spike waveform features. See [1] for
+details.
 
 References
 ----------
@@ -74,7 +75,7 @@ class ClusterlessDecodingSelection(SpyglassMixin, dj.Manual):
     -> DecodingParameters
     -> IntervalList.proj(encoding_interval='interval_list_name')
     -> IntervalList.proj(decoding_interval='interval_list_name')
-    estimate_decoding_params = 1 : bool # whether to estimate the decoding parameters
+    estimate_decoding_params = 1 : bool # 1 to estimate the decoding parameters
     """
 
 
@@ -107,8 +108,9 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
             position_variable_names,
         ) = self.fetch_position_info(key)
 
-        # Get the waveform features for the selected units
-        # Don't need to filter by interval since the non_local_detector code will do that
+        # Get the waveform features for the selected units. Don't need to filter
+        # by interval since the non_local_detector code will do that
+
         (
             spike_times,
             spike_waveform_features,
@@ -145,10 +147,13 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
         classifier = ClusterlessDetector(**decoding_params)
 
         if key["estimate_decoding_params"]:
-            # if estimating parameters, then we need to treat times outside decoding interval as missing
-            # this means that times outside the decoding interval will not use the spiking data
-            # a better approach would be to treat the intervals as multiple sequences
-            # (see https://en.wikipedia.org/wiki/Baum%E2%80%93Welch_algorithm#Multiple_sequences)
+
+            # if estimating parameters, then we need to treat times outside
+            # decoding interval as missing this means that times outside the
+            # decoding interval will not use the spiking data a better approach
+            # would be to treat the intervals as multiple sequences (see
+            # https://en.wikipedia.org/wiki/Baum%E2%80%93Welch_algorithm#Multiple_sequences)
+
             is_missing = np.ones(len(position_info), dtype=bool)
             for interval_start, interval_end in decoding_interval:
                 is_missing[
@@ -326,7 +331,7 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
 
     @staticmethod
     def _get_interval_range(key):
-        """Get the maximum range of model times in the encoding and decoding intervals
+        """Return max range of model times in the encoding/decoding intervals
 
         Parameters
         ----------
@@ -440,9 +445,10 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
         key : dict
             The decoding selection key
         filter_by_interval : bool, optional
-            Whether to filter for spike times in the model interval, by default True
+            Whether to filter for spike times in the model interval.
+            Default True
         time_slice : Slice, optional
-            User provided slice of time to restrict spikes to, by default None
+            User provided slice of time to restrict spikes to. Default None
 
         Returns
         -------
@@ -529,9 +535,11 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
         time : np.ndarray
             time vector for which to calculate the firing rate
         multiunit : bool, optional
-            if True, return the multiunit firing rate for units in the group, by default False
+            if True, return the multiunit firing rate for units in the group.
+            Default False
         smoothing_sigma : float, optional
-            standard deviation of gaussian filter to smooth firing rates in seconds, by default 0.015
+            standard deviation of gaussian filter to smooth firing rates in
+            seconds. Default 0.015
 
         Returns
         -------

--- a/src/spyglass/decoding/v1/core.py
+++ b/src/spyglass/decoding/v1/core.py
@@ -22,7 +22,7 @@ schema = dj.schema("decoding_core_v1")
 
 @schema
 class DecodingParameters(SpyglassMixin, dj.Lookup):
-    """Parameters for decoding the animal's mental position and some category of interest"""
+    """Params for decoding mental position and some category of interest"""
 
     definition = """
     decoding_param_name : varchar(80)  # a name for this set of parameters
@@ -31,22 +31,25 @@ class DecodingParameters(SpyglassMixin, dj.Lookup):
     decoding_kwargs = NULL : BLOB      # additional keyword arguments
     """
 
+    pk = "decoding_param_name"
+    sk = "decoding_params"
+
     contents = [
         {
-            "decoding_param_name": f"contfrag_clusterless_{non_local_detector_version}",
-            "decoding_params": ContFragClusterlessClassifier(),
+            pk: f"contfrag_clusterless_{non_local_detector_version}",
+            sk: ContFragClusterlessClassifier(),
         },
         {
-            "decoding_param_name": f"nonlocal_clusterless_{non_local_detector_version}",
-            "decoding_params": NonLocalClusterlessDetector(),
+            pk: f"nonlocal_clusterless_{non_local_detector_version}",
+            sk: NonLocalClusterlessDetector(),
         },
         {
-            "decoding_param_name": f"contfrag_sorted_{non_local_detector_version}",
-            "decoding_params": ContFragSortedSpikesClassifier(),
+            pk: f"contfrag_sorted_{non_local_detector_version}",
+            sk: ContFragSortedSpikesClassifier(),
         },
         {
-            "decoding_param_name": f"nonlocal_sorted_{non_local_detector_version}",
-            "decoding_params": NonLocalSortedSpikesDetector(),
+            pk: f"nonlocal_sorted_{non_local_detector_version}",
+            sk: NonLocalSortedSpikesDetector(),
         },
     ]
 
@@ -147,9 +150,11 @@ class PositionGroup(SpyglassMixin, dj.Manual):
         key : dict, optional
             restriction to a single entry in PositionGroup, by default None
         min_time : float, optional
-            restrict position information to times greater than min_time, by default None
+            restrict position information to times greater than min_time,
+            by default None
         max_time : float, optional
-            restrict position information to times less than max_time, by default None
+            restrict position information to times less than max_time,
+            by default None
 
         Returns
         -------

--- a/src/spyglass/decoding/v1/core.py
+++ b/src/spyglass/decoding/v1/core.py
@@ -117,7 +117,7 @@ class PositionGroup(SpyglassMixin, dj.Manual):
         }
         if self & group_key:
             raise ValueError(
-                f"Group {nwb_file_name}: {position_group_name} already exists",
+                f"Group {nwb_file_name}: {group_name} already exists",
                 "please delete the group before creating a new one",
             )
         self.insert1(

--- a/src/spyglass/decoding/v1/sorted_spikes.py
+++ b/src/spyglass/decoding/v1/sorted_spikes.py
@@ -1,5 +1,5 @@
-"""Pipeline for decoding the animal's mental position and some category of interest
-from clustered spikes times. See [1] for details.
+"""Pipeline for decoding the animal's mental position and some category of
+interest from clustered spikes times. See [1] for details.
 
 References
 ----------
@@ -44,7 +44,7 @@ class SortedSpikesDecodingSelection(SpyglassMixin, dj.Manual):
     -> DecodingParameters
     -> IntervalList.proj(encoding_interval='interval_list_name')
     -> IntervalList.proj(decoding_interval='interval_list_name')
-    estimate_decoding_params = 1 : bool # whether to estimate the decoding parameters
+    estimate_decoding_params = 1 : bool # 1 to estimate the decoding parameters
     """
     # NOTE: Excessive key length fixed by reducing UnitSelectionParams.unit_filter_params_name
 
@@ -78,8 +78,9 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
             position_variable_names,
         ) = self.fetch_position_info(key)
 
-        # Get the spike times for the selected units
-        # Don't need to filter by interval since the non_local_detector code will do that
+        # Get the spike times for the selected units. Don't need to filter by
+        # interval since the non_local_detector code will do that
+
         spike_times = self.fetch_spike_data(key, filter_by_interval=False)
 
         # Get the encoding and decoding intervals
@@ -113,10 +114,13 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
         classifier = SortedSpikesDetector(**decoding_params)
 
         if key["estimate_decoding_params"]:
-            # if estimating parameters, then we need to treat times outside decoding interval as missing
-            # this means that times outside the decoding interval will not use the spiking data
-            # a better approach would be to treat the intervals as multiple sequences
-            # (see https://en.wikipedia.org/wiki/Baum%E2%80%93Welch_algorithm#Multiple_sequences)
+
+            # if estimating parameters, then we need to treat times outside
+            # decoding interval as missing this means that times outside the
+            # decoding interval will not use the spiking data a better approach
+            # would be to treat the intervals as multiple sequences (see
+            # https://en.wikipedia.org/wiki/Baum%E2%80%93Welch_algorithm#Multiple_sequences)
+
             is_missing = np.ones(len(position_info), dtype=bool)
             for interval_start, interval_end in decoding_interval:
                 is_missing[
@@ -291,7 +295,7 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
 
     @staticmethod
     def _get_interval_range(key):
-        """Get the maximum range of model times in the encoding and decoding intervals
+        """Return maximum range of model times in encoding/decoding intervals
 
         Parameters
         ----------
@@ -405,12 +409,14 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
         key : dict
             The decoding selection key
         filter_by_interval : bool, optional
-            Whether to filter for spike times in the model interval, by default True
+            Whether to filter for spike times in the model interval,
+            by default True
         time_slice : Slice, optional
             User provided slice of time to restrict spikes to, by default None
         return_unit_ids : bool, optional
-            if True, return the unit_ids along with the spike times, by default False
-            Unit ids defined as a list of dictionaries with keys 'spikesorting_merge_id' and 'unit_number'
+            if True, return the unit_ids along with the spike times, by default
+            False Unit ids defined as a list of dictionaries with keys
+            'spikesorting_merge_id' and 'unit_number'
 
         Returns
         -------
@@ -479,7 +485,7 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
         return "orientation" if "orientation" in cols else "head_orientation"
 
     def get_ahead_behind_distance(self, track_graph=None, time_slice=None):
-        """Get the ahead-behind distance of the decoded position from the animal's actual position
+        """Get relative decoded position from the animal's actual position
 
         Parameters
         ----------

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -20,8 +20,7 @@ schema = dj.schema("decoding_waveform_features")
 
 @schema
 class WaveformFeaturesParams(SpyglassMixin, dj.Lookup):
-    """Defines the types of spike waveform features computed for a given spike
-    time."""
+    """Defines types of waveform features computed for a given spike time."""
 
     definition = """
     features_param_name : varchar(80) # a name for this set of parameters
@@ -34,7 +33,7 @@ class WaveformFeaturesParams(SpyglassMixin, dj.Lookup):
             "estimate_peak_time": False,
         }
     }
-    _default_waveform_extraction_params = {
+    _default_waveform_extract_params = {
         "ms_before": 0.5,
         "ms_after": 0.5,
         "max_spikes_per_unit": None,
@@ -46,7 +45,7 @@ class WaveformFeaturesParams(SpyglassMixin, dj.Lookup):
             "amplitude",
             {
                 "waveform_features_params": _default_waveform_feature_params,
-                "waveform_extraction_params": _default_waveform_extraction_params,
+                "waveform_extraction_params": _default_waveform_extract_params,
             },
         ],
         [
@@ -56,7 +55,7 @@ class WaveformFeaturesParams(SpyglassMixin, dj.Lookup):
                     "amplitude": _default_waveform_feature_params["amplitude"],
                     "spike_location": {},
                 },
-                "waveform_extraction_params": _default_waveform_extraction_params,
+                "waveform_extraction_params": _default_waveform_extract_params,
             },
         ],
     ]
@@ -92,8 +91,9 @@ class UnitWaveformFeaturesSelection(SpyglassMixin, dj.Manual):
 
 @schema
 class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
-    """For each spike time, compute a spike waveform feature associated with that
-    spike. Used for clusterless decoding.
+    """For each spike time, compute waveform feature associated with that spike.
+
+    Used for clusterless decoding.
     """
 
     definition = """
@@ -115,7 +115,8 @@ class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
             params["waveform_features_params"]
         ):
             raise NotImplementedError(
-                f"Features {set(params['waveform_features_params'])} are not supported"
+                f"Features {set(params['waveform_features_params'])} are "
+                + "not supported"
             )
 
         merge_key = {"merge_id": key["spikesorting_merge_id"]}
@@ -303,7 +304,7 @@ def _write_waveform_features_to_nwb(
     spike_times: pd.DataFrame,
     waveform_features: dict,
 ) -> tuple[str, str]:
-    """Save waveforms, metrics, labels, and merge groups to NWB in the units table.
+    """Save waveforms, metrics, labels, and merge groups to NWB units table.
 
     Parameters
     ----------
@@ -318,7 +319,8 @@ def _write_waveform_features_to_nwb(
     Returns
     -------
     analysis_nwb_file : str
-        name of analysis NWB file containing the sorting and curation information
+        name of analysis NWB file containing the sorting and curation
+        information
     object_id : str
         object_id of the units table in the analysis NWB file
     """

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -9,6 +9,7 @@ import pynwb
 import spikeinterface as si
 
 from spyglass.common.common_nwbfile import AnalysisNwbfile
+from spyglass.decoding.utils import _get_peak_amplitude
 from spyglass.settings import temp_dir
 from spyglass.spikesorting.spikesorting_merge import SpikeSortingOutput
 from spyglass.spikesorting.v1 import SpikeSortingSelection
@@ -246,47 +247,6 @@ class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
             )
             for _, unit in feature_df.iterrows()
         ]
-
-
-def _get_peak_amplitude(
-    waveform_extractor: si.WaveformExtractor,
-    unit_id: int,
-    peak_sign: str = "neg",
-    estimate_peak_time: bool = False,
-) -> np.ndarray:
-    """Returns the amplitudes of all channels at the time of the peak
-    amplitude across channels.
-
-    Parameters
-    ----------
-    waveform : array-like, shape (n_spikes, n_time, n_channels)
-    peak_sign : ('pos', 'neg', 'both'), optional
-        Direction of the peak in the waveform
-    estimate_peak_time : bool, optional
-        Find the peak times for each spike because some spikesorters do not
-        align the spike time (at index n_time // 2) to the peak
-
-    Returns
-    -------
-    peak_amplitudes : array-like, shape (n_spikes, n_channels)
-
-    """
-    waveforms = waveform_extractor.get_waveforms(unit_id)
-    if estimate_peak_time:
-        if peak_sign == "neg":
-            peak_inds = np.argmin(np.min(waveforms, axis=2), axis=1)
-        elif peak_sign == "pos":
-            peak_inds = np.argmax(np.max(waveforms, axis=2), axis=1)
-        elif peak_sign == "both":
-            peak_inds = np.argmax(np.max(np.abs(waveforms), axis=2), axis=1)
-
-        # Get mode of peaks to find the peak time
-        values, counts = np.unique(peak_inds, return_counts=True)
-        spike_peak_ind = values[counts.argmax()]
-    else:
-        spike_peak_ind = waveforms.shape[1] // 2
-
-    return waveforms[:, spike_peak_ind]
 
 
 def _get_full_waveform(

--- a/src/spyglass/lfp/analysis/v1/lfp_band.py
+++ b/src/spyglass/lfp/analysis/v1/lfp_band.py
@@ -39,7 +39,6 @@ class LFPBandSelection(SpyglassMixin, dj.Manual):
         -> LFPBandSelection # the LFP band selection
         -> LFPElectrodeGroup.LFPElectrode  # the LFP electrode to be filtered
         reference_elect_id = -1: int  # the reference electrode to use; -1 for no reference
-        ---
         """
 
     def set_lfp_band_electrodes(
@@ -178,7 +177,8 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
         lfp_band_file_name = AnalysisNwbfile().create(  # logged
             key["nwb_file_name"]
         )
-        # get the NWB object with the lfp data; FIX: change to fetch with additional infrastructure
+        # get the NWB object with the lfp data;
+        # FIX: change to fetch with additional infrastructure
         lfp_key = {"merge_id": key["lfp_merge_id"]}
         lfp_object = (LFPOutput & lfp_key).fetch_nwb()[0]["lfp"]
 
@@ -293,12 +293,15 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
             decimation,
         )
 
-        # now that the LFP is filtered, we create an electrical series for it and add it to the file
+        # now that the LFP is filtered, we create an electrical series for it
+        # and add it to the file
         with pynwb.NWBHDF5IO(
             path=lfp_band_file_abspath, mode="a", load_namespaces=True
         ) as io:
             nwbf = io.read()
-            # get the indices of the electrodes in the electrode table of the file to get the right values
+
+            # get the indices of the electrodes in the electrode table of the
+            # file to get the right values
             elect_index = get_electrode_indices(nwbf, lfp_band_elect_id)
             electrode_table_region = nwbf.create_electrode_table_region(
                 elect_index, "filtered electrode table"
@@ -325,8 +328,8 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
         key["analysis_file_name"] = lfp_band_file_name
         key["lfp_band_object_id"] = lfp_band_object_id
 
-        # finally, we need to censor the valid times to account for the downsampling if this is the first time we've
-        # downsampled these data
+        # finally, censor the valid times to account for the downsampling if
+        # this is the first time we've downsampled these data
         key["interval_list_name"] = (
             interval_list_name
             + " lfp band "
@@ -378,7 +381,7 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
     def compute_analytic_signal(self, electrode_list: list[int], **kwargs):
         """Computes the hilbert transform of a given LFPBand signal
 
-        Uses scipy.signal.hilbert to compute the hilbert transform of the signal
+        Uses scipy.signal.hilbert to compute the hilbert transform
 
         Parameters
         ----------
@@ -415,7 +418,7 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
     def compute_signal_phase(
         self, electrode_list: list[int] = None, **kwargs
     ) -> pd.DataFrame:
-        """Computes the phase of a given LFPBand signals using the hilbert transform
+        """Computes phase of LFPBand signals using the hilbert transform
 
         Parameters
         ----------
@@ -443,7 +446,7 @@ class LFPBandV1(SpyglassMixin, dj.Computed):
     def compute_signal_power(
         self, electrode_list: list[int] = None, **kwargs
     ) -> pd.DataFrame:
-        """Computes the power of a given LFPBand signals using the hilbert transform
+        """Computes power LFPBand signals using the hilbert transform
 
         Parameters
         ----------

--- a/src/spyglass/lfp/lfp_electrode.py
+++ b/src/spyglass/lfp/lfp_electrode.py
@@ -11,8 +11,8 @@ schema = dj.schema("lfp_electrode")
 @schema
 class LFPElectrodeGroup(SpyglassMixin, dj.Manual):
     definition = """
-     -> Session                             # the session to which this LFP belongs
-     lfp_electrode_group_name: varchar(200) # the name of this group of electrodes
+     -> Session                             # the session for this LFP
+     lfp_electrode_group_name: varchar(200) # name for this group of electrodes
      """
 
     class LFPElectrode(SpyglassMixin, dj.Part):

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -15,7 +15,7 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
     -> Session                      # the session to which this LFP belongs
     -> LFPElectrodeGroup            # the group of electrodes to be filtered
     -> IntervalList # the original set of times to be filtered
-    lfp_object_id: varchar(40)      # the NWB object ID for loading this object from the file
+    lfp_object_id: varchar(40)      # object ID for loading from the NWB file
     ---
     lfp_sampling_rate: float        # the sampling rate, in samples/sec
     -> AnalysisNwbfile

--- a/src/spyglass/lfp/v1/lfp.py
+++ b/src/spyglass/lfp/v1/lfp.py
@@ -25,14 +25,15 @@ MIN_LFP_INTERVAL_DURATION = 1.0  # 1 second minimum interval duration
 class LFPSelection(SpyglassMixin, dj.Manual):
     """The user's selection of LFP data to be filtered
 
-    This table is used to select the LFP data to be filtered.  The user can select
-    the LFP data by specifying the electrode group and the interval list to be used.
-    The interval list is used to select the times from the raw data that will be
-    filtered.  The user can also specify the filter to be used.
+    This table is used to select the LFP data to be filtered.  The user can
+    select the LFP data by specifying the electrode group and the interval list
+    to be used. The interval list is used to select the times from the raw data
+    that will be filtered.  The user can also specify the filter to be used.
 
-    The LFP data is filtered and downsampled to the user-defined sampling rate, specified
-    as lfp_sampling_rate.  The filtered data is stored in the AnalysisNwbfile table.
-    The valid times for the filtered data are stored in the IntervalList table.
+    The LFP data is filtered and downsampled to the user-defined sampling rate,
+    specified as lfp_sampling_rate.  The filtered data is stored in the
+    AnalysisNwbfile table. The valid times for the filtered data are stored in
+    the IntervalList table.
     """
 
     definition = """
@@ -40,7 +41,7 @@ class LFPSelection(SpyglassMixin, dj.Manual):
      -> IntervalList.proj(target_interval_list_name='interval_list_name')  # the original set of times to be filtered
      -> FirFilterParameters                                                # the filter to be used
      ---
-     target_sampling_rate = 1000 : float                                     # the desired output sampling rate, in HZ
+     target_sampling_rate = 1000 : float                                   # the desired output sampling rate, in HZ
      """
 
 
@@ -49,11 +50,11 @@ class LFPV1(SpyglassMixin, dj.Computed):
     """The filtered LFP data"""
 
     definition = """
-    -> LFPSelection             # the user's selection of LFP data to be filtered
+    -> LFPSelection             # the user's selection of data to be filtered
     ---
     -> AnalysisNwbfile          # the name of the nwb file with the lfp data
-    -> IntervalList             # the final interval list of valid times for the data
-    lfp_object_id: varchar(40)  # the NWB object ID for loading this object from the file
+    -> IntervalList             # final interval list of times for the data
+    lfp_object_id: varchar(40)  # object ID for loading from the NWB file
     lfp_sampling_rate: float    # the sampling rate, in HZ
     """
 
@@ -78,7 +79,7 @@ class LFPV1(SpyglassMixin, dj.Computed):
         orig_key = copy.deepcopy(key)
         orig_key["interval_list_name"] = key["target_interval_list_name"]
         user_valid_times = (IntervalList() & orig_key).fetch1("valid_times")
-        # we remove the extra entry so we can insert this into the LFPOutput table.
+        # remove the extra entry so we can insert into the LFPOutput table.
         del orig_key["interval_list_name"]
 
         raw_valid_times = (
@@ -153,7 +154,8 @@ class LFPV1(SpyglassMixin, dj.Computed):
         # need to censor the valid times to account for the downsampling
         lfp_valid_times = interval_list_censor(valid_times, timestamp_interval)
 
-        # add an interval list for the LFP valid times, or check that it matches the existing one
+        # add an interval list for the LFP valid times, or check that it
+        # matches the existing one
         key["interval_list_name"] = "_".join(
             (
                 "lfp",

--- a/src/spyglass/lfp/v1/lfp_artifact_MAD_detection.py
+++ b/src/spyglass/lfp/v1/lfp_artifact_MAD_detection.py
@@ -21,7 +21,8 @@ def mad_artifact_detector(
     mad_thresh : float, optional
         Threshold on the median absolute deviation scaled LFPs, defaults to 6.0
     proportion_above_thresh : float, optional
-        Proportion of electrodes that need to be above the threshold, defaults to 1.0
+        Proportion of electrodes that need to be above the threshold, defaults
+        to 1.0
     removal_window_ms : float, optional
         Width of the window in milliseconds to mask out per artifact
         (window/2 removed on each side of threshold crossing), defaults to 1 ms
@@ -31,10 +32,11 @@ def mad_artifact_detector(
     Returns
     -------
     artifact_removed_valid_times : np.ndarray
-        Intervals of valid times where artifacts were not detected, unit: seconds
+        Intervals of valid times where artifacts were not detected,
+        unit: seconds
     artifact_intervals : np.ndarray
-        Intervals in which artifacts are detected (including removal windows), unit: seconds
-
+        Intervals in which artifacts are detected (including removal windows),
+        unit: seconds
     """
 
     timestamps = np.asarray(recording.timestamps)
@@ -82,7 +84,7 @@ def _is_above_proportion_thresh(
     mad_thresh: np.ndarray,
     proportion_above_thresh: float = 1.0,
 ) -> np.ndarray:
-    """Return whether each sample is above the threshold on the proportion of electrodes.
+    """Return array of bools for samples > thresh on proportion of electodes.
 
     Parameters
     ----------
@@ -96,7 +98,8 @@ def _is_above_proportion_thresh(
     Returns
     -------
     is_above_thresh : np.ndarray, shape (n_samples,)
-        Whether each sample is above the threshold on the proportion of electrodes
+        Whether each sample is above the threshold on the proportion of
+        electrodes
     """
 
     return (

--- a/src/spyglass/lfp/v1/lfp_artifact_difference_detection.py
+++ b/src/spyglass/lfp/v1/lfp_artifact_difference_detection.py
@@ -53,7 +53,8 @@ def difference_artifact_detector(
         Width of the window in milliseconds to mask out per artifact (window/2
         removed on each side of threshold crossing), defaults to 1 ms
     referencing : bool, optional
-        Whether or not the data passed to this function is referenced, defaults to False
+        Whether or not the data passed to this function is referenced, defaults
+        to False
 
     Returns
     -------

--- a/src/spyglass/linearization/v0/main.py
+++ b/src/spyglass/linearization/v0/main.py
@@ -57,6 +57,8 @@ class TrackGraph(SpyglassMixin, dj.Manual):
     """
 
     def get_networkx_track_graph(self, track_graph_parameters=None):
+        # CB: Does this need to be a public method? Can other methods inherit
+        # the logic? It's a pretty simple wrapper around make_track_graph.
         if track_graph_parameters is None:
             track_graph_parameters = self.fetch1()
         return make_track_graph(
@@ -66,7 +68,9 @@ class TrackGraph(SpyglassMixin, dj.Manual):
 
     def plot_track_graph(self, ax=None, draw_edge_labels=False, **kwds):
         """Plot the track graph in 2D position space."""
-        track_graph = self.get_networkx_track_graph()
+        track_graph = self.get_networkx_track_graph(
+            track_graph_parameters=self.fetch1()
+        )
         plot_track_graph(
             track_graph, ax=ax, draw_edge_labels=draw_edge_labels, **kwds
         )

--- a/src/spyglass/linearization/v1/main.py
+++ b/src/spyglass/linearization/v1/main.py
@@ -43,11 +43,11 @@ class TrackGraph(SpyglassMixin, dj.Manual):
     definition = """
     track_graph_name : varchar(80)
     ----
-    environment : varchar(80)    # Type of Environment
-    node_positions : blob  # 2D position of track_graph nodes, shape (n_nodes, 2)
-    edges: blob                  # shape (n_edges, 2)
-    linear_edge_order : blob  # order of track graph edges in the linear space, shape (n_edges, 2)
-    linear_edge_spacing : blob  # amount of space between edges in the linear space, shape (n_edges,)
+    environment : varchar(80)  # Type of Environment
+    node_positions : blob      # 2D position of nodes, (n_nodes, 2)
+    edges: blob                # shape (n_edges, 2)
+    linear_edge_order : blob   # order of edges in linear space, (n_edges, 2)
+    linear_edge_spacing : blob # space btwn edges in linear space, (n_edges,)
     """
 
     def get_networkx_track_graph(self, track_graph_parameters=None):

--- a/src/spyglass/linearization/v1/main.py
+++ b/src/spyglass/linearization/v1/main.py
@@ -51,6 +51,8 @@ class TrackGraph(SpyglassMixin, dj.Manual):
     """
 
     def get_networkx_track_graph(self, track_graph_parameters=None):
+        # CB: Does this need to be a public method? Can other methods inherit
+        # the logic? It's a pretty simple wrapper around make_track_graph.
         if track_graph_parameters is None:
             track_graph_parameters = self.fetch1()
         return make_track_graph(
@@ -60,7 +62,9 @@ class TrackGraph(SpyglassMixin, dj.Manual):
 
     def plot_track_graph(self, ax=None, draw_edge_labels=False, **kwds):
         """Plot the track graph in 2D position space."""
-        track_graph = self.get_networkx_track_graph()
+        track_graph = self.get_networkx_track_graph(
+            track_graph_parameters=self.fetch1()
+        )
         plot_track_graph(
             track_graph, ax=ax, draw_edge_labels=draw_edge_labels, **kwds
         )

--- a/src/spyglass/lock/file_lock.py
+++ b/src/spyglass/lock/file_lock.py
@@ -37,9 +37,11 @@ class AnalysisNwbfileLock(SpyglassMixin, dj.Manual):
     """
 
     def populate_from_lock_file(self):
-        """Reads from the ANALYSIS_LOCK_FILE (defined by an environment variable), adds the entries to this schema, and
-        then removes the file
+        """Reads/inserts from lock file, then removes lock file.
+
+        Requires ANALYSIS_LOCK_FILE environment variable.
         """
+
         if os.path.exists(os.getenv("ANALYSIS_LOCK_FILE")):
             lock_file = open(os.getenv("ANALYSIS_LOCK_FILE"), "r")
             for line in lock_file:

--- a/src/spyglass/position/v1/dlc_utils.py
+++ b/src/spyglass/position/v1/dlc_utils.py
@@ -19,13 +19,9 @@ import pandas as pd
 from position_tools import get_distance
 
 from spyglass.common.common_behav import VideoFile
-from spyglass.common.common_position import PositionVideo
 from spyglass.common.common_usage import ActivityLog
 from spyglass.settings import dlc_output_dir, dlc_video_dir, raw_dir
 from spyglass.utils.logging import logger, stream_handler
-
-convert_to_pixels = PositionVideo.convert_to_pixels
-fill_nan = PositionVideo.fill_nan
 
 
 def validate_option(

--- a/src/spyglass/position/v1/dlc_utils.py
+++ b/src/spyglass/position/v1/dlc_utils.py
@@ -19,9 +19,13 @@ import pandas as pd
 from position_tools import get_distance
 
 from spyglass.common.common_behav import VideoFile
+from spyglass.common.common_position import PositionVideo
 from spyglass.common.common_usage import ActivityLog
 from spyglass.settings import dlc_output_dir, dlc_video_dir, raw_dir
 from spyglass.utils.logging import logger, stream_handler
+
+convert_to_pixels = PositionVideo.convert_to_pixels
+fill_nan = PositionVideo.fill_nan
 
 
 def validate_option(
@@ -744,36 +748,6 @@ _key_to_func_dict = {
     "red_green_orientation": two_pt_head_orientation,
     "red_led_bisector": red_led_bisector_orientation,
 }
-
-
-def fill_nan(variable, video_time, variable_time):
-    video_ind = np.digitize(variable_time, video_time[1:])
-
-    n_video_time = len(video_time)
-    try:
-        n_variable_dims = variable.shape[1]
-        filled_variable = np.full((n_video_time, n_variable_dims), np.nan)
-    except IndexError:
-        filled_variable = np.full((n_video_time,), np.nan)
-    filled_variable[video_ind] = variable
-
-    return filled_variable
-
-
-def convert_to_pixels(data, frame_size=None, cm_to_pixels=1.0):
-    """Converts from cm to pixels and flips the y-axis.
-
-    Parameters
-    ----------
-    data : ndarray, shape (n_time, 2)
-    frame_size : array_like, shape (2,)
-    cm_to_pixels : float
-
-    Returns
-    -------
-    converted_data : ndarray, shape (n_time, 2)
-    """
-    return data / cm_to_pixels
 
 
 class Centroid:

--- a/src/spyglass/position/v1/dlc_utils_makevid.py
+++ b/src/spyglass/position/v1/dlc_utils_makevid.py
@@ -8,9 +8,9 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm as tqdm
 
-from spyglass.position.v1.dlc_utils import convert_to_pixels as _to_px
-from spyglass.position.v1.dlc_utils import fill_nan
 from spyglass.utils import logger
+from spyglass.utils.position import convert_to_pixels as _to_px
+from spyglass.utils.position import fill_nan
 
 RGB_PINK = (234, 82, 111)
 RGB_YELLOW = (253, 231, 76)

--- a/src/spyglass/ripple/v1/ripple.py
+++ b/src/spyglass/ripple/v1/ripple.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import sortingview.views as vv
 from ripple_detection import Karlsson_ripple_detector, Kay_ripple_detector
-from ripple_detection.core import gaussian_smooth, get_envelope
 from scipy.stats import zscore
 
 from spyglass.common.common_interval import (
@@ -297,7 +296,7 @@ class RippleTimesV1(SpyglassMixin, dj.Computed):
     def get_Kay_ripple_consensus_trace(
         ripple_filtered_lfps, sampling_frequency, smoothing_sigma=0.004
     ):
-        return RippleTimesV1.get_Kay_ripple_consensus_trace(
+        return RippleTimes.get_Kay_ripple_consensus_trace(
             ripple_filtered_lfps=ripple_filtered_lfps,
             sampling_frequency=sampling_frequency,
             smoothing_sigma=smoothing_sigma,

--- a/src/spyglass/ripple/v1/ripple.py
+++ b/src/spyglass/ripple/v1/ripple.py
@@ -12,6 +12,7 @@ from spyglass.common.common_interval import (
     interval_list_intersect,
 )
 from spyglass.common.common_nwbfile import AnalysisNwbfile
+from spyglass.common.common_ripple import RippleTimes
 from spyglass.lfp.analysis.v1.lfp_band import LFPBandSelection, LFPBandV1
 from spyglass.lfp.lfp_merge import LFPOutput
 from spyglass.position import PositionOutput
@@ -296,20 +297,10 @@ class RippleTimesV1(SpyglassMixin, dj.Computed):
     def get_Kay_ripple_consensus_trace(
         ripple_filtered_lfps, sampling_frequency, smoothing_sigma=0.004
     ):
-        ripple_consensus_trace = np.full_like(ripple_filtered_lfps, np.nan)
-        not_null = np.all(pd.notnull(ripple_filtered_lfps), axis=1)
-
-        ripple_consensus_trace[not_null] = get_envelope(
-            np.asarray(ripple_filtered_lfps)[not_null]
-        )
-        ripple_consensus_trace = np.sum(ripple_consensus_trace**2, axis=1)
-        ripple_consensus_trace[not_null] = gaussian_smooth(
-            ripple_consensus_trace[not_null],
-            smoothing_sigma,
-            sampling_frequency,
-        )
-        return pd.DataFrame(
-            np.sqrt(ripple_consensus_trace), index=ripple_filtered_lfps.index
+        return RippleTimesV1.get_Kay_ripple_consensus_trace(
+            ripple_filtered_lfps=ripple_filtered_lfps,
+            sampling_frequency=sampling_frequency,
+            smoothing_sigma=smoothing_sigma,
         )
 
     @staticmethod

--- a/src/spyglass/ripple/v1/ripple.py
+++ b/src/spyglass/ripple/v1/ripple.py
@@ -11,7 +11,7 @@ from spyglass.common.common_interval import (
     interval_list_intersect,
 )
 from spyglass.common.common_nwbfile import AnalysisNwbfile
-from spyglass.common.common_ripple import RippleTimes
+from spyglass.common.common_ripple import RippleTimes, interpolate_to_new_time
 from spyglass.lfp.analysis.v1.lfp_band import LFPBandSelection, LFPBandV1
 from spyglass.lfp.lfp_merge import LFPOutput
 from spyglass.position import PositionOutput
@@ -27,20 +27,6 @@ RIPPLE_DETECTION_ALGORITHMS = {
 
 # Do we need this anymore given that LFPBand is no longer a merge table?
 UPSTREAM_ACCEPTED_VERSIONS = ["LFPBandV1"]
-
-
-def interpolate_to_new_time(
-    df, new_time, upsampling_interpolation_method="linear"
-):
-    old_time = df.index
-    new_index = pd.Index(
-        np.unique(np.concatenate((old_time, new_time))), name="time"
-    )
-    return (
-        df.reindex(index=new_index)
-        .interpolate(method=upsampling_interpolation_method)
-        .reindex(index=new_time)
-    )
 
 
 @schema

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -211,7 +211,7 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
 
     @classmethod
     def get_spike_indicator(cls, key: dict, time: np.ndarray) -> np.ndarray:
-        """get spike indicator matrix for the group
+        """Get spike indicator matrix for the group
 
         Parameters
         ----------

--- a/src/spyglass/spikesorting/spikesorting_merge.py
+++ b/src/spyglass/spikesorting/spikesorting_merge.py
@@ -219,8 +219,8 @@ class SpikeSortingOutput(_Merge, SpyglassMixin):
                 minlength=time.shape[0],
             )
 
-        # CB: spikesorting.analysis.get_spike_indicator checks ndim == 1
-        #     and returns spike_indicator[:, np.newaxis] if True. Do here?
+        if spike_indicator.ndim == 1:
+            spike_indicator = spike_indicator[:, np.newaxis]
 
         return spike_indicator
 

--- a/src/spyglass/spikesorting/spikesorting_merge.py
+++ b/src/spyglass/spikesorting/spikesorting_merge.py
@@ -4,11 +4,11 @@ from datajoint.utils import to_camel_case
 from ripple_detection import get_multiunit_population_firing_rate
 
 from spyglass.spikesorting.imported import ImportedSpikeSorting  # noqa: F401
-from spyglass.spikesorting.v0.spikesorting_curation import (  # noqa: F401
+from spyglass.spikesorting.v0.spikesorting_curation import (
     CuratedSpikeSorting,
-)
-from spyglass.spikesorting.v1 import (  # noqa: F401
-    ArtifactDetectionSelection,
+)  # noqa: F401
+from spyglass.spikesorting.v1 import ArtifactDetectionSelection  # noqa: F401
+from spyglass.spikesorting.v1 import (
     CurationV1,
     MetricCurationSelection,
     SpikeSortingRecordingSelection,
@@ -208,7 +208,13 @@ class SpikeSortingOutput(_Merge, SpyglassMixin):
         return spike_indicator
 
     @classmethod
-    def get_firing_rate(cls, key, time, multiunit=False):
+    def get_firing_rate(
+        cls,
+        key: dict,
+        time: np.array,
+        multiunit: bool = False,
+        smoothing_sigma: float = 0.015,
+    ):
         spike_indicator = cls.get_spike_indicator(key, time)
         if spike_indicator.ndim == 1:
             spike_indicator = spike_indicator[:, np.newaxis]
@@ -220,7 +226,9 @@ class SpikeSortingOutput(_Merge, SpyglassMixin):
         return np.stack(
             [
                 get_multiunit_population_firing_rate(
-                    indicator[:, np.newaxis], sampling_frequency
+                    indicator[:, np.newaxis],
+                    sampling_frequency,
+                    smoothing_sigma,
                 )
                 for indicator in spike_indicator.T
             ],

--- a/src/spyglass/spikesorting/spikesorting_merge.py
+++ b/src/spyglass/spikesorting/spikesorting_merge.py
@@ -193,6 +193,20 @@ class SpikeSortingOutput(_Merge, SpyglassMixin):
 
     @classmethod
     def get_spike_indicator(cls, key, time):
+        """Get spike indicator matrix for the group
+
+        Parameters
+        ----------
+        key : dict
+            key to identify the group
+        time : np.ndarray
+            time vector for which to calculate the spike indicator matrix
+
+        Returns
+        -------
+        np.ndarray
+            spike indicator matrix with shape (len(time), n_units)
+        """
         time = np.asarray(time)
         min_time, max_time = time[[0, -1]]
         spike_times = cls.fetch_spike_data(key)
@@ -204,6 +218,9 @@ class SpikeSortingOutput(_Merge, SpyglassMixin):
                 np.digitize(times, time[1:-1]),
                 minlength=time.shape[0],
             )
+
+        # CB: spikesorting.analysis.get_spike_indicator checks ndim == 1
+        #     and returns spike_indicator[:, np.newaxis] if True. Do here?
 
         return spike_indicator
 

--- a/src/spyglass/spikesorting/utils.py
+++ b/src/spyglass/spikesorting/utils.py
@@ -1,0 +1,130 @@
+import numpy as np
+import spikeinterface as si
+
+from spyglass.common.common_ephys import Electrode
+from spyglass.utils import logger
+
+
+def get_group_by_shank(
+    nwb_file_name: str,
+    references: dict = None,
+    omit_ref_electrode_group=False,
+    omit_unitrode=True,
+):
+    """Divides electrodes into groups based on their shank position.
+
+    * Electrodes from probes with 1 shank (e.g. tetrodes) are placed in a
+      single group
+    * Electrodes from probes with multiple shanks (e.g. polymer probes) are
+      placed in one group per shank
+    * Bad channels are omitted
+
+    Parameters
+    ----------
+    nwb_file_name : str
+        the name of the NWB file whose electrodes should be put into
+        sorting groups
+    references : dict, optional
+        If passed, used to set references. Otherwise, references set using
+        original reference electrodes from config. Keys: electrode groups.
+        Values: reference electrode.
+    omit_ref_electrode_group : bool
+        Optional. If True, no sort group is defined for electrode group of
+        reference.
+    omit_unitrode : bool
+        Optional. If True, no sort groups are defined for unitrodes.
+    """
+    # get the electrodes from this NWB file
+    electrodes = (
+        Electrode()
+        & {"nwb_file_name": nwb_file_name}
+        & {"bad_channel": "False"}
+    ).fetch()
+
+    e_groups = list(np.unique(electrodes["electrode_group_name"]))
+    e_groups.sort(key=int)  # sort electrode groups numerically
+
+    sort_group = 0
+    sg_keys = list()
+    sge_keys = list()
+    for e_group in e_groups:
+        sg_key = dict()
+        sge_key = dict()
+        sg_key["nwb_file_name"] = sge_key["nwb_file_name"] = nwb_file_name
+        # for each electrode group, get a list of the unique shank numbers
+        shank_list = np.unique(
+            electrodes["probe_shank"][
+                electrodes["electrode_group_name"] == e_group
+            ]
+        )
+        sge_key["electrode_group_name"] = e_group
+        # get the indices of all electrodes in this group / shank and set their sorting group
+        for shank in shank_list:
+            sg_key["sort_group_id"] = sge_key["sort_group_id"] = sort_group
+            # specify reference electrode. Use 'references' if passed, otherwise use reference from config
+            if not references:
+                shank_elect_ref = electrodes["original_reference_electrode"][
+                    np.logical_and(
+                        electrodes["electrode_group_name"] == e_group,
+                        electrodes["probe_shank"] == shank,
+                    )
+                ]
+                if np.max(shank_elect_ref) == np.min(shank_elect_ref):
+                    sg_key["sort_reference_electrode_id"] = shank_elect_ref[0]
+                else:
+                    ValueError(
+                        f"Error in electrode group {e_group}: reference "
+                        + "electrodes are not all the same"
+                    )
+            else:
+                if e_group not in references.keys():
+                    raise Exception(
+                        f"electrode group {e_group} not a key in "
+                        + "references, so cannot set reference"
+                    )
+                else:
+                    sg_key["sort_reference_electrode_id"] = references[e_group]
+            # Insert sort group and sort group electrodes
+            reference_electrode_group = electrodes[
+                electrodes["electrode_id"]
+                == sg_key["sort_reference_electrode_id"]
+            ][
+                "electrode_group_name"
+            ]  # reference for this electrode group
+            if len(reference_electrode_group) == 1:  # unpack single reference
+                reference_electrode_group = reference_electrode_group[0]
+            elif (int(sg_key["sort_reference_electrode_id"]) > 0) and (
+                len(reference_electrode_group) != 1
+            ):
+                raise Exception(
+                    "Should have found exactly one electrode group for "
+                    + "reference electrode, but found "
+                    + f"{len(reference_electrode_group)}."
+                )
+            if omit_ref_electrode_group and (
+                str(e_group) == str(reference_electrode_group)
+            ):
+                logger.warn(
+                    f"Omitting electrode group {e_group} from sort groups "
+                    + "because contains reference."
+                )
+                continue
+            shank_elect = electrodes["electrode_id"][
+                np.logical_and(
+                    electrodes["electrode_group_name"] == e_group,
+                    electrodes["probe_shank"] == shank,
+                )
+            ]
+            if (
+                omit_unitrode and len(shank_elect) == 1
+            ):  # omit unitrodes if indicated
+                logger.warn(
+                    f"Omitting electrode group {e_group}, shank {shank} "
+                    + "from sort groups because unitrode."
+                )
+                continue
+            sg_keys.append(sg_key)
+            for elect in shank_elect:
+                sge_key["electrode_id"] = elect
+                sge_keys.append(sge_key.copy())
+            sort_group += 1

--- a/src/spyglass/spikesorting/v0/curation_figurl.py
+++ b/src/spyglass/spikesorting/v0/curation_figurl.py
@@ -194,18 +194,15 @@ def _generate_the_figurl(
 
 
 def _reformat_metrics(metrics: Dict[str, Dict[str, float]]) -> List[Dict]:
-    for metric_name in metrics:
-        metrics[metric_name] = {
-            str(unit_id): metric_value
-            for unit_id, metric_value in metrics[metric_name].items()
-        }
-    new_external_metrics = [
+    return [
         {
             "name": metric_name,
             "label": metric_name,
             "tooltip": metric_name,
-            "data": metric,
+            "data": {
+                str(unit_id): metric_value
+                for unit_id, metric_value in metric.items()
+            },
         }
         for metric_name, metric in metrics.items()
     ]
-    return new_external_metrics

--- a/src/spyglass/spikesorting/v0/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_artifact.py
@@ -164,10 +164,12 @@ def _get_artifact_times(
     **job_kwargs,
 ):
     """Detects times during which artifacts do and do not occur.
-    Artifacts are defined as periods where the absolute value of the recording signal exceeds one
-    or both specified amplitude or zscore thresholds on the proportion of channels specified,
-    with the period extended by the removal_window_ms/2 on each side. Z-score and amplitude
-    threshold values of None are ignored.
+
+    Artifacts are defined as periods where the absolute value of the recording
+    signal exceeds one or both specified amplitude or z-score thresholds on the
+    proportion of channels specified, with the period extended by the
+    removal_window_ms/2 on each side. Z-score and amplitude threshold values of
+    None are ignored.
 
     Parameters
     ----------
@@ -224,8 +226,6 @@ def _get_artifact_times(
     n_jobs = ensure_n_jobs(recording, n_jobs=job_kwargs.get("n_jobs", 1))
     logger.info(f"using {n_jobs} jobs...")
 
-    func = _compute_artifact_chunk
-    init_func = _init_artifact_worker
     if n_jobs == 1:
         init_args = (
             recording,
@@ -242,10 +242,10 @@ def _get_artifact_times(
         )
 
     executor = ChunkRecordingExecutor(
-        recording,
-        func,
-        init_func,
-        init_args,
+        recording=recording,
+        func=_compute_artifact_chunk,
+        init_func=_init_artifact_worker,
+        init_args=init_args,
         verbose=verbose,
         handle_returns=True,
         job_name="detect_artifact_frames",

--- a/src/spyglass/spikesorting/v0/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_recording.py
@@ -21,7 +21,8 @@ from spyglass.common.common_lab import LabTeam  # noqa: F401
 from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session  # noqa: F401
 from spyglass.settings import recording_dir
-from spyglass.utils import SpyglassMixin, logger
+from spyglass.spikesorting.utils import get_group_by_shank
+from spyglass.utils import SpyglassMixin
 from spyglass.utils.dj_helper_fn import dj_replace
 
 schema = dj.schema("spikesorting_recording")
@@ -75,104 +76,15 @@ class SortGroup(SpyglassMixin, dj.Manual):
         """
         # delete any current groups
         (SortGroup & {"nwb_file_name": nwb_file_name}).delete()
-        # get the electrodes from this NWB file
-        electrodes = (
-            Electrode()
-            & {"nwb_file_name": nwb_file_name}
-            & {"bad_channel": "False"}
-        ).fetch()
-        e_groups = list(np.unique(electrodes["electrode_group_name"]))
-        e_groups.sort(key=int)  # sort electrode groups numerically
-        sort_group = 0
-        sg_key = dict()
-        sge_key = dict()
-        sg_key["nwb_file_name"] = sge_key["nwb_file_name"] = nwb_file_name
-        for e_group in e_groups:
-            # for each electrode group, get a list of the unique shank numbers
-            shank_list = np.unique(
-                electrodes["probe_shank"][
-                    electrodes["electrode_group_name"] == e_group
-                ]
-            )
-            sge_key["electrode_group_name"] = e_group
-            # get the indices of all electrodes in this group / shank and set their sorting group
-            for shank in shank_list:
-                sg_key["sort_group_id"] = sge_key["sort_group_id"] = sort_group
-                # specify reference electrode. Use 'references' if passed, otherwise use reference from config
-                if not references:
-                    shank_elect_ref = electrodes[
-                        "original_reference_electrode"
-                    ][
-                        np.logical_and(
-                            electrodes["electrode_group_name"] == e_group,
-                            electrodes["probe_shank"] == shank,
-                        )
-                    ]
-                    if np.max(shank_elect_ref) == np.min(shank_elect_ref):
-                        sg_key["sort_reference_electrode_id"] = shank_elect_ref[
-                            0
-                        ]
-                    else:
-                        ValueError(
-                            f"Error in electrode group {e_group}: reference "
-                            + "electrodes are not all the same"
-                        )
-                else:
-                    if e_group not in references.keys():
-                        raise Exception(
-                            f"electrode group {e_group} not a key in "
-                            + "references, so cannot set reference"
-                        )
-                    else:
-                        sg_key["sort_reference_electrode_id"] = references[
-                            e_group
-                        ]
-                # Insert sort group and sort group electrodes
-                reference_electrode_group = electrodes[
-                    electrodes["electrode_id"]
-                    == sg_key["sort_reference_electrode_id"]
-                ][
-                    "electrode_group_name"
-                ]  # reference for this electrode group
-                if (
-                    len(reference_electrode_group) == 1
-                ):  # unpack single reference
-                    reference_electrode_group = reference_electrode_group[0]
-                elif (int(sg_key["sort_reference_electrode_id"]) > 0) and (
-                    len(reference_electrode_group) != 1
-                ):
-                    raise Exception(
-                        "Should have found exactly one electrode group for "
-                        + "reference electrode, but found "
-                        + f"{len(reference_electrode_group)}."
-                    )
-                if omit_ref_electrode_group and (
-                    str(e_group) == str(reference_electrode_group)
-                ):
-                    logger.warn(
-                        f"Omitting electrode group {e_group} from sort groups "
-                        + "because contains reference."
-                    )
-                    continue
-                shank_elect = electrodes["electrode_id"][
-                    np.logical_and(
-                        electrodes["electrode_group_name"] == e_group,
-                        electrodes["probe_shank"] == shank,
-                    )
-                ]
-                if (
-                    omit_unitrode and len(shank_elect) == 1
-                ):  # omit unitrodes if indicated
-                    logger.warn(
-                        f"Omitting electrode group {e_group}, shank {shank} "
-                        + "from sort groups because unitrode."
-                    )
-                    continue
-                self.insert1(sg_key)
-                for elect in shank_elect:
-                    sge_key["electrode_id"] = elect
-                    self.SortGroupElectrode().insert1(sge_key)
-                sort_group += 1
+
+        sg_keys, sge_keys = get_group_by_shank(
+            nwb_file_name=nwb_file_name,
+            references=references,
+            omit_ref_electrode_group=omit_ref_electrode_group,
+            omit_unitrode=omit_unitrode,
+        )
+        self.insert(sg_keys, skip_duplicates=False)
+        self.SortGroupElectrode().insert(sge_keys, skip_duplicates=False)
 
     def set_group_by_electrode_group(self, nwb_file_name: str):
         """Assign groups to all non-bad channel electrodes based on their electrode group

--- a/src/spyglass/spikesorting/v1/artifact.py
+++ b/src/spyglass/spikesorting/v1/artifact.py
@@ -229,8 +229,7 @@ def _get_artifact_times(
     # detect frames that are above threshold in parallel
     n_jobs = ensure_n_jobs(recording, n_jobs=job_kwargs.get("n_jobs", 1))
     logger.info(f"Using {n_jobs} jobs...")
-    func = _compute_artifact_chunk
-    init_func = _init_artifact_worker
+
     if n_jobs == 1:
         init_args = (
             recording,
@@ -247,10 +246,10 @@ def _get_artifact_times(
         )
 
     executor = ChunkRecordingExecutor(
-        recording,
-        func,
-        init_func,
-        init_args,
+        recording=recording,
+        func=_compute_artifact_chunk,
+        init_func=_init_artifact_worker,
+        init_args=init_args,
         verbose=verbose,
         handle_returns=True,
         job_name="detect_artifact_frames",

--- a/src/spyglass/spikesorting/v1/curation.py
+++ b/src/spyglass/spikesorting/v1/curation.py
@@ -85,7 +85,6 @@ class CurationV1(SpyglassMixin, dj.Manual):
         sort_query = cls & {"sorting_id": sorting_id}
         parent_curation_id = max(parent_curation_id, -1)
         if parent_curation_id == -1:
-            parent_curation_id = -1
             # check to see if this sorting with a parent of -1
             # has already been inserted and if so, warn the user
             query = sort_query & {"parent_curation_id": -1}
@@ -124,10 +123,7 @@ class CurationV1(SpyglassMixin, dj.Manual):
             "merges_applied": apply_merge,
             "description": description,
         }
-        cls.insert1(
-            key,
-            skip_duplicates=True,
-        )
+        cls.insert1(key, skip_duplicates=True)
         AnalysisNwbfile().log(analysis_file_name, table=cls.full_table_name)
 
         return key

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -19,6 +19,8 @@ from spyglass.common.common_interval import (
 )
 from spyglass.common.common_lab import LabTeam
 from spyglass.common.common_nwbfile import AnalysisNwbfile, Nwbfile
+from spyglass.common.common_usage import ActivityLog
+from spyglass.spikesorting.utils import get_group_by_shank
 from spyglass.utils import SpyglassMixin, logger
 
 schema = dj.schema("spikesorting_v1_recording")
@@ -74,106 +76,15 @@ class SortGroup(SpyglassMixin, dj.Manual):
         """
         # delete any current groups
         (SortGroup & {"nwb_file_name": nwb_file_name}).delete()
-        # get the electrodes from this NWB file
-        electrodes = (
-            Electrode()
-            & {"nwb_file_name": nwb_file_name}
-            & {"bad_channel": "False"}
-        ).fetch()
-        e_groups = list(np.unique(electrodes["electrode_group_name"]))
-        e_groups.sort(key=int)  # sort electrode groups numerically
-        sort_group = 0
-        sg_key = dict()
-        sge_key = dict()
-        sg_key["nwb_file_name"] = sge_key["nwb_file_name"] = nwb_file_name
-        for e_group in e_groups:
-            # for each electrode group, get a list of the unique shank numbers
-            shank_list = np.unique(
-                electrodes["probe_shank"][
-                    electrodes["electrode_group_name"] == e_group
-                ]
-            )
-            sge_key["electrode_group_name"] = e_group
-            # get the indices of all electrodes in this group / shank and set their sorting group
-            for shank in shank_list:
-                sg_key["sort_group_id"] = sge_key["sort_group_id"] = sort_group
-                # specify reference electrode. Use 'references' if passed, otherwise use reference from config
-                if not references:
-                    shank_elect_ref = electrodes[
-                        "original_reference_electrode"
-                    ][
-                        np.logical_and(
-                            electrodes["electrode_group_name"] == e_group,
-                            electrodes["probe_shank"] == shank,
-                        )
-                    ]
-                    if np.max(shank_elect_ref) == np.min(shank_elect_ref):
-                        sg_key["sort_reference_electrode_id"] = shank_elect_ref[
-                            0
-                        ]
-                    else:
-                        ValueError(
-                            f"Error in electrode group {e_group}: reference "
-                            + "electrodes are not all the same"
-                        )
-                else:
-                    if e_group not in references.keys():
-                        raise Exception(
-                            f"electrode group {e_group} not a key in "
-                            + "references, so cannot set reference"
-                        )
-                    else:
-                        sg_key["sort_reference_electrode_id"] = references[
-                            e_group
-                        ]
-                # Insert sort group and sort group electrodes
-                reference_electrode_group = electrodes[
-                    electrodes["electrode_id"]
-                    == sg_key["sort_reference_electrode_id"]
-                ][
-                    "electrode_group_name"
-                ]  # reference for this electrode group
-                if (
-                    len(reference_electrode_group) == 1
-                ):  # unpack single reference
-                    reference_electrode_group = reference_electrode_group[0]
-                elif (int(sg_key["sort_reference_electrode_id"]) > 0) and (
-                    len(reference_electrode_group) != 1
-                ):
-                    raise Exception(
-                        "Should have found exactly one electrode group for "
-                        + "reference electrode, but found "
-                        + f"{len(reference_electrode_group)}."
-                    )
-                if omit_ref_electrode_group and (
-                    str(e_group) == str(reference_electrode_group)
-                ):
-                    logger.warn(
-                        f"Omitting electrode group {e_group} from sort groups "
-                        + "because contains reference."
-                    )
-                    continue
-                shank_elect = electrodes["electrode_id"][
-                    np.logical_and(
-                        electrodes["electrode_group_name"] == e_group,
-                        electrodes["probe_shank"] == shank,
-                    )
-                ]
-                if (
-                    omit_unitrode and len(shank_elect) == 1
-                ):  # omit unitrodes if indicated
-                    logger.warn(
-                        f"Omitting electrode group {e_group}, shank {shank} "
-                        + "from sort groups because unitrode."
-                    )
-                    continue
-                cls.insert1(sg_key, skip_duplicates=True)
-                for elect in shank_elect:
-                    sge_key["electrode_id"] = elect
-                    cls.SortGroupElectrode().insert1(
-                        sge_key, skip_duplicates=True
-                    )
-                sort_group += 1
+
+        sg_keys, sge_keys = get_group_by_shank(
+            nwb_file_name=nwb_file_name,
+            references=references,
+            omit_ref_electrode_group=omit_ref_electrode_group,
+            omit_unitrode=omit_unitrode,
+        )
+        cls.insert(sg_keys, skip_duplicates=True)
+        cls.SortGroupElectrode().insert(sge_keys, skip_duplicates=True)
 
 
 @schema

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -19,7 +19,6 @@ from spyglass.common.common_interval import (
 )
 from spyglass.common.common_lab import LabTeam
 from spyglass.common.common_nwbfile import AnalysisNwbfile, Nwbfile
-from spyglass.common.common_usage import ActivityLog
 from spyglass.spikesorting.utils import get_group_by_shank
 from spyglass.utils import SpyglassMixin, logger
 

--- a/src/spyglass/utils/position.py
+++ b/src/spyglass/utils/position.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+
+def convert_to_pixels(data, frame_size=None, cm_to_pixels=1.0):
+    """Converts from cm to pixels and flips the y-axis.
+    Parameters
+    ----------
+    data : ndarray, shape (n_time, 2)
+    frame_size : array_like, shape (2,)
+    cm_to_pixels : float
+
+    Returns
+    -------
+    converted_data : ndarray, shape (n_time, 2)
+    """
+    return data / cm_to_pixels
+
+
+def fill_nan(variable, video_time, variable_time):
+    video_ind = np.digitize(variable_time, video_time[1:])
+
+    n_video_time = len(video_time)
+    try:
+        n_variable_dims = variable.shape[1]
+        filled_variable = np.full((n_video_time, n_variable_dims), np.nan)
+    except IndexError:
+        filled_variable = np.full((n_video_time,), np.nan)
+    filled_variable[video_ind] = variable
+
+    return filled_variable

--- a/tests/common/test_nwbfile.py
+++ b/tests/common/test_nwbfile.py
@@ -30,7 +30,7 @@ def test_add_to_lock(common_nwbfile, lockfile, mini_copy_name):
     with lockfile.open("r") as f:
         assert mini_copy_name in f.read()
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(FileNotFoundError):
         common_nwbfile.Nwbfile.add_to_lock("non-existent-file.nwb")
 
 

--- a/tests/common/test_position.py
+++ b/tests/common/test_position.py
@@ -159,11 +159,12 @@ def test_position_video(position_video, upsample_position):
     assert len(position_video) == 1, "Failed to populate PositionVideo table."
 
 
-def test_convert_to_pixels(position_video):
+def test_convert_to_pixels():
+    from spyglass.utils.position import convert_to_pixels
 
     data = np.array([[2, 4], [6, 8]])
     expect = np.array([[1, 2], [3, 4]])
-    output = position_video.convert_to_pixels(data, "junk", 2)
+    output = convert_to_pixels(data, "junk", 2)
 
     assert np.array_equal(output, expect), "Failed to convert to pixels."
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,9 +276,9 @@ def mini_insert(
 ):
     from spyglass.common import LabMember, Nwbfile, Session  # noqa: E402
     from spyglass.data_import import insert_sessions  # noqa: E402
-    from spyglass.spikesorting.spikesorting_merge import (  # noqa: E402
+    from spyglass.spikesorting.spikesorting_merge import (
         SpikeSortingOutput,
-    )
+    )  # noqa: E402
     from spyglass.utils.nwb_helper_fn import close_nwb_files  # noqa: E402
 
     _ = SpikeSortingOutput()


### PR DESCRIPTION
# Description

This is a tidying PR that aims to (a) merge existing fully duplicated functions, and (b) increase similarity across functions that will be merged in future PRs. The latter is included as an initial step to make sure what I see as similar is intended as such. This includes cases where the newer version of something was improved without giving the same stylistic edits or additional functionality to the old version.

This partially addresses #977, per checklist in most recent comment.

- `common_ephys.py`, B: add spacing/line breaks to reflect updated version
- `common_position.py`, B: Add default value for unused variable. 
- `decoding/utils.py`, A: Common location for `_get_peak_amplitude`. Updated V0 to pass the waveform extractor instead of waveform
- `decoding/v0/`
  - A: Migrate funcs to V0 utils
    - `discretize_and_trim`
    - `get_time_bins_from_interval`
    - `make_default_decoding_params` - required some additional control-flow for cpu/gpu and clusterless/spikes.
  - B: Add comments/spacing to `get_X_data`
- `decoding/v1/`
  - `clusterless`, B: add `track_graph` and `time_slice` params/functionality
  - migrate out subfunc for `get_orientation_name`
- `linearization/v1/main`, B: make table definition comments/spacing like V0 def 
- `position/v1/dlc_utils`, A: import funcs from `common`
- `ripple/v1/ripple`, A: import func from prev version
- `spikesorting_merge`, B: add smoothing sigma param with default
- other Bs: Adjust to look like match
  - `spikesorting_curation`
  - `spikesorting/v1/curation`
  - `spikesorting/v1/recording`
- `spikesorting/utils.py`, A: Extracting core logic of `set_group_by_shank` into a function that returns insert candidates for parent functions to run. Internal logic otherwise the same
- `spikesorting/v0/curation_figurl`, B: Updated to reflect V1 version that uses comprehension over for loops
- `spikesorting/vX/artifact`, B: Reflow of docstring, migrate variable reassignment to within `ChunkRecordingExecutor` call.

Other changes:

- `decoding_merge`: removed unused import
- `decoding/v1/core`: remove reference to undefined variable in error message
- See comments about...
  - linearization: potential removal of `get_networkx` methods
  - spikesorting_merge: lack of a check for ndim==1 compared to alternate version

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a If table edits, I have included an `alter` snippet for release notes.
- [X] No. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a I have added/edited docs/notebooks to reflect the changes
