### PR TITLE
Remove mambaforge from tests

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -45,7 +45,6 @@ jobs:
       with:
         activate-environment: spyglass
         environment-file: environment.yml
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
     - name: Install apt dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 - Fix dandi upload process for nwb's with video or linked objects #1095, #1151
 - Minor docs fixes #1145
 - Remove stored hashes from pytests #1152
+- Remove mambaforge from tests #1153
 
 ### Pipelines
 


### PR DESCRIPTION
Mambaforge is being sunset (see https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/) because miniforge is now essentially the same. This PR removes the mambaforge variant and switches to using miniforge for the tests.


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] This PR should be accompanied by a release: (yes/no/unsure)
- [x] If release, I have updated the `CITATION.cff`
- [x] This PR makes edits to table definitions: (yes/no)
- [x] If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
