### PR TITLE
Allow disable transaction for select populates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ PositionGroup.alter()
     - Misc -> Features/ForDevelopers. #1029
     - Installation instructions -> Setup notebook. #1029
 - Migrate SQL export tools to `utils` to support exporting `DandiPath` #1048
+- Disable populate transaction protection for long-populating tables #1066
 
 ### Pipelines
 

--- a/docs/src/Features/Mixin.md
+++ b/docs/src/Features/Mixin.md
@@ -188,3 +188,33 @@ nwbfile = Nwbfile()
 (nwbfile & "nwb_file_name LIKE 'Name%'").ddp(dry_run=False)
 (nwbfile & "nwb_file_name LIKE 'Other%'").ddp(dry_run=False)
 ```
+
+## Populate Calls
+
+The mixin also overrides the default `populate` function to provide additional
+functionality for non-daemon process pools and disabling transaction protection.
+
+### Non-Daemon Process Pools
+
+To allow the `make` function to spawn a new process pool, the mixin overrides
+the default `populate` function for tables with `_parallel_make` set to `True`.
+See [issue #1000](https://github.com/LorenFrankLab/spyglass/issues/1000) and
+[PR #1001](https://github.com/LorenFrankLab/spyglass/pull/1001) for more
+information.
+
+### Disable Transaction Protection
+
+By default, DataJoint wraps the `populate` function in a transaction to ensure
+data integrity (see
+[Transactions](https://docs.datajoint.io/python/definition/05-Transactions.html)).
+
+This can cause issues when populating large tables if another user attempts to
+declare/modify a table while the transaction is open (see
+[issue #1030](https://github.com/LorenFrankLab/spyglass/issues/1030) and
+[DataJoint issue #1170](https://github.com/datajoint/datajoint-python/issues/1170)).
+
+Tables with `_use_transaction` set to `False` will not be wrapped in a
+transaction when calling `populate`. Transaction protection is replaced by a
+hash of upstream data to ensure no changes are made to the table during the
+unprotected populate. The additional time required to hash the data is a
+trade-off for already time-consuming populates, but avoids blocking other users.

--- a/src/spyglass/position/v1/position_dlc_training.py
+++ b/src/spyglass/position/v1/position_dlc_training.py
@@ -104,7 +104,7 @@ class DLCModelTraining(SpyglassMixin, dj.Computed):
     """
 
     log_path = None
-    _use_transaction = False
+    _use_transaction, _allow_insert = False, True
 
     # To continue from previous training snapshot,
     # devs suggest editing pose_cfg.yml

--- a/src/spyglass/position/v1/position_dlc_training.py
+++ b/src/spyglass/position/v1/position_dlc_training.py
@@ -102,7 +102,9 @@ class DLCModelTraining(SpyglassMixin, dj.Computed):
     latest_snapshot: int unsigned # latest exact snapshot index (i.e., never -1)
     config_template: longblob     # stored full config file
     """
+
     log_path = None
+    _use_transaction = False
 
     # To continue from previous training snapshot,
     # devs suggest editing pose_cfg.yml

--- a/src/spyglass/spikesorting/v1/figurl_curation.py
+++ b/src/spyglass/spikesorting/v1/figurl_curation.py
@@ -117,6 +117,8 @@ class FigURLCuration(SpyglassMixin, dj.Computed):
     url: varchar(1000)
     """
 
+    _use_transaction = False
+
     def make(self, key: dict):
         # FETCH
         query = (

--- a/src/spyglass/spikesorting/v1/figurl_curation.py
+++ b/src/spyglass/spikesorting/v1/figurl_curation.py
@@ -117,7 +117,7 @@ class FigURLCuration(SpyglassMixin, dj.Computed):
     url: varchar(1000)
     """
 
-    _use_transaction = False
+    _use_transaction, _allow_insert = False, True
 
     def make(self, key: dict):
         # FETCH

--- a/src/spyglass/spikesorting/v1/metric_curation.py
+++ b/src/spyglass/spikesorting/v1/metric_curation.py
@@ -203,6 +203,8 @@ class MetricCuration(SpyglassMixin, dj.Computed):
     object_id: varchar(40) # Object ID for the metrics in NWB file
     """
 
+    _use_transaction = False
+
     def make(self, key):
         AnalysisNwbfile()._creation_times["pre_create_time"] = time()
         # FETCH

--- a/src/spyglass/spikesorting/v1/metric_curation.py
+++ b/src/spyglass/spikesorting/v1/metric_curation.py
@@ -203,7 +203,7 @@ class MetricCuration(SpyglassMixin, dj.Computed):
     object_id: varchar(40) # Object ID for the metrics in NWB file
     """
 
-    _use_transaction = False
+    _use_transaction, _allow_insert = False, True
 
     def make(self, key):
         AnalysisNwbfile()._creation_times["pre_create_time"] = time()

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -144,7 +144,7 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
     time_of_sort: int               # in Unix time, to the nearest second
     """
 
-    _use_transaction = False
+    _use_transaction, _allow_insert = False, True
 
     def make(self, key: dict):
         """Runs spike sorting on the data and parameters specified by the

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -144,6 +144,8 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
     time_of_sort: int               # in Unix time, to the nearest second
     """
 
+    _use_transaction = False
+
     def make(self, key: dict):
         """Runs spike sorting on the data and parameters specified by the
         SpikeSortingSelection table and inserts a new entry to SpikeSorting table.

--- a/src/spyglass/utils/dj_graph.py
+++ b/src/spyglass/utils/dj_graph.py
@@ -615,7 +615,7 @@ class RestrGraph(AbstractGraph):
         """Return hash of all visited nodes."""
         initial = hash_md5(b"")
         for table in self.all_ft:
-            initial.update(table.fetch().tobytes())
+            initial.update(table.fetch())
         return initial.hexdigest()
 
     # ------------------------------- Add Nodes -------------------------------

--- a/src/spyglass/utils/dj_graph.py
+++ b/src/spyglass/utils/dj_graph.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from enum import Enum
 from functools import cached_property
+from hashlib import md5 as hash_md5
 from itertools import chain as iter_chain
 from typing import Any, Dict, Iterable, List, Set, Tuple, Union
 
@@ -608,6 +609,14 @@ class RestrGraph(AbstractGraph):
     def leaf_ft(self):
         """Get restricted FreeTables from graph leaves."""
         return [self._get_ft(table, with_restr=True) for table in self.leaves]
+
+    @property
+    def hash(self):
+        """Return hash of all visited nodes."""
+        initial = hash_md5(b"")
+        for table in self.all_ft:
+            initial.update(table.fetch().tobytes())
+        return initial.hexdigest()
 
     # ------------------------------- Add Nodes -------------------------------
 

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -497,7 +497,8 @@ def make_file_obj_id_unique(nwb_path: str):
 def populate_pass_function(value):
     """Pass function for parallel populate.
 
-    Note: To avoid pickling errors, the table must be passed by class, NOT by instance.
+    Note: To avoid pickling errors, the table must be passed by class,
+        NOT by instance.
     Note: This function must be defined in the global namespace.
 
     Parameters

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -795,9 +795,10 @@ class SpyglassMixin:
                 for key in keys:
                     self.make(key)
                 if upstream_hash != self._hash_upstream(keys):
-                    raise RuntimeError(
-                        "Upstream tables have changed during populate. "
-                        + "PLEASE DELETE AND REPOPULATE."
+                    (self & keys).delete(force=True)
+                    logger.error(
+                        "Upstream tables changed during non-transaction "
+                        + "populate. Please try again."
                     )
                 return
 

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -774,8 +774,9 @@ class SpyglassMixin:
                 + f"Table default transaction use: {self._use_transaction}"
             )
 
-        keys = [True]  # Get keys to pop, needed for no-transact or parallel
-        if use_transact is False or processes > 1 or self._parallel_make:
+        # Get keys, needed for no-transact or multi-process w/_parallel_make
+        keys = [True]
+        if use_transact is False or (processes > 1 and self._parallel_make):
             keys = (self._jobs_to_do(restrictions) - self.target).fetch(
                 "KEY", limit=kwargs.get("limit", None)
             )


### PR DESCRIPTION
# Description

To address issues discussed in #1030, this PR allows the disabling of transaction protection.
This sacrifices full data integrity protection in order to avoid the bottleneck

# Checklist:

- [x] No. This PR should be accompanied by a release: (yes/no/unsure)
- [x] N/a. If release, I have updated the `CITATION.cff`
- [x] No. This PR makes edits to table definitions: (yes/no)
- [x] N/a. If table edits, I have included an `alter` snippet for release notes.
- [x] No. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
