### PR TITLE
`DLCPosVideo`: Use provided epoch, multithread matplotlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ spyglass.code-workspace
 mountainsort4_output/
 .idea/
 mysql_config
+memray*
 
 # Notebooks
 *.ipynb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     - Restore #973, allow DLC without position tracking #1100
     - Minor fix to `DLCCentroid` make function order #1112, #1148
     - Pass output path as string to `cv2.VideoWriter` #1150
-    - Set `DLCPosVideo` default processor to `matplotlib` #11XX
+    - Set `DLCPosVideo` default processor to `matplotlib` #1168
+    - Save generated video to temp directory, then move #1168
 
 - Spike Sorting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,12 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     - Fix video directory bug in `DLCPoseEstimationSelection` #1103
     - Restore #973, allow DLC without position tracking #1100
     - Minor fix to `DLCCentroid` make function order #1112, #1148
-    - Pass output path as string to `cv2.VideoWriter` #1150
-    - Set `DLCPosVideo` default processor to `matplotlib` #1168
-    - Save generated video to temp directory, then move #1168
+    - Video creator tools:
+
+        - Pass output path as string to `cv2.VideoWriter` #1150
+        - Set `DLCPosVideo` default processor to `matplotlib`, remove support 
+            for `open-cv` #1168
+        - Save generated video to temp directory, then move #1168
 
 - Spike Sorting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,11 +57,10 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     - Restore #973, allow DLC without position tracking #1100
     - Minor fix to `DLCCentroid` make function order #1112, #1148
     - Video creator tools:
-
         - Pass output path as string to `cv2.VideoWriter` #1150
-        - Set `DLCPosVideo` default processor to `matplotlib`, remove support 
+        - Set `DLCPosVideo` default processor to `matplotlib`, remove support
             for `open-cv` #1168
-        - Save generated video to temp directory, then move #1168
+        - `VideoMaker` class to process frames in multithreaded batches #1168
 
 - Spike Sorting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     - Restore #973, allow DLC without position tracking #1100
     - Minor fix to `DLCCentroid` make function order #1112, #1148
     - Pass output path as string to `cv2.VideoWriter` #1150
+    - Set `DLCPosVideo` default processor to `matplotlib` #11XX
 
 - Spike Sorting
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -541,7 +541,7 @@ class PositionIntervalMap(SpyglassMixin, dj.Computed):
 
         # Skip populating if no pos interval list names
         if len(pos_intervals) == 0:
-            logger.error(f"NO POS INTERVALS FOR {key}; {no_pop_msg}")
+            logger.error(f"NO POS INTERVALS FOR {key};\n{no_pop_msg}")
             self.insert1(null_key, **insert_opts)
             return
 

--- a/src/spyglass/position/v1/dlc_utils_makevid.py
+++ b/src/spyglass/position/v1/dlc_utils_makevid.py
@@ -530,4 +530,4 @@ class VideoMaker:
 
 def make_video(**kwargs):
     """Passthrough for VideoMaker class for backwards compatibility."""
-    VideoMaker(**kwargs)
+    return VideoMaker(**kwargs)

--- a/src/spyglass/position/v1/dlc_utils_makevid.py
+++ b/src/spyglass/position/v1/dlc_utils_makevid.py
@@ -483,7 +483,16 @@ class VideoMaker:
             output_partial_video,
             *self.ffmpeg_log_args,
         ]
-        subprocess.run(ffmpeg_cmd, check=True)
+        try:
+            ret = subprocess.run(
+                ffmpeg_cmd,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                check=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Error stitching partial video: {e.stderr}")
 
     def concat_partial_videos(self):
         """Concatenate all the partial videos into one final video."""
@@ -507,7 +516,16 @@ class VideoMaker:
             str(self.output_video_filename),
             *self.ffmpeg_log_args,
         ]
-        subprocess.run(ffmpeg_cmd, check=True)
+        try:
+            ret = subprocess.run(
+                ffmpeg_cmd,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Error stitching partial video: {e.stderr}")
 
 
 def make_video(**kwargs):

--- a/src/spyglass/position/v1/dlc_utils_makevid.py
+++ b/src/spyglass/position/v1/dlc_utils_makevid.py
@@ -1,20 +1,22 @@
 # Convenience functions
 # some DLC-utils copied from datajoint element-interface utils.py
+import shutil
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from functools import cached_property
+from os import system as os_system
 from pathlib import Path
-from random import choice as random_choice
-from shutil import move as shutil_move
+from random import choices as random_choices
 from string import ascii_letters
 
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from tqdm import tqdm as tqdm
+from tqdm import tqdm
 
 from spyglass.settings import temp_dir
 from spyglass.utils import logger
 from spyglass.utils.position import convert_to_pixels as _to_px
-from spyglass.utils.position import fill_nan
 
 RGB_PINK = (234, 82, 111)
 RGB_YELLOW = (253, 231, 76)
@@ -41,335 +43,89 @@ class VideoMaker:
         position_time,
         video_frame_inds=None,
         likelihoods=None,
-        processor="opencv",  # opencv, opencv-trodes, matplotlib
-        video_time=None,
+        processor="matplotlib",
         frames=None,
         percent_frames=1,
         output_video_filename="output.mp4",
         cm_to_pixels=1.0,
         disable_progressbar=False,
         crop=None,
-        arrow_radius=15,
-        circle_radius=8,
+        *args,
+        **kwargs,
     ):
