### PR TITLE
Quick fix for parralel populate and spike unit naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ PositionGroup.alter()
 - Expand `delete_downstream_merge` -> `delete_downstream_parts`. #1002
 - `cautious_delete` now checks `IntervalList` and externals tables. #1002
 - Allow mixin tables with parallelization in `make` to run populate with
-    `processes > 1` #1001
+    `processes > 1` #1001, #1052
 - Speed up fetch_nwb calls through merge tables #1017
 - Allow `ModuleNotFoundError` or `ImportError` for optional dependencies #1023
 - Ensure integrity of group tables #1026
@@ -75,7 +75,7 @@ PositionGroup.alter()
     - Fix bug in identification of artifact samples to be zeroed out in
         `spikesorting.v1.SpikeSorting` #1009
     - Remove deprecated dependencies on kachery_client #1014
-    - Add `UnitAnnotation` table and naming convention for units #1027
+    - Add `UnitAnnotation` table and naming convention for units #1027, #1052
 
 ## [0.5.2] (April 22, 2024)
 

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -289,7 +289,6 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
         )
 
 
-@staticmethod
 def _get_spike_obj_name(nwb_file, allow_empty=False):
     nwb_field_name = (
         "object_id"

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -708,6 +708,7 @@ class SpyglassMixin:
         # Pass through to super if not parallel in the make function or only a single process
         processes = kwargs.pop("processes", 1)
         if processes == 1 or not self._parallel_make:
+            kwargs["processes"] = processes
             return super().populate(*restrictions, **kwargs)
 
         # If parallel in both make and populate, use non-daemon processes


### PR DESCRIPTION
# Description
Quick fixes

- Fix bug from #1001 that prevented parallel populate processes on tables with `_parallel_make = False`
- Fix bug from #1027 
    - during review, I moved `_get_spike_obj_name` from a class method to separate function
    - this pr removes leftover `static_method` decorator

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [X] N This PR should be accompanied by a release: (yes/no/unsure)
- [X]  N/A If release, I have updated the `CITATION.cff`
- [X] N This PR makes edits to table definitions: (yes/no)
- [X] N/A If table edits, I have included an `alter` snippet for release notes.
- [X] N/A If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/AI have added/edited docs/notebooks to reflect the changes
