### PR TITLE
Fix topological sort logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 - Update DataJoint to 0.14.2 #1081
 - Allow restriction based on parent keys in `Merge.fetch_nwb()` #1086, #1126
 - Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116,
-    #1137, #11XX
+    #1137, #1162
 - Fix bool settings imported from dj config file #1117
 - Allow definition of tasks and new probe entries from config #1074, #1120
 - Enforce match between ingested nwb probe geometry and existing table entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 - Add docstrings to all public methods #1076
 - Update DataJoint to 0.14.2 #1081
 - Allow restriction based on parent keys in `Merge.fetch_nwb()` #1086, #1126
-- Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116, #1137
+- Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116,
+    #1137, #11XX
 - Fix bool settings imported from dj config file #1117
 - Allow definition of tasks and new probe entries from config #1074, #1120
 - Enforce match between ingested nwb probe geometry and existing table entry

--- a/src/spyglass/utils/dj_graph.py
+++ b/src/spyglass/utils/dj_graph.py
@@ -17,6 +17,7 @@ from datajoint.hash import key_hash
 from datajoint.user_tables import TableMeta
 from datajoint.utils import get_master, to_camel_case
 from networkx import (
+    DiGraph,
     NetworkXNoPath,
     NodeNotFound,
     all_simple_paths,
@@ -33,10 +34,36 @@ from spyglass.utils.dj_helper_fn import (
     unique_dicts,
 )
 
-try:  # Datajoint 0.14.2+ uses topo_sort instead of unite_master_parts
-    from datajoint.dependencies import topo_sort as dj_topo_sort
-except ImportError:
-    from datajoint.dependencies import unite_master_parts as dj_topo_sort
+
+def dj_topo_sort(graph: DiGraph) -> List[str]:
+    """Topologically sort graph.
+
+    Uses datajoint's topo_sort if available, otherwise uses networkx's
+    topological_sort, combined with datajoint's unite_master_parts.
+
+    NOTE: This ordering will impact _hash_upstream, but usage should be
+    consistent before/after a no-transaction populate.
+
+    Parameters
+    ----------
+    graph : nx.DiGraph
+        Directed graph to sort
+
+    Returns
+    -------
+    List[str]
+        List of table names in topological order
+    """
+    __import__("pdb").set_trace()
+    try:  # Datajoint 0.14.2+ uses topo_sort instead of unite_master_parts
+        from datajoint.dependencies import topo_sort
+
+        return topo_sort(graph)
+    except ImportError:
+        from datajoint.dependencies import unite_master_parts
+        from networkx.algorithms.dag import topological_sort
+
+        return unite_master_parts(list(topological_sort(graph)))
 
 
 class Direction(Enum):


### PR DESCRIPTION
# Description

In small scale tests, the old and new topological sort mechanisms behaved the same, but failed with an alias node in #1161. 

This PR re-introduces the old logic pending release of DataJoint 0.14.3. Ordering isn't exactly the same across versions, but this would only cause problems if someone upgraded within a python session

# Checklist:

- [x] No. This PR should be accompanied by a release: (yes/no/unsure)
- [x] N/a. If release, I have updated the `CITATION.cff`
- [x] No. This PR makes edits to table definitions: (yes/no)
- [x] N/a. If table edits, I have included an `alter` snippet for release notes.
- [x] No. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] N/a. I have added/edited docs/notebooks to reflect the changes