+        if processor != "matplotlib":
+            raise ValueError(
+                "open-cv processors are no longer supported. \n"
+                + "Use matplotlib or submit a feature request via GitHub."
+            )
+
+        # self.output_temp_dir = Path(temp_dir) / "vid_frames"
+        self.output_temp_dir = Path(".")
+        # while self.output_temp_dir.exists():  # multi-user
+        # suffix = "".join(random_choices(ascii_letters, k=2))
+        # self.output_temp_dir = Path(temp_dir) / f"vid_frames_{suffix}"
+        self.output_temp_dir.mkdir(parents=True, exist_ok=True)
+
+        if not Path(video_filename).exists():
+            raise FileNotFoundError(f"Video not found: {video_filename}")
+
         self.video_filename = video_filename
         self.video_frame_inds = video_frame_inds
-        self.position_mean = position_mean
-        self.orientation_mean = orientation_mean
+        self.position_mean = position_mean["DLC"]
+        self.orientation_mean = orientation_mean["DLC"]
         self.centroids = centroids
         self.likelihoods = likelihoods
         self.position_time = position_time
-        self.processor = processor
-        self.video_time = video_time
-        self.frames = frames
         self.percent_frames = percent_frames
+        self.frames = frames
         self.output_video_filename = output_video_filename
         self.cm_to_pixels = cm_to_pixels
-        self.disable_progressbar = disable_progressbar
         self.crop = crop
-        self.arrow_radius = arrow_radius
-        self.circle_radius = circle_radius
 
-        self.output_temp_file = Path(temp_dir) / "temp.mp4"
-        while self.output_temp_file.exists():
-            self.output_temp_file = (  # unilikely, but just in case
-                Path(temp_dir) / f"temp_{random_choice(ascii_letters)}.mp4"
-            )
+        _ = self._set_frame_info()
+        _ = self._set_plot_bases()
 
-        if not Path(self.video_filename).exists():
-            raise FileNotFoundError(f"Video not found: {self.video_filename}")
+        logger.info(f"Making video: {self.output_video_filename}")
+        self.generate_frames_multithreaded()
+        self.stitch_video_from_frames()
+        logger.info(f"Finished video: {self.output_video_filename}")
+        plt.close(self.fig)
 
