### PR TITLE
Quickfix: typo in adding objects to nwb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 
     - Fix video directory bug in `DLCPoseEstimationSelection` #1103
     - Restore #973, allow DLC without position tracking #1100
-    - Minor fix to `DLCCentroid` make function order #1112
+    - Minor fix to `DLCCentroid` make function order #1112, #1148
 
 - Spike Sorting
 

--- a/src/spyglass/position/v1/position_dlc_centroid.py
+++ b/src/spyglass/position/v1/position_dlc_centroid.py
@@ -296,10 +296,10 @@ class DLCCentroid(SpyglassMixin, dj.Computed):
         analysis_file_name = AnalysisNwbfile().create(key["nwb_file_name"])
         nwb_analysis_file = AnalysisNwbfile()
         key["dlc_position_object_id"] = nwb_analysis_file.add_nwb_object(
-            nwb_analysis_file.add_nwb_object(analysis_file_name, position)
+            analysis_file_name, position
         )
         key["dlc_velocity_object_id"] = nwb_analysis_file.add_nwb_object(
-            nwb_analysis_file.add_nwb_object(analysis_file_name, velocity)
+            analysis_file_name, velocity
         )
 
         nwb_analysis_file.add(


### PR DESCRIPTION
# Description

#1112 introduced a bug in how objects were added to the analysis nwb file in `DLCCentroid.populate()`.  This corrects this error.

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
