### PR TITLE
fix fetch efficiency in insert_curation

### DIFF
--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -145,7 +145,7 @@ class Curation(SpyglassMixin, dj.Manual):
         Curation.insert1(sorting_key, skip_duplicates=True)
 
         # get the primary key for this curation
-        c_key = Curation.fetch("KEY")[0]
+        c_key = (Curation & sorting_key).fetch1("KEY")
         curation_key = {item: sorting_key[item] for item in c_key}
 
         return curation_key


### PR DESCRIPTION
# Description

Quickfix for 1070.  Not a breaking bug but made unnecessary fetch of full `v0.Curation` tables (currently has ~10^5 entries). instead only fetch and return key of interest.

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] NO This PR should be accompanied by a release: (yes/no/unsure)
- [ ] NA If release, I have updated the `CITATION.cff`
- [ ] NO This PR makes edits to table definitions: (yes/no)
- [ ] NA If table edits, I have included an `alter` snippet for release notes.
- [ ] NA If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] NA I have added/edited docs/notebooks to reflect the changes
