### PR TITLE
Prevent error from unitless spike group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [0.5.4] (Unreleased)
+
+### Release Notes
+
+<!-- Running draft to be removed immediately prior to release. -->
+
+### Infrastructure
+
+### Pipelines
+
+- Decoding
+    - Fix edge case errors in spike time loading #1083
+
 ## [0.5.3] (August 27, 2024)
 
 ### Infrastructure

--- a/src/spyglass/decoding/v1/waveform_features.py
+++ b/src/spyglass/decoding/v1/waveform_features.py
@@ -152,9 +152,12 @@ class UnitWaveformFeatures(SpyglassMixin, dj.Computed):
                 sorter,
             )
 
-        spike_times = SpikeSortingOutput().fetch_nwb(merge_key)[0][
-            analysis_nwb_key
-        ]["spike_times"]
+        nwb = SpikeSortingOutput().fetch_nwb(merge_key)[0]
+        spike_times = (
+            nwb[analysis_nwb_key]["spike_times"]
+            if analysis_nwb_key in nwb
+            else pd.DataFrame()
+        )
 
         (
             key["analysis_file_name"],
@@ -349,6 +352,8 @@ def _write_waveform_features_to_nwb(
                     metric_dict[unit_id] if unit_id in metric_dict else []
                     for unit_id in unit_ids
                 ]
+                if not metric_values:
+                    metric_values = np.array([]).astype(np.float32)
                 nwbf.add_unit_column(
                     name=metric,
                     description=metric,

--- a/src/spyglass/spikesorting/spikesorting_merge.py
+++ b/src/spyglass/spikesorting/spikesorting_merge.py
@@ -4,9 +4,9 @@ from datajoint.utils import to_camel_case
 from ripple_detection import get_multiunit_population_firing_rate
 
 from spyglass.spikesorting.imported import ImportedSpikeSorting  # noqa: F401
-from spyglass.spikesorting.v0.spikesorting_curation import (
+from spyglass.spikesorting.v0.spikesorting_curation import (  # noqa: F401
     CuratedSpikeSorting,
-)  # noqa: F401
+)
 from spyglass.spikesorting.v1 import ArtifactDetectionSelection  # noqa: F401
 from spyglass.spikesorting.v1 import (
     CurationV1,
@@ -210,7 +210,7 @@ class SpikeSortingOutput(_Merge, SpyglassMixin):
         """
         time = np.asarray(time)
         min_time, max_time = time[[0, -1]]
-        spike_times = cls.fetch_spike_data(key)  # CB: This is undefined.
+        spike_times = (cls & key).get_spike_times(key)
         spike_indicator = np.zeros((len(time), len(spike_times)))
 
         for ind, times in enumerate(spike_times):


### PR DESCRIPTION
# Description

fixes #1082 
- prevents key errors when extracting `UnitWaveformFeatures` from a curated sorting with no units

fixes #1077 
- correct call to `get_spike_times` in `SpikeSortingOutput.get_spike_indicator`

# Checklist:

- [x] No This PR should be accompanied by a release: (yes/no/unsure)
- [x] NAIf release, I have updated the `CITATION.cff`
- [x] No This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
