### PR TITLE
Fix Curation primary key creation from spikesorting key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 
     - Fix bug in `get_group_by_shank` #1096
     - Fix bug in `_compute_metric` #1099
+    - Fix bug in `insert_curation` returned key #1114
 
 ## [0.5.3] (August 27, 2024)
 

--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -146,8 +146,9 @@ class Curation(SpyglassMixin, dj.Manual):
         Curation.insert1(sorting_key, skip_duplicates=True)
 
         # get the primary key for this curation
-        c_key = (Curation & sorting_key).fetch1("KEY")
-        curation_key = {item: sorting_key[item] for item in c_key}
+        curation_key = {
+            item: sorting_key[item] for item in Curation.primary_key
+        }
 
         return curation_key
 


### PR DESCRIPTION
# Description

Fixes #1110 
- avoids restricting `v0.Curation` by secondary keys which contain dictionary blobs (which led to SQL errors)

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] No This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] No This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
