### PR TITLE
Fix #1094

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@
 ### Pipelines
 
 - Decoding
+
     - Fix edge case errors in spike time loading #1083
+
+- Spike Sorting
+
+    - Fix bug in `get_group_by_shank` #1095
 
 ## [0.5.3] (August 27, 2024)
 

--- a/src/spyglass/spikesorting/utils.py
+++ b/src/spyglass/spikesorting/utils.py
@@ -123,7 +123,7 @@ def get_group_by_shank(
                 )
                 continue
 
-            sg_keys.append(sg_key)
+            sg_keys.append(sg_key.copy())
             sge_keys.extend(
                 [
                     {


### PR DESCRIPTION
# Description

#1050 migrated from a for-loop-insert pattern to a for-loop-append pattern, but did not check whether or not the appended list was edited in subsequent iterations.

```python
# insert pattern
for item in my_list: 
    item.update(other_data)
    tbl.insert1(item)

# append pattern
inserts = []
for item in my_list:
    item.update(other_data)
    inserts.append(my_func(item))
tbl.insert(inserts)
```

The former inserts the data as-is, preventing subsequent loop iterations from changing in-memory values. The latter reduces database calls to speed up the process and prevent inserts in the event a later iteration fails, but is susceptible to later iterations doing in memory manipulations of the previous insert. Making sure to append `item.copy()` fixes this issue.

While this bug is present in a release, using the bugged version will result in the error shown in #1094 - integrity error because the part table will refer to a non-existent master. `sg_keys` is susceptible to this effect, but not `sge_keys` as the `sge_key` is decomposed with `**` when appended to the inserts list.

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [ ] N/a. If release, I have updated the `CITATION.cff`
- [ ] No. This PR makes edits to table definitions: (yes/no)
- [ ] N/a. If table edits, I have included an `alter` snippet for release notes.
- [ ] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] N/a. I have added/edited docs/notebooks to reflect the changes
