### PR TITLE
Update common_ephys.py to handle nan in from raw data timestamps

### DIFF
--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -812,6 +812,10 @@ class LFPBand(SpyglassMixin, dj.Computed):
         # load in the timestamps
         timestamps = np.asarray(lfp_object.timestamps)
 
+        # leave nan timestamps out. Raw nwb files can have small amount (a couple samples) of nan.
+        notnan_mask = ~np.isnan(timestamps)
+        timestamps = timestamps[notnan_mask]
+
         # get the indices of the first timestamp and the last timestamp that
         # are within the valid times
         included_indices = interval_list_contains_ind(
@@ -826,8 +830,9 @@ class LFPBand(SpyglassMixin, dj.Computed):
         timestamps = timestamps[included_indices[0] : included_indices[-1]]
 
         # load all the data to speed filtering
+        lfp_object_data = lfp_object.data[notnan_mask,:]
         lfp_data = np.asarray(
-            lfp_object.data[included_indices[0] : included_indices[-1], :],
+            lfp_object_data[included_indices[0] : included_indices[-1], :],
             dtype=type(lfp_object.data[0][0]),
         )
 


### PR DESCRIPTION
# Description

Raw nwb file, sampled in 30000 Hz, can occationally have nan in timestamps. NaNs in timestamps mess up LFP band pass filtering. It is still unknown whether NaN's are there in the raw recording or the NaN's are introduced when converting recording files to nwb. For now, it is determined that Raw() nwb file contains a small number of NaN in timestamps. Files to investigate: eliot20221017, eliot20221024. (In both files exactly 1 data point is NaN)


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [yes] This PR should be accompanied by a release: (yes/no/unsure)
- [no] If release, I have updated the `CITATION.cff`
- [no] This PR makes edits to table definitions: (yes/no)
- [ ] If table edits, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [no] I have updated the `CHANGELOG.md` with PR number and description.
- [no] I have added/edited docs/notebooks to reflect the changes
