### PR TITLE
Fix waveform params in metric curation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 
     - Drop `SessionGroup` table #1106
     - Improve electrodes import efficiency #1125
+    - Fix logger method call in `common_task` #1132
 
 - Decoding
 
@@ -53,6 +54,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     - Fix bug in `get_group_by_shank` #1096
     - Fix bug in `_compute_metric` #1099
     - Fix bug in `insert_curation` returned key #1114
+    - Fix handling of waveform extraction sparse parameter #1132
 
 ## [0.5.3] (August 27, 2024)
 

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -236,9 +236,9 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
             if target_interval in interval
         ]
         if not possible_targets:
-            logger.warn(f"Interval not found for epoch {epoch}.")
+            logger.warning(f"Interval not found for epoch {epoch}.")
         elif len(possible_targets) > 1:
-            logger.warn(
+            logger.warning(
                 f"Multiple intervals found for epoch {epoch}. "
                 + f"matches are {possible_targets}."
             )

--- a/src/spyglass/spikesorting/v1/metric_curation.py
+++ b/src/spyglass/spikesorting/v1/metric_curation.py
@@ -263,10 +263,13 @@ class MetricCuration(SpyglassMixin, dj.Computed):
         os.makedirs(waveforms_dir, exist_ok=True)
 
         logger.info("Extracting waveforms...")
+
+        # Extract non-sparse waveforms by default
+        waveform_params.setdefault("sparse", False)
+
         waveforms = si.extract_waveforms(
             recording=recording,
             sorting=sorting,
-            sparse=waveform_params.get("sparse", False),
             folder=waveforms_dir,
             overwrite=True,
             **waveform_params,


### PR DESCRIPTION
# Description

Fixes waveform_params dict in metric curation so that the `sparse` keyword is handled when set.

- Fixes #1127 

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] This PR should be accompanied by a release: (yes/**no**/unsure)
- [x] If release, I have updated the `CITATION.cff`
- [x] This PR makes edits to table definitions: (yes/**no**)
- [x] If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
