### PR TITLE
Switch to or logic when multiple merge ids in restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     #1108
 - Add docstrings to all public methods #1076
 - Update DataJoint to 0.14.2 #1081
-- Allow restriction based on parent keys in `Merge.fetch_nwb()` #1086
+- Allow restriction based on parent keys in `Merge.fetch_nwb()` #1086, #1126
 - Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116
 
 ### Pipelines

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -853,6 +853,9 @@ class Merge(dj.Manual):
         merge_id present in the input, relying on parent func to
         restrict on secondary or part-parent key(s).
 
+        Assumes that a valid set of merge_id keys should have OR logic
+        to allow selection of an entries.
+
         Parameters
         ----------
         restriction : str, dict, or dj.condition.AndList
@@ -878,9 +881,7 @@ class Merge(dj.Manual):
             merge_restr = [x for x in merge_id_list if x is not None]
         elif isinstance(restriction, str):
             parsed = [x.split(")")[0] for x in restriction.split("(") if x]
-            merge_restr = dj.condition.AndList(
-                [x for x in parsed if "merge_id" in x]
-            )
+            merge_restr = [x for x in parsed if "merge_id" in x]
 
         if len(merge_restr) == 0:
             return True


### PR DESCRIPTION
# Description

- `Merge.extract_merge_id()` was introduced in #1086 to help allow restriction by Merge table or parent table in `Merge.fetch_nwb()`
- The logic of this function created a And restriction when multiple merge ids were present in the restriction
    - This would always lead to an empty table when applied since an entry can't match 2 different merge_id values
- This PR changes the restriction returned by `Merge.extract_merge_id()` to or logic to allow proper function. 

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
