### PR TITLE
Fix #1101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,14 @@ TrackGraph.alter() # Comment regarding the change
 - Decoding
 
     - Fix edge case errors in spike time loading #1083
+
 - Linearization
+
     - Add edge_map parameter to LinearizedPositionV1 #1091
+
+- Position
+
+    - Fix video directory bug in `DLCPoseEstimationSelection` #1103
 
 - Spike Sorting
 

--- a/src/spyglass/position/v1/position_dlc_pose_estimation.py
+++ b/src/spyglass/position/v1/position_dlc_pose_estimation.py
@@ -122,9 +122,8 @@ class DLCPoseEstimationSelection(SpyglassMixin, dj.Manual):
         if not v_path:
             raise FileNotFoundError(f"Video file not found for {key}")
         logger.info("Pose Estimation Selection")
-        v_dir = Path(v_path).parent
-        logger.info("video_dir: %s", v_dir)
-        v_path = find_mp4(video_path=v_dir, video_filename=v_fname)
+        logger.info(f"video_dir: {v_path}")
+        v_path = find_mp4(video_path=Path(v_path), video_filename=v_fname)
         if check_crop:
             params["cropping"] = self.get_video_crop(
                 video_path=v_path.as_posix()


### PR DESCRIPTION
# Description

Fixing bug caused by #870 where the parent of the video folder was used as the storage location for the video file. 

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a If table edits, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [X] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a I have added/edited docs/notebooks to reflect the changes
