### PR TITLE
Fix null config_tasks value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 - Update DataJoint to 0.14.2 #1081
 - Allow restriction based on parent keys in `Merge.fetch_nwb()` #1086
 - Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116
+- Allow definition of tasks and new probe entries from config #1074, #1120
+- Enforce match between ingested nwb probe geometry and existing table entry #1074
 
 ### Pipelines
 

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -134,8 +134,8 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
         # schema if it isn't there and then add an entry for each epoch
 
         tasks_mod = nwbf.processing.get("tasks")
-        config_tasks = config.get("Tasks")
-        if tasks_mod is None and config_tasks is None:
+        config_tasks = config.get("Tasks", [])
+        if tasks_mod is None and (not config_tasks):
             logger.warn(
                 f"No tasks processing module found in {nwbf} or config\n"
             )

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -236,12 +236,10 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
             if target_interval in interval
         ]
         if not possible_targets:
-            logger.warn(
-                f"Interval not found for epoch {epoch} in {nwb_file_name}."
-            )
+            logger.warn(f"Interval not found for epoch {epoch}.")
         elif len(possible_targets) > 1:
             logger.warn(
-                f"Multiple intervals found for epoch {epoch} in {nwb_file_name}. "
+                f"Multiple intervals found for epoch {epoch}. "
                 + f"matches are {possible_targets}."
             )
         else:

--- a/tests/common/test_behav.py
+++ b/tests/common/test_behav.py
@@ -101,8 +101,11 @@ def test_pos_interval_no_transaction(verbose_context, common, mini_restr):
         common.PositionIntervalMap()._no_transaction_make(mini_restr)
     after = common.PositionIntervalMap().fetch()
     assert (
-        len(after) == len(before) + 2
+        len(after) == len(before) + 3
     ), "PositionIntervalMap no_transaction had unexpected effect"
+    assert (
+        "" in after["position_interval_name"]
+    ), "PositionIntervalMap null insert failed"
 
 
 def test_get_pos_interval_name(pos_src, pos_interval_01):


### PR DESCRIPTION
# Description

Fixes #1119 
- make the null value when getting `config_tasks` an empty list to prevent non-iterable error

Fixes #1122 
- alter warning to avoid error

Fixes #1123 
- Update test of position interval map for updated null key insert

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
