### PR TITLE
Add edge map parameter to track linearization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 <!-- Running draft to be removed immediately prior to release. -->
 
 ```python
-from spyglass.example import Table
-Table.alter() # Comment regarding the change
+from spyglass.linearization.v1.main import TrackGraph
+TrackGraph.alter() # Comment regarding the change
 ```
 
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 <!-- Running draft to be removed immediately prior to release. -->
 
+```python
+from spyglass.example import Table
+Table.alter() # Comment regarding the change
+```
+
 ### Infrastructure
 
 - Disable populate transaction protection for long-populating tables #1066
@@ -16,6 +21,8 @@
 
 - Decoding
     - Fix edge case errors in spike time loading #1083
+- Linearization
+    - Add edge_map parameter to LinearizedPositionV1 #1091
 
 ## [0.5.3] (August 27, 2024)
 

--- a/src/spyglass/linearization/v1/main.py
+++ b/src/spyglass/linearization/v1/main.py
@@ -49,6 +49,7 @@ class TrackGraph(SpyglassMixin, dj.Manual):
     edges: blob                # shape (n_edges, 2)
     linear_edge_order : blob   # order of edges in linear space, (n_edges, 2)
     linear_edge_spacing : blob # space btwn edges in linear space, (n_edges,)
+    edge_map = NULL : blob     # Maps one edge to another before linearization
     """
 
     def get_networkx_track_graph(self, track_graph_parameters=None):
@@ -58,6 +59,7 @@ class TrackGraph(SpyglassMixin, dj.Manual):
         return make_track_graph(
             node_positions=track_graph_parameters["node_positions"],
             edges=track_graph_parameters["edges"],
+            edge_map=track_graph_parameters["edge_map"],
         )
 
     def plot_track_graph(self, ax=None, draw_edge_labels=False, **kwds):


### PR DESCRIPTION
# Description
 
V0 had a parameter for edge_map in the track linearization but V1 does not. The edge_map allows the user to combine linear edges in the 1D space.

# Checklist:

- [x] This PR should be accompanied by a release: (yes/**no**/unsure)
- [x] If release, I have updated the `CITATION.cff`
- [x] This PR makes edits to table definitions: (**yes**/no)
- [x] If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
