### PR TITLE
Long distance restr fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 - Add docstrings to all public methods #1076
 - Update DataJoint to 0.14.2 #1081
 - Allow restriction based on parent keys in `Merge.fetch_nwb()` #1086, #1126
-- Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116
+- Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116, #1137
 - Fix bool settings imported from dj config file #1117
 - Allow definition of tasks and new probe entries from config #1074, #1120
 - Enforce match between ingested nwb probe geometry and existing table entry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ ignore-words-list = 'nevers'
 minversion = "7.0"
 addopts = [
     # "-sv", # no capture, verbose output
-    "--sw", # stepwise: resume with next test after failure
+    # "--sw", # stepwise: resume with next test after failure
     # "--pdb", # drop into debugger on failure
     "-p no:warnings",
     # "--no-teardown", # don't teardown the database after tests

--- a/src/spyglass/utils/database_settings.py
+++ b/src/spyglass/utils/database_settings.py
@@ -15,7 +15,7 @@ SHARED_MODULES = [
     "spikesorting",
     "decoding",
     "position",
-    "position_linearization",
+    "linearization",
     "ripple",
     "lfp",
     "waveform",

--- a/src/spyglass/utils/dj_graph.py
+++ b/src/spyglass/utils/dj_graph.py
@@ -22,7 +22,6 @@ from networkx import (
     all_simple_paths,
     shortest_path,
 )
-from networkx.algorithms.dag import topological_sort
 from tqdm import tqdm
 
 from spyglass.utils import logger
@@ -478,7 +477,7 @@ class AbstractGraph(ABC):
             if not self._is_out(node, warn=False)
         ]
         graph = self.graph.subgraph(nodes) if subgraph else self.graph
-        ordered = dj_topo_sort(list(topological_sort(graph)))
+        ordered = dj_topo_sort(graph)
         if reverse:
             ordered.reverse()
         return [n for n in ordered if n in nodes]
@@ -869,10 +868,10 @@ class TableChain(RestrGraph):
             self.direction = Direction.DOWN
 
         self.leaf = None
-        if search_restr and not parent:
+        if search_restr and not self.parent:  # using `parent` fails on empty
             self.direction = Direction.UP
             self.leaf = self.child
-        if search_restr and not child:
+        if search_restr and not self.child:
             self.direction = Direction.DOWN
             self.leaf = self.parent
         if self.leaf:

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -3,7 +3,7 @@ from itertools import chain as iter_chain
 from pprint import pprint
 from re import sub as re_sub
 from time import time
-from typing import Union, List
+from typing import List, Union
 
 import datajoint as dj
 from datajoint.condition import make_condition
@@ -348,7 +348,7 @@ class Merge(dj.Manual):
                         )
                     key = keys[0]
                     if part & key:
-                        print(f"Key already in part {part_name}: {key}")
+                        logger.info(f"Key already in part {part_name}: {key}")
                         continue
                     master_sk = {cls()._reserved_sk: part_name}
                     uuid = dj.hash.key_hash(key | master_sk)

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -157,7 +157,7 @@ def test_restr_from_upstream(graph_tables, restr, expect_n, msg):
         ("PkAliasNode", "parent_attr > 17", 2, "pk pk alias"),
         ("SkAliasNode", "parent_attr > 18", 2, "sk sk alias"),
         ("MergeChild", "parent_attr > 18", 2, "merge child"),
-        ("MergeChild", {"parent_attr": 18}, 1, "dict restr"),
+        ("MergeChild", {"parent_attr": 19}, 1, "dict restr"),
     ],
 )
 def test_restr_from_downstream(graph_tables, table, restr, expect_n, msg):


### PR DESCRIPTION
# Description

This PR...
- Removes a redundant `topological_sort` in long distance restrictions
- Fixes `print` -> `logger.info`
- Fixes `position_linearization` -> `linearization`

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
