### PR TITLE
Decode fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ PositionGroup.alter()
     - Default values for classes on `ImportError` #966
     - Add option to upsample data rate in `PositionGroup` #1008
     - Avoid interpolating over large `nan` intervals in position #1033
+    - Minor code calling corrections #1073
 
 - Position
 

--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -57,6 +57,11 @@ class UnitWaveformFeaturesGroup(SpyglassMixin, dj.Manual):
             "nwb_file_name": nwb_file_name,
             "waveform_features_group_name": group_name,
         }
+        if self & group_key:
+            raise ValueError(
+                f"Group {nwb_file_name}: {group_name} already exists",
+                "please delete the group before creating a new one",
+            )
         self.insert1(
             group_key,
             skip_duplicates=True,

--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -533,7 +533,7 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
         classifier = self.fetch_model()
         posterior = (
             self.fetch_results()
-            .acausal_posterior(time=time_slice)
+            .acausal_posterior.sel(time=time_slice)
             .squeeze()
             .unstack("state_bins")
             .sum("state")

--- a/src/spyglass/spikesorting/v0/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_recording.py
@@ -366,7 +366,7 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             & key
         ).fetch1(
             "nwb_file_name",
-            "sort_interval",
+            "sort_interval_name",
             "preproc_params",
             "interval_list_name",
         )

--- a/src/spyglass/spikesorting/v0/spikesorting_sorting.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_sorting.py
@@ -213,7 +213,7 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
             detected_spikes = detect_peaks(recording, **sorter_params)
             sorting = si.NumpySorting.from_times_labels(
                 times_list=detected_spikes["sample_index"],
-                labels_list=np.zeros(len(detected_spikes), dtype=np.int),
+                labels_list=np.zeros(len(detected_spikes), dtype=np.int32),
                 sampling_frequency=recording.get_sampling_frequency(),
             )
         else:

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -240,7 +240,7 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
             detected_spikes = detect_peaks(recording, **sorter_params)
             sorting = si.NumpySorting.from_times_labels(
                 times_list=detected_spikes["sample_index"],
-                labels_list=np.zeros(len(detected_spikes), dtype=np.int),
+                labels_list=np.zeros(len(detected_spikes), dtype=np.int32),
                 sampling_frequency=recording.get_sampling_frequency(),
             )
         else:


### PR DESCRIPTION
# Description

Minor fixes in decode and spikesorting function calls
- fixes #1071 
    - fetch `sort_interval_name` instead of `sort_interval`
- fixes #1047 
    - Add check to `UnitWaveformFeaturesGroup.create_group` to avoid adding new parts to existing group
-  fix time slicing call in `ClusterlessDecodingV1.get_ahead_behind_distance`
- replace `np.int` with `np.int32` for future compatability 


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] No This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] No This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