-        if frames is None:
-            self.n_frames = (
-                int(self.orientation_mean.shape[0])
-                if processor == "opencv-trodes"
-                else int(len(video_frame_inds) * percent_frames)
+        # shutil.rmtree(self.output_temp_dir)
+
+    def _set_frame_info(self):
+        """Set the frame information for the video."""
+        if self.frames is None:
+            self.n_frames = int(
+                len(self.video_frame_inds) * self.percent_frames
             )
             self.frames = np.arange(0, self.n_frames)
         else:
-            self.n_frames = len(frames)
+            self.n_frames = len(self.frames)
+        self.pad_len = len(str(self.n_frames))
 
-        self.tqdm_kwargs = {
-            "iterable": (
-                range(self.n_frames - 1)
-                if self.processor == "opencv-trodes"
-                else self.frames
-            ),
-            "desc": "frames",
-            "disable": self.disable_progressbar,
-        }
-
-        # init for cv
-        self.video, self.frame_size = None, None
-        self.frame_rate, self.out = None, None
-        self.source_map = {
-            "DLC": RGB_BLUE,
-            "Trodes": RGB_ORANGE,
-            "Common": RGB_PINK,
-        }
-
-        # intit for matplotlib
-        self.image, self.title, self.progress_bar = None, None, None
-        self.crop_offset_x = crop[0] if crop else 0
-        self.crop_offset_y = crop[2] if crop else 0
-        self.centroid_plot_objs, self.centroid_position_dot = None, None
-        self.orientation_line = None
-        self.likelihood_objs = None
         self.window_ind = np.arange(501) - 501 // 2
 
-        self.make_video()
-
-    def make_video(self):
-        """Make video based on processor chosen at init."""
-        logger.info(f"Making video: {self.output_video_filename}")
-        if self.processor == "opencv":
-            self.make_video_opencv()
-        elif self.processor == "opencv-trodes":
-            self.make_trodes_video()
-        elif self.processor == "matplotlib":
-            self.make_video_matplotlib()
-        shutil_move(self.output_temp_file, self.output_video_filename)
-        logger.info(f"Finished video: {self.output_video_filename}")
-
-    def _init_video(self):
-        self.video = cv2.VideoCapture(str(self.video_filename))
+        video = cv2.VideoCapture(str(self.video_filename))
         self.frame_size = (
-            (int(self.video.get(3)), int(self.video.get(4)))
+            (int(video.get(3)), int(video.get(4)))
             if not self.crop
             else (
                 self.crop[1] - self.crop[0],
                 self.crop[3] - self.crop[2],
             )
         )
-        self.frame_rate = self.video.get(5)
-
-    def _init_cv_video(self):
-        _ = self._init_video()
-        self.out = cv2.VideoWriter(
-            filename=str(self.output_temp_file),
-            fourcc=cv2.VideoWriter_fourcc(*"mp4v"),
-            fps=self.frame_rate,
-            frameSize=self.frame_size,
-            isColor=True,
+        self.ratio = (
+            (self.crop[3] - self.crop[2]) / (self.crop[1] - self.crop[0])
+            if self.crop
+            else self.frame_size[1] / self.frame_size[0]
         )
-        frames_log = (
-            f"\tFrames start: {self.frames[0]}\n" if np.any(self.frames) else ""
-        )
-        inds_log = (
-            f"\tVideo frame inds: {self.video_frame_inds[0]}\n"
-            if np.any(self.video_frame_inds)
-            else ""
-        )
-        logger.info(
-            f"\n{frames_log}{inds_log}\tcv2 ind start: {int(self.video.get(1))}"
-        )
+        self.frame_rate = video.get(5)
+        self.fps = int(np.round(self.frame_rate))
+        video.release()
 
-    def _close_cv_video(self):
-        self.video.release()
-        self.out.release()
-        try:
-            cv2.destroyAllWindows()
-        except cv2.error:  # if cv is already closed or does not have func
-            pass
-
-    def _get_frame(self, frame, init_only=False, crop_order=(0, 1, 2, 3)):
-        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        if init_only or not self.crop:
-            return frame
-        x1, x2, y1, y2 = self.crop_order
-        return frame[
-            self.crop[x1] : self.crop[x2], self.crop[y1] : self.crop[y2]
-        ].copy()
-
-    def _video_set_by_ind(self, time_ind):
-        if time_ind == 0:
-            self.video.set(1, time_ind + 1)
-        elif int(self.video.get(1)) != time_ind - 1:
-            self.video.set(1, time_ind - 1)
-
-    def _all_num(self, *args):
-        return all(np.all(~np.isnan(data)) for data in args)
-
-    def _make_arrow(
-        self,
-        position,
-        orientation,
-        color,
-        img,
-        thickness=4,
-        line_type=8,
-        tipLength=0.25,
-        shift=cv2.CV_8U,
-    ):
-        if not self._all_num(position, orientation):
-            return
-        arrow_tip = (
-            int(position[0] + self.arrow_radius * np.cos(orientation)),
-            int(position[1] + self.arrow_radius * np.sin(orientation)),
-        )
-        cv2.arrowedLine(
-            img=img,
-            pt1=tuple(position.astype(int)),
-            pt2=arrow_tip,
-            color=color,
-            thickness=thickness,
-            line_type=line_type,
-            tipLength=tipLength,
-            shift=shift,
-        )
-
-    def _make_circle(
-        self,
-        data,
-        color,
-        img,
-        radius=None,
-        thickness=-1,
-        shift=cv2.CV_8U,
-        **kwargs,
-    ):
-        if not self._all_num(data):
-            return
-        cv2.circle(
-            img=img,
-            center=tuple(data.astype(int)),
-            radius=radius or self.circle_radius,
-            color=color,
-            thickness=thickness,
-            shift=shift,
-        )
-
-    def make_video_opencv(self):
-        """Make video using opencv."""
-        _ = self._init_cv_video()
-
-        if self.video_time:
-            self.position_mean = {
-                key: fill_nan(
-                    self.position_mean[key]["position"],
-                    self.video_time,
-                    self.position_time,
-                )
-                for key in self.position_mean.keys()
-            }
-            self.orientation_mean = {
-                key: fill_nan(
-                    self.position_mean[key]["orientation"],
-                    self.video_time,
-                    self.position_time,
-                )
-                for key in self.position_mean.keys()
-            }
-
-        for time_ind in tqdm(**self.tqdm_kwargs):
-            _ = self._video_set_by_ind(time_ind)
-
-            is_grabbed, frame = self.video.read()
-
-            if not is_grabbed:
-                break
-
-            frame = self._get_frame(frame)
-
-            cv2.putText(
-                img=frame,
-                text=f"time_ind: {int(time_ind)} video frame: {int(self.video.get(1))}",
-                org=(10, 10),
-                fontFace=cv2.FONT_HERSHEY_SIMPLEX,
-                fontScale=0.5,
-                color=RGB_YELLOW,
-                thickness=1,
-            )
-
-            if time_ind < self.video_frame_inds[0] - 1:
-                self.out.write(self._get_frame(frame, init_only=True))
-                continue
-
-            pos_ind = time_ind - self.video_frame_inds[0]
-
-            for key in self.position_mean:
-                position = _to_px(
-                    data=self.position_mean[key][pos_ind],
-                    cm_to_pixels=self.cm_to_pixels,
-                )
-                orientation = self.orientation_mean[key][pos_ind]
-                cv_kwargs = {
-                    "img": frame,
-                    "color": self.source_map[key],
-                }
-                self._make_arrow(position, orientation, **cv_kwargs)
-                self._make_circle(data=position, **cv_kwargs)
-
-            self._get_frame(frame, init_only=True)
-            self.out.write(frame)
-        self._close_cv_video()
-        return
-
-    def make_trodes_video(self):
-        """Make video using opencv with trodes data."""
-        _ = self._init_cv_video()
-
-        if np.any(self.video_time):
-            centroids = {
-                color: fill_nan(
-                    variable=data,
-                    video_time=self.video_time,
-                    variable_time=self.position_time,
-                )
-                for color, data in self.centroids.items()
-            }
-            position_mean = fill_nan(
-                self.position_mean, self.video_time, self.position_time
-            )
-            orientation_mean = fill_nan(
-                self.orientation_mean, self.video_time, self.position_time
-            )
-
-        for time_ind in tqdm(**self.tqdm_kwargs):
-            is_grabbed, frame = self.video.read()
-            if not is_grabbed:
-                break
-
-            frame = self._get_frame(frame)
-
-            red_centroid = centroids["red"][time_ind]
-            green_centroid = centroids["green"][time_ind]
-            position = position_mean[time_ind]
-            position = _to_px(data=position, cm_to_pixels=self.cm_to_pixels)
-            orientation = orientation_mean[time_ind]
-
-            self._make_circle(data=red_centroid, img=frame, color=RGB_YELLOW)
-            self._make_circle(data=green_centroid, img=frame, color=RGB_PINK)
-            self._make_arrow(
-                position=position,
-                orientation=orientation,
-                color=RGB_WHITE,
-                img=frame,
-            )
-            self._make_circle(data=position, img=frame, color=RGB_WHITE)
-            self._get_frame(frame, init_only=True)
-            self.out.write(frame)
-
-        self._close_cv_video()
-
-    def make_video_matplotlib(self):
-        """Make video using matplotlib."""
-        import matplotlib.animation as animation
-
-        self.position_mean = self.position_mean["DLC"]
-        self.orientation_mean = self.orientation_mean["DLC"]
-
-        _ = self._init_video()
-
-        video_slowdown = 1
-        fps = int(np.round(self.frame_rate / video_slowdown))
-        Writer = animation.writers["ffmpeg"]
-        writer = Writer(fps=fps, bitrate=-1)
-
-        ret, frame = self.video.read()
-        frame = self._get_frame(frame, crop_order=(2, 3, 0, 1))
-
-        frame_ind = 0
+    def _set_plot_bases(self):
+        """Create the figure and axes for the video."""
         plt.style.use("dark_background")
         fig, axes = plt.subplots(
             2,
@@ -382,9 +138,6 @@ class VideoMaker:
         axes[0].tick_params(colors="white", which="both")
         axes[0].spines["bottom"].set_color("white")
         axes[0].spines["left"].set_color("white")
-        self.image = axes[0].imshow(frame, animated=True)
-
-        logger.info(f"frame after init plot: {self.video.get(1)}")
 
         self.centroid_plot_objs = {
             bodypart: axes[0].scatter(
@@ -394,7 +147,7 @@ class VideoMaker:
                 zorder=102,
                 color=color,
                 label=f"{bodypart} position",
-                animated=True,
+                # animated=True,
                 alpha=0.6,
             )
             for color, bodypart in zip(COLOR_SWATCH, self.centroids.keys())
@@ -406,7 +159,6 @@ class VideoMaker:
             zorder=102,
             color="#b045f3",
             label="centroid position",
-            animated=True,
             alpha=0.6,
         )
         (self.orientation_line,) = axes[0].plot(
@@ -414,23 +166,18 @@ class VideoMaker:
             [],
             color="cyan",
             linewidth=1,
-            animated=True,
             label="Orientation",
         )
 
         axes[0].set_xlabel("")
         axes[0].set_ylabel("")
 
-        ratio = (
-            (self.crop[3] - self.crop[2]) / (self.crop[1] - self.crop[0])
-            if self.crop
-            else self.frame_size[1] / self.frame_size[0]
-        )
-
         x_left, x_right = axes[0].get_xlim()
         y_low, y_high = axes[0].get_ylim()
 
-        axes[0].set_aspect(abs((x_right - x_left) / (y_low - y_high)) * ratio)
+        axes[0].set_aspect(
+            abs((x_right - x_left) / (y_low - y_high)) * self.ratio
+        )
         axes[0].spines["top"].set_color("black")
         axes[0].spines["right"].set_color("black")
 
@@ -440,7 +187,7 @@ class VideoMaker:
 
         axes[0].legend(loc="lower right", fontsize=4)
         self.title = axes[0].set_title(
-            f"time = {time_delta:3.4f}s\n frame = {frame_ind}",
+            f"time = {time_delta:3.4f}s\n frame = {0}",
             fontsize=8,
         )
         axes[0].axis("off")
@@ -452,7 +199,6 @@ class VideoMaker:
                     [],
                     color=color,
                     linewidth=1,
-                    animated=True,
                     clip_on=False,
                     label=bodypart,
                 )[0]
@@ -474,20 +220,82 @@ class VideoMaker:
             axes[1].spines["right"].set_color("black")
             axes[1].legend(loc="upper right", fontsize=4)
 
-        self.progress_bar = tqdm(leave=True, position=0)
-        self.progress_bar.reset(total=self.n_frames)
+        self.fig = fig
+        self.axes = axes
 
-        movie = animation.FuncAnimation(
-            fig,
-            self._update_plot,
-            frames=self.frames,
-            interval=1000 / fps,
-            blit=True,
+    def _get_frame(self, frame, crop_order=(2, 3, 0, 1)):
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        if not self.crop:
+            return frame
+        x1, x2, y1, y2 = self.crop_order
+        return frame[
+            self.crop[x1] : self.crop[x2], self.crop[y1] : self.crop[y2]
+        ].copy()
+
+    def _generate_single_frame(self, frame_ind):
+        """Generate a single frame and save it as an image."""
+        # Each frame open video bc video not picklable as multiprocessing arg
+        video = cv2.VideoCapture(str(self.video_filename))
+        video.set(cv2.CAP_PROP_POS_FRAMES, frame_ind)
+
+        ret, frame = video.read()
+        if not ret:
+            video.release()
+            return None
+
+        frame = self._get_frame(frame)
+
+        _ = self.axes[0].imshow(frame)
+
+        pos_ind = np.where(self.video_frame_inds == frame_ind)[0]
+
+        if len(pos_ind) == 0:
+            self.centroid_position_dot.set_offsets((np.NaN, np.NaN))
+            for bodypart in self.centroid_plot_objs.keys():
+                self.centroid_plot_objs[bodypart].set_offsets((np.NaN, np.NaN))
+            self.orientation_line.set_data((np.NaN, np.NaN))
+            self.title.set_text(f"time = {0:3.4f}s\n frame = {frame_ind}")
+        else:
+            pos_ind = pos_ind[0]
+            likelihood_inds = pos_ind + self.window_ind
+            neg_inds = np.where(likelihood_inds < 0)[0]
+            likelihood_inds[neg_inds] = 0 if len(neg_inds) > 0 else -1
+
+            dlc_centroid_data = self._get_centroid_data(pos_ind)
+
+            for bodypart in self.centroid_plot_objs:
+                self.centroid_plot_objs[bodypart].set_offsets(
+                    _to_px(
+                        data=self.centroids[bodypart][pos_ind],
+                        cm_to_pixels=self.cm_to_pixels,
+                    )
+                )
+            self.centroid_position_dot.set_offsets(dlc_centroid_data)
+            _ = self._set_orient_line(frame, pos_ind)
+
+            time_delta = pd.Timedelta(
+                pd.to_datetime(self.position_time[pos_ind] * 1e9, unit="ns")
+                - pd.to_datetime(self.position_time[0] * 1e9, unit="ns")
+            ).total_seconds()
+
+            self.title.set_text(
+                f"time = {time_delta:3.4f}s\n frame = {frame_ind}"
+            )
+            if self.likelihoods:
+                for bodypart in self.likelihood_objs.keys():
+                    self.likelihood_objs[bodypart].set_data(
+                        self.window_ind / self.frame_rate,
+                        np.asarray(self.likelihoods[bodypart][likelihood_inds]),
+                    )
+
+        # Zero-padded filename based on the dynamic padding length
+        frame_path = (
+            self.output_temp_dir / f"temp-{frame_ind:0{self.pad_len}d}.png"
         )
-        movie.save(self.output_temp_file, writer=writer, dpi=400)
-        self.video.release()
-        plt.style.use("default")
-        return
+        self.fig.savefig(frame_path, dpi=400)
+        video.release()
+
+        return frame_path
 
     def _get_centroid_data(self, pos_ind):
         def centroid_to_px(*idx):
@@ -514,62 +322,43 @@ class VideoMaker:
             c0, c1 = self._get_centroid_data(pos_ind)
             self.orientation_line.set_data(orient_list(c0), orient_list(c1))
 
-    def _update_plot(self, time_ind, *args):
-        _ = self._video_set_by_ind(time_ind)
+    def generate_frames_multithreaded(self):
+        """Generate frames in parallel using ProcessPoolExecutor."""
+        logger.info("Generating frames in parallel...")
+        with ProcessPoolExecutor(max_workers=25) as executor:
+            futures = {
+                executor.submit(
+                    self._generate_single_frame, frame_ind
+                ): frame_ind
+                for frame_ind in tqdm(self.frames, desc="Submitting frames")
+            }
+            for future in tqdm(
+                as_completed(futures),
+                total=self.n_frames,
+                desc="Generating frames",
+            ):
+                try:
+                    frame_path = future.result()
+                except Exception as exc:
+                    logger.error(
+                        f"Error generating frame {futures[future]}: {exc}"
+                    )
 
-        ret, frame = self.video.read()
-        if ret:
-            frame = self._get_frame(frame, crop_order=(2, 3, 0, 1))
-            self.image.set_array(frame)
+    def stitch_video_from_frames(self):
+        """Stitch generated frames into a video using ffmpeg."""
+        logger.info("Stitching frames into video...")
 
-        pos_ind = np.where(self.video_frame_inds == time_ind)[0]
-
-        if len(pos_ind) == 0:
-            self.centroid_position_dot.set_offsets((np.NaN, np.NaN))
-            for bodypart in self.centroid_plot_objs.keys():
-                self.centroid_plot_objs[bodypart].set_offsets((np.NaN, np.NaN))
-            self.orientation_line.set_data((np.NaN, np.NaN))
-            self.title.set_text(f"time = {0:3.4f}s\n frame = {time_ind}")
-            self.progress_bar.update()
-            return
-
-        pos_ind = pos_ind[0]
-        likelihood_inds = pos_ind + self.window_ind
-        # initial implementation did not cover case of both neg and over < 0
-        neg_inds = np.where(likelihood_inds < 0)[0]
-        likelihood_inds[neg_inds] = 0 if len(neg_inds) > 0 else -1
-
-        dlc_centroid_data = self._get_centroid_data(pos_ind)
-
-        for bodypart in self.centroid_plot_objs:
-            self.centroid_plot_objs[bodypart].set_offsets(
-                _to_px(
-                    data=self.centroids[bodypart][pos_ind],
-                    cm_to_pixels=self.cm_to_pixels,
-                )
-            )
-        self.centroid_position_dot.set_offsets(dlc_centroid_data)
-        _ = self._set_orient_line(frame, pos_ind)
-
-        time_delta = pd.Timedelta(
-            pd.to_datetime(self.position_time[pos_ind] * 1e9, unit="ns")
-            - pd.to_datetime(self.position_time[0] * 1e9, unit="ns")
-        ).total_seconds()
-
-        self.title.set_text(f"time = {time_delta:3.4f}s\n frame = {time_ind}")
-        for bodypart in self.likelihood_objs.keys():
-            self.likelihood_objs[bodypart].set_data(
-                self.window_ind / self.frame_rate,
-                np.asarray(self.likelihoods[bodypart][likelihood_inds]),
-            )
-        self.progress_bar.update()
-
-        return (
-            self.image,
-            self.centroid_position_dot,
-            self.orientation_line,
-            self.title,
+        frame_pattern = str(
+            self.output_temp_dir / f"temp-%0{self.pad_len}d.png"
         )
+        output_video = str(self.output_video_filename)
+
+        ffmpeg_cmd = (
+            "ffmpeg -hide_banner -loglevel error -y "
+            + f"-r {self.fps} -i {frame_pattern} "
+            + f"-c:v libx264 -pix_fmt yuv420p {output_video}"
+        )
+        os_system(ffmpeg_cmd)
 
 
 def make_video(**kwargs):

--- a/src/spyglass/position/v1/dlc_utils_makevid.py
+++ b/src/spyglass/position/v1/dlc_utils_makevid.py
@@ -7,8 +7,6 @@ import subprocess
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from os import system as os_system
 from pathlib import Path
-from random import choices as random_choices
-from string import ascii_letters
 from typing import Tuple
 
 import matplotlib.pyplot as plt
@@ -56,6 +54,7 @@ class VideoMaker:
         max_workers=25,
         max_jobs_in_queue=250,
         debug=False,
+        key_hash=None,
         *args,
         **kwargs,
     ):
@@ -74,10 +73,8 @@ class VideoMaker:
                 + "Use matplotlib or submit a feature request via GitHub."
             )
 
-        self.temp_dir = Path(temp_dir) / "vid_frames"
-        while self.temp_dir.exists():  # multi-user protection
-            suffix = "".join(random_choices(ascii_letters, k=2))
-            self.temp_dir = Path(temp_dir) / f"vid_frames_{suffix}"
+        # key_hash supports resume from previous run
+        self.temp_dir = Path(temp_dir) / f"dlc_vid_{key_hash}"
         self.temp_dir.mkdir(parents=True, exist_ok=True)
         logger.debug(f"Temporary directory: {self.temp_dir}")
         atexit.register(self.cleanup)
@@ -442,6 +439,7 @@ class VideoMaker:
         # Use ffmpeg to extract frames
         ffmpeg_cmd = [
             "ffmpeg",
+            "-y",  # overwrite
             "-i",
             self.video_filename,
             "-vf",
@@ -475,6 +473,7 @@ class VideoMaker:
 
         ffmpeg_cmd = [
             "ffmpeg",
+            "-y",  # overwrite
             "-r",
             str(self.fps),
             "-start_number",
@@ -498,6 +497,7 @@ class VideoMaker:
 
         ffmpeg_cmd = [
             "ffmpeg",
+            "-y",  # overwrite
             "-f",
             "concat",
             "-safe",

--- a/src/spyglass/position/v1/dlc_utils_makevid.py
+++ b/src/spyglass/position/v1/dlc_utils_makevid.py
@@ -425,7 +425,10 @@ class VideoMaker:
 
                 for job in as_completed(jobs):
                     frames_left -= 1
-                    ret = job.result()
+                    try:
+                        ret = job.result()
+                    except IndexError:
+                        ret = None
                     self._debug_print(f"Finish: {ret}")
                     progress_bar.update()
                     del jobs[job]

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -419,7 +419,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             video_frame_inds = video_frame_inds[:limit]
             pos_info_df = pos_info_df.head(limit)
 
-        make_video(
+        video_maker = make_video(
             video_filename=video_filename,
             video_frame_inds=video_frame_inds,
             position_mean={
@@ -441,6 +441,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
         )
 
         if limit:  # don't insert if we're just debugging
-            return
+            return video_maker
 
-        self.insert1(key)
+        if output_video_filename.exists():
+            self.insert1(key)

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -435,6 +435,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             output_video_filename=output_video_filename,
             cm_to_pixels=meters_per_pixel * M_TO_CM,
             crop=pose_estimation_params.get("cropping"),
+            key_hash=dj.hash.key_hash(key),
             **params.get("video_params", {}),
         )
 

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -436,6 +436,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             cm_to_pixels=meters_per_pixel * M_TO_CM,
             crop=pose_estimation_params.get("cropping"),
             key_hash=dj.hash.key_hash(key),
+            debug=params.get("debug", False),
             **params.get("video_params", {}),
         )
 

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -8,15 +8,18 @@ import pandas as pd
 import pynwb
 from datajoint.utils import to_camel_case
 
-from spyglass.common.common_behav import \
-    convert_epoch_interval_name_to_position_interval_name
+from spyglass.common.common_behav import (
+    convert_epoch_interval_name_to_position_interval_name,
+)
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.position.v1.dlc_utils_makevid import make_video
 from spyglass.position.v1.position_dlc_centroid import DLCCentroid
 from spyglass.position.v1.position_dlc_cohort import DLCSmoothInterpCohort
 from spyglass.position.v1.position_dlc_orient import DLCOrientation
 from spyglass.position.v1.position_dlc_pose_estimation import (
-    DLCPoseEstimation, DLCPoseEstimationSelection)
+    DLCPoseEstimation,
+    DLCPoseEstimationSelection,
+)
 from spyglass.position.v1.position_dlc_position import DLCSmoothInterpParams
 from spyglass.utils import SpyglassMixin, logger
 

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -437,6 +437,12 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
         )
         frames = params.get("frames", None)
 
+        limit = 25  # or int to only show first n frames
+        if limit:
+            output_video_filename = Path(".") / f"TEMP_TEST-RM_{limit}.mp4"
+            video_frame_inds = video_frame_inds[:limit]
+            pos_info_df = pos_info_df.head(limit)
+
         make_video(
             video_filename=video_filename,
             video_frame_inds=video_frame_inds,
@@ -455,5 +461,8 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             crop=pose_estimation_params.get("cropping"),
             **params.get("video_params", {}),
         )
+
+        if limit:
+            return
 
         self.insert1(key)

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -437,9 +437,8 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
         )
         frames = params.get("frames", None)
 
-        limit = 25  # or int to only show first n frames
-        if limit:
-            output_video_filename = Path(".") / f"TEMP_TEST-TH_{limit}.mp4"
+        if limit := params.get("limit", None):  # new int param for debugging
+            output_video_filename = Path(".") / f"TEST_VID_{limit}.mp4"
             video_frame_inds = video_frame_inds[:limit]
             pos_info_df = pos_info_df.head(limit)
 
@@ -462,7 +461,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             **params.get("video_params", {}),
         )
 
-        if limit:
+        if limit:  # don't insert if we're just debugging
             return
 
         self.insert1(key)

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -439,7 +439,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
 
         limit = 25  # or int to only show first n frames
         if limit:
-            output_video_filename = Path(".") / f"TEMP_TEST-RM_{limit}.mp4"
+            output_video_filename = Path(".") / f"TEMP_TEST-TH_{limit}.mp4"
             video_frame_inds = video_frame_inds[:limit]
             pos_info_df = pos_info_df.head(limit)
 

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -437,12 +437,6 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
         )
         frames = params.get("frames", None)
 
