### PR TITLE
#1053 bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ PositionGroup.alter()
 - Allow `ModuleNotFoundError` or `ImportError` for optional dependencies #1023
 - Ensure integrity of group tables #1026
 - Convert list of LFP artifact removed interval list to array #1046
-- Merge duplicate functions in decoding and spikesorting #1050, #1053
+- Merge duplicate functions in decoding and spikesorting #1050, #1053, #1058
 - Revise docs organization.
     - Misc -> Features/ForDevelopers. #1029
     - Installation instructions -> Setup notebook. #1029

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -35,7 +35,7 @@ PERIPHERAL_TABLES = [
 
 
 def ensure_names(
-    self, table: Union[str, Table, Iterable] = None
+    table: Union[str, Table, Iterable] = None
 ) -> Union[str, List[str], None]:
     """Ensure table is a string."""
     if table is None:


### PR DESCRIPTION
# Description

`ensure_names` was generalized to a utils helper without removing the `self` arg, inadvertently always returning `None`

# Checklist:

- [x] No. This PR should be accompanied by a release: (yes/no/unsure)
- [x] N/a. If release, I have updated the `CITATION.cff`
- [x] No. This PR makes edits to table definitions: (yes/no)
- [x] N/a. If table edits, I have included an `alter` snippet for release notes.
- [x] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] N/a. I have added/edited docs/notebooks to reflect the changes
