### PR TITLE
Add objects to analysis file before insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 
     - Fix video directory bug in `DLCPoseEstimationSelection` #1103
     - Restore #973, allow DLC without position tracking #1100
+    - Minor fix to `DLCCentroid` make function order #1112
 
 - Spike Sorting
 

--- a/src/spyglass/position/v1/position_dlc_centroid.py
+++ b/src/spyglass/position/v1/position_dlc_centroid.py
@@ -295,6 +295,13 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
         # Add to Analysis NWB file
         analysis_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
         nwb_analysis_file = AnalysisNwbfile()
+        key["dlc_position_object_id"] = nwb_analysis_file.add_nwb_object(
+            nwb_analysis_file.add_nwb_object(analysis_file_name, position)
+        )
+        key["dlc_velocity_object_id"] = nwb_analysis_file.add_nwb_object(
+            nwb_analysis_file.add_nwb_object(analysis_file_name, velocity)
+        )
+
         nwb_analysis_file.add(
             nwb_file_name=key["nwb_file_name"],
             analysis_file_name=analysis_file_name,
@@ -304,12 +311,6 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
             {
                 **key,
                 "analysis_file_name": analysis_file_name,
-                "dlc_position_object_id": nwb_analysis_file.add_nwb_object(
-                    analysis_file_name, position
-                ),
-                "dlc_velocity_object_id": nwb_analysis_file.add_nwb_object(
-                    analysis_file_name, velocity
-                ),
             }
         )
 


### PR DESCRIPTION
# Description

Fixes #1107:
- add position and velocity object to the analysis nwb file before inserting to `AnalysisNwbfile`
- prevents mismatched checksum/size from altering file after insert

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] No This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] No This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