-        limit = None  # or int to only show first n frames
-        if limit:
-            output_video_filename = f"TEMP_FIRST_{limit}.mp4"
-            video_frame_inds = video_frame_inds[:limit]
-            pos_info_df = pos_info_df.head(limit)
-
         make_video(
             video_filename=video_filename,
             video_frame_inds=video_frame_inds,
@@ -461,8 +455,5 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             crop=pose_estimation_params.get("cropping"),
             **params.get("video_params", {}),
         )
-
-        if limit:
-            return
 
         self.insert1(key)

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -8,18 +8,15 @@ import pandas as pd
 import pynwb
 from datajoint.utils import to_camel_case
 
-from spyglass.common.common_behav import (
-    convert_epoch_interval_name_to_position_interval_name,
-)
+from spyglass.common.common_behav import \
+    convert_epoch_interval_name_to_position_interval_name
 from spyglass.common.common_nwbfile import AnalysisNwbfile
 from spyglass.position.v1.dlc_utils_makevid import make_video
 from spyglass.position.v1.position_dlc_centroid import DLCCentroid
 from spyglass.position.v1.position_dlc_cohort import DLCSmoothInterpCohort
 from spyglass.position.v1.position_dlc_orient import DLCOrientation
 from spyglass.position.v1.position_dlc_pose_estimation import (
-    DLCPoseEstimation,
-    DLCPoseEstimationSelection,
-)
+    DLCPoseEstimation, DLCPoseEstimationSelection)
 from spyglass.position.v1.position_dlc_position import DLCSmoothInterpParams
 from spyglass.utils import SpyglassMixin, logger
 
