### PR TITLE
Fix #1098

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
     - Fix edge case errors in spike time loading #1083
 
+- Position
+
+    - Restore #973, allow DLC without position tracking #1100
+
 - Spike Sorting
 
     - Fix bug in `get_group_by_shank` #1096

--- a/src/spyglass/position/v1/position_dlc_orient.py
+++ b/src/spyglass/position/v1/position_dlc_orient.py
@@ -15,7 +15,7 @@ from spyglass.position.v1.dlc_utils import (
     red_led_bisector_orientation,
     two_pt_head_orientation,
 )
-from spyglass.utils import SpyglassMixin, logger
+from spyglass.utils import SpyglassMixin
 
 from .position_dlc_cohort import DLCSmoothInterpCohort
 

--- a/src/spyglass/position/v1/position_dlc_pose_estimation.py
+++ b/src/spyglass/position/v1/position_dlc_pose_estimation.py
@@ -258,16 +258,19 @@ class DLCPoseEstimation(SpyglassMixin, dj.Computed):
                 populate_missing=False,
             )
         )
-        spatial_series = (
-            RawPosition() & {**key, "interval_list_name": interval_list_name}
-        ).fetch_nwb()[0]["raw_position"]
-        _, _, _, video_time = get_video_info(key)
-        pos_time = spatial_series.timestamps
+        if interval_list_name:
+            spatial_series = (
+                RawPosition()
+                & {**key, "interval_list_name": interval_list_name}
+            ).fetch_nwb()[0]["raw_position"]
+        else:
+            spatial_series = None
+
+        _, _, meters_per_pixel, video_time = get_video_info(key)
+        key["meters_per_pixel"] = meters_per_pixel
 
         # TODO: should get timestamps from VideoFile, but need the
         # video_frame_ind from RawPosition, which also has timestamps
-
-        key["meters_per_pixel"] = spatial_series.conversion
 
         # Insert entry into DLCPoseEstimation
         logger.info(
@@ -296,7 +299,9 @@ class DLCPoseEstimation(SpyglassMixin, dj.Computed):
             part_df = convert_to_cm(part_df, meters_per_pixel)
             logger.info("adding timestamps to DataFrame")
             part_df = add_timestamps(
-                part_df, pos_time=pos_time, video_time=video_time
+                part_df,
+                pos_time=getattr(spatial_series, "timestamps", video_time),
+                video_time=video_time,
             )
             key["bodypart"] = body_part
             key["analysis_file_name"] = AnalysisNwbfile().create(
@@ -309,8 +314,8 @@ class DLCPoseEstimation(SpyglassMixin, dj.Computed):
                 timestamps=part_df.time.to_numpy(),
                 conversion=METERS_PER_CM,
                 data=part_df.loc[:, idx[("x", "y")]].to_numpy(),
-                reference_frame=spatial_series.reference_frame,
-                comments=spatial_series.comments,
+                reference_frame=getattr(spatial_series, "reference_frame", ""),
+                comments=getattr(spatial_series, "comments", "no comments"),
                 description="x_position, y_position",
             )
             likelihood.create_timeseries(

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -614,7 +614,7 @@ class SpyglassMixin:
                 for key in keys:
                     self.make(key)
                 if upstream_hash != self._hash_upstream(keys):
-                    (self & keys).delete(force=True)
+                    (self & keys).delete(safemode=False)
                     logger.error(
                         "Upstream tables changed during non-transaction "
                         + "populate. Please try again."


### PR DESCRIPTION
# Description

As described in #1098, concurrent PRs overwrote feature adds in #973. This PR adds those edits back in the current structure.

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] No. I have added/edited docs/notebooks to reflect the changes
