### PR TITLE
Revise get_group_by_shank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ PositionGroup.alter()
 - Allow `ModuleNotFoundError` or `ImportError` for optional dependencies #1023
 - Ensure integrity of group tables #1026
 - Convert list of LFP artifact removed interval list to array #1046
-- Merge duplicate functions in decoding and spikesorting #1050
+- Merge duplicate functions in decoding and spikesorting #1050, #1052
 - Revise docs organization.
     - Misc -> Features/ForDevelopers. #1029
     - Installation instructions -> Setup notebook. #1029
@@ -88,6 +88,7 @@ PositionGroup.alter()
     - Add `UnitAnnotation` table and naming convention for units #1027, #1052
     - Set `sparse` parameter to waveform extraction step in `spikesorting.v1`
         #1039
+
 ## [0.5.2] (April 22, 2024)
 
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ PositionGroup.alter()
 - Migrate `pip` dependencies from `environment.yml`s to `pyproject.toml` #966
 - Add documentation for common error messages #997
 - Expand `delete_downstream_merge` -> `delete_downstream_parts`. #1002
-- `cautious_delete` now checks `IntervalList` and externals tables. #1002
+- `cautious_delete` now ...
+    - Checks `IntervalList` and externals tables. #1002
+    - Ends early if called on empty table. #1055
 - Allow mixin tables with parallelization in `make` to run populate with
     `processes > 1` #1001, #1052
 - Speed up fetch_nwb calls through merge tables #1017

--- a/src/spyglass/spikesorting/utils.py
+++ b/src/spyglass/spikesorting/utils.py
@@ -45,12 +45,11 @@ def get_group_by_shank(
     e_groups.sort(key=int)  # sort electrode groups numerically
 
     sort_group = 0
-    sg_keys = list()
-    sge_keys = list()
+    sg_keys, sge_keys = list(), list()
     for e_group in e_groups:
-        sg_key = dict()
-        sge_key = dict()
+        sg_key, sge_key = dict(), dict()
         sg_key["nwb_file_name"] = sge_key["nwb_file_name"] = nwb_file_name
+
         # for each electrode group, get a list of the unique shank numbers
         shank_list = np.unique(
             electrodes["probe_shank"][
@@ -58,73 +57,77 @@ def get_group_by_shank(
             ]
         )
         sge_key["electrode_group_name"] = e_group
-        # get the indices of all electrodes in this group / shank and set their sorting group
+
+        # get the indices of all electrodes in this group / shank and set their
+        # sorting group
         for shank in shank_list:
             sg_key["sort_group_id"] = sge_key["sort_group_id"] = sort_group
-            # specify reference electrode. Use 'references' if passed, otherwise use reference from config
-            if not references:
-                shank_elect_ref = electrodes["original_reference_electrode"][
-                    np.logical_and(
-                        electrodes["electrode_group_name"] == e_group,
-                        electrodes["probe_shank"] == shank,
+
+            match_names_bool = np.logical_and(
+                electrodes["electrode_group_name"] == e_group,
+                electrodes["probe_shank"] == shank,
+            )
+
+            if references:  # Use 'references' if passed
+                sort_ref_id = references.get(e_group, None)
+                if not sort_ref_id:
+                    raise Exception(
+                        f"electrode group {e_group} not a key in "
+                        + "references, so cannot set reference"
                     )
+            else:  # otherwise use reference from config
+                shank_elect_ref = electrodes["original_reference_electrode"][
+                    match_names_bool
                 ]
                 if np.max(shank_elect_ref) == np.min(shank_elect_ref):
-                    sg_key["sort_reference_electrode_id"] = shank_elect_ref[0]
+                    sort_ref_id = shank_elect_ref[0]
                 else:
                     ValueError(
                         f"Error in electrode group {e_group}: reference "
                         + "electrodes are not all the same"
                     )
-            else:
-                if e_group not in references.keys():
-                    raise Exception(
-                        f"electrode group {e_group} not a key in "
-                        + "references, so cannot set reference"
-                    )
-                else:
-                    sg_key["sort_reference_electrode_id"] = references[e_group]
+            sg_key["sort_reference_electrode_id"] = sort_ref_id
+
             # Insert sort group and sort group electrodes
-            reference_electrode_group = electrodes[
-                electrodes["electrode_id"]
-                == sg_key["sort_reference_electrode_id"]
-            ][
-                "electrode_group_name"
-            ]  # reference for this electrode group
-            if len(reference_electrode_group) == 1:  # unpack single reference
-                reference_electrode_group = reference_electrode_group[0]
-            elif (int(sg_key["sort_reference_electrode_id"]) > 0) and (
-                len(reference_electrode_group) != 1
-            ):
+            match_elec = electrodes[electrodes["electrode_id"] == sort_ref_id]
+            ref_elec_group = match_elec["electrode_group_name"]  # group ref
+
+            n_ref_groups = len(ref_elec_group)
+            if n_ref_groups == 1:  # unpack single reference
+                ref_elec_group = ref_elec_group[0]
+            elif int(sort_ref_id) > 0:  # multiple references
                 raise Exception(
                     "Should have found exactly one electrode group for "
-                    + "reference electrode, but found "
-                    + f"{len(reference_electrode_group)}."
+                    + f"reference electrode, but found {n_ref_groups}."
                 )
+
             if omit_ref_electrode_group and (
-                str(e_group) == str(reference_electrode_group)
+                str(e_group) == str(ref_elec_group)
             ):
                 logger.warn(
                     f"Omitting electrode group {e_group} from sort groups "
                     + "because contains reference."
                 )
                 continue
-            shank_elect = electrodes["electrode_id"][
-                np.logical_and(
-                    electrodes["electrode_group_name"] == e_group,
-                    electrodes["probe_shank"] == shank,
-                )
-            ]
-            if (
-                omit_unitrode and len(shank_elect) == 1
-            ):  # omit unitrodes if indicated
+            shank_elect = electrodes["electrode_id"][match_names_bool]
+
+            # omit unitrodes if indicated
+            if omit_unitrode and len(shank_elect) == 1:
                 logger.warn(
                     f"Omitting electrode group {e_group}, shank {shank} "
                     + "from sort groups because unitrode."
                 )
                 continue
+
             sg_keys.append(sg_key)
-            for elect in shank_elect:
-                sge_key["electrode_id"] = elect
-                sge_keys.append(sge_key.copy())
+            sge_keys.extend(
+                [
+                    {
+                        **sge_key,
+                        "electrode_id": elect,
+                    }
+                    for elect in shank_elect
+                ]
+            )
             sort_group += 1
+    return sg_keys, sge_keys

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -652,6 +652,11 @@ class SpyglassMixin:
             Passed to datajoint.table.Table.delete.
         """
         start = time()
+
+        if len(self) == 0:
+            logger.warning(f"Table is empty. No need to delete.\n{self}")
+            return
+
         external, IntervalList = self._delete_deps[3], self._delete_deps[4]
 
         if not force_permission or dry_run:


### PR DESCRIPTION
# Description

Streamlines logic of `get_group_by_shank` and adds missing returns #1054 

# Checklist:

- [x] No. This PR should be accompanied by a release: (yes/no/unsure)
- [x] N/a. If release, I have updated the `CITATION.cff`
- [x] No. This PR makes edits to table definitions: (yes/no)
- [x] N/a. If table edits, I have included an `alter` snippet for release notes.
- [x] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] N/a. I have added/edited docs/notebooks to reflect the changes