@@ -342,30 +339,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
         M_TO_CM = 100
 
         params = (DLCPosVideoParams & key).fetch1("params")
-
-        interval_name = convert_epoch_interval_name_to_position_interval_name(
-            {
-                "nwb_file_name": key["nwb_file_name"],
-                "epoch": key["epoch"],
-            },
-            populate_missing=False,
-        )
-
-        if isinstance(interval_name, str):
-            epoch = (
-                int(
-                    interval_name.replace("pos ", "").replace(
-                        " valid times", ""
-                    )
-                )
-                + 1
-            )
-        else:
-            logger.warning(
-                f"Could not find interval name for "
-                + f"{key['nwb_file_name']} epoch {key['epoch']}"
-            )
-            epoch = key["epoch"]
+        epoch = key["epoch"]
 
         pose_est_key = {
             "nwb_file_name": key["nwb_file_name"],


### PR DESCRIPTION
# Description

This PR addresses #1160 by allowing the `make_video` process to continue without a `PosIntervalMap` entry. 

This PR is also a partial address of #1157 by reverting to `matplotlib` as the default video processor, and saves the output as temp files. OpenCV as a tool for reading frames was very memory hungry (300gb for 10k frames) during testing of batch processing, and was probably memory leaking somewhere. Switching to a two step process that saves each frame to disk, RAM usage hovered ~7gb over baseline with the current batch size. More work could be done to dial in these defaults to optimize video creation time based on available resources

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
