### PR TITLE
Fix 1080

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Spike Sorting
 
     - Fix bug in `get_group_by_shank` #1096
+    - Fix bug in `_compute_metric` #1099
 
 ## [0.5.3] (August 27, 2024)
 

--- a/src/spyglass/spikesorting/utils.py
+++ b/src/spyglass/spikesorting/utils.py
@@ -38,6 +38,7 @@ def get_group_by_shank(
     omit_unitrode : bool
         Optional. If True, no sort groups are defined for unitrodes.
     """
+    print("Run new")
     # get the electrodes from this NWB file
     electrodes = (
         Electrode()

--- a/src/spyglass/spikesorting/utils.py
+++ b/src/spyglass/spikesorting/utils.py
@@ -38,7 +38,6 @@ def get_group_by_shank(
     omit_unitrode : bool
         Optional. If True, no sort groups are defined for unitrodes.
     """
-    print("Run new")
     # get the electrodes from this NWB file
     electrodes = (
         Electrode()

--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -581,7 +581,7 @@ class QualityMetrics(SpyglassMixin, dj.Computed):
 
         peak_sign_metrics = ["snr", "peak_offset", "peak_channel"]
         if metric_name == "isi_violation":
-            metric = metric_func(waveform_extractor, **metric_params)
+            return metric_func(waveform_extractor, **metric_params)
         elif metric_name in peak_sign_metrics:
             if "peak_sign" not in metric_params:
                 raise Exception(


### PR DESCRIPTION
# Description

#1053 made an edit to `_compute_metric` control flow anticipating an early return, but instead allowed `isi_violation` to be recomputed for each unit. This is present in the most recent release, but will result in failed saving, as shown in #1080, because the embedded dictionary will not be able to save to json

# Checklist:

- [x] No. This PR should be accompanied by a release: (yes/no/unsure)
- [x] N/a. If release, I have updated the `CITATION.cff`
- [x] No. This PR makes edits to table definitions: (yes/no)
- [x] N/a. If table edits, I have included an `alter` snippet for release notes.
- [x] No. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] N/a. I have added/edited docs/notebooks to reflect the changes
