### PR TITLE
Allow python <3.13 and remove numpy pin

### DIFF
--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -50,6 +50,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12]
         package: ['wheel', 'sdist', 'archive']
     steps:
       - name: Download sdist and wheel artifacts
@@ -66,7 +67,7 @@ jobs:
           path: archive/
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Update pip

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -74,7 +74,6 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade setuptools wheel
-          pip install --upgrade setuptools_scm pkg_resources
       - name: Install wheel
         if: matrix.package == 'wheel'
         run: pip install dist/*.whl

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install --upgrade setuptools wheel
+          pip install --upgrade setuptools_scm pkg_resources
       - name: Install wheel
         if: matrix.package == 'wheel'
         run: pip install dist/*.whl

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -50,7 +50,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
         package: ['wheel', 'sdist', 'archive']
     steps:
       - name: Download sdist and wheel artifacts

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -50,7 +50,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         package: ['wheel', 'sdist', 'archive']
     steps:
       - name: Download sdist and wheel artifacts

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -49,7 +49,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         package: ['wheel', 'sdist', 'archive']
     steps:
       - name: Download sdist and wheel artifacts

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -29,7 +29,6 @@ jobs:
           python-version: 3.9
       - run: |
           pip install --upgrade build twine
-          pip install importlib_metadata==7.2.1 # twine #977
       - name: Build sdist and wheel
         run: python -m build
       - run: twine check dist/*

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -70,8 +70,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
-      - name: Update pip
-        run: pip install --upgrade pip
+      - name: Install build dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade setuptools wheel
       - name: Install wheel
         if: matrix.package == 'wheel'
         run: pip install dist/*.whl

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -71,8 +71,8 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Install build dependencies
         run: |
-          pip install --upgrade pip
           pip install --upgrade setuptools wheel
+          pip install --upgrade pip
       - name: Install wheel
         if: matrix.package == 'wheel'
         run: pip install dist/*.whl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     - Remove stored hashes from pytests #1152
     - Remove mambaforge from tests #1153
     - Remove debug statement #1164
+- Allow python < 3.13 #1169
+- Remove numpy version restriction #1169
+- Add testing for python versions 3.9, 3.10, 3.11, 3.12 #1169
 
 ### Pipelines
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   # - libgcc # dlc-only
   - matplotlib
   - non_local_detector
-  - numpy<1.24
+  - numpy
   - pip
   - position_tools
   - pybind11  # req by mountainsort4 -> isosplit5

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - pybind11  # req by mountainsort4 -> isosplit5
   - pydotplus
   - pyfftw<=0.12.0  # ghostipy req. install from conda-forge for Mac ARM
-  - python>=3.9,<3.10
+  - python>=3.9,<3.13
   - pytorch<1.12.0
   - ripple_detection
   - seaborn

--- a/environment_dlc.yml
+++ b/environment_dlc.yml
@@ -23,7 +23,7 @@ dependencies:
   - libgcc   # dlc-only
   - matplotlib
   - non_local_detector
-  - numpy<1.24
+  - numpy
   - pip>=20.2.*
   - position_tools
   - pybind11  # req by mountainsort4 -> isosplit5

--- a/environment_dlc.yml
+++ b/environment_dlc.yml
@@ -29,7 +29,7 @@ dependencies:
   - pybind11  # req by mountainsort4 -> isosplit5
   - pydotplus>=2.0.*
   - pyfftw<=0.12.0  # ghostipy req. install from conda-forge for Mac ARM
-  - python>=3.9,<3.10
+  - python>=3.9,<3.13
   - pytorch<1.12.0
   - ripple_detection
   - seaborn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,9 @@ dependencies = [
     "non_local_detector",
     "numpy<1.24",
     "opencv-python",
-    "panel>=1.4.0", # panel #6325 resolved
+    "panel>=1.4.0",                  # panel #6325 resolved
     "position_tools>=0.1.0",
-    "pubnub<6.4.0",            # TODO: remove this when sortingview is updated
+    "pubnub<6.4.0",                  # TODO: remove this when sortingview is updated
     "pydotplus",
     "pynwb>=2.2.0,<3",
     "ripple_detection",
@@ -62,21 +62,21 @@ dependencies = [
 
 [project.optional-dependencies]
 dlc = [
-  "ffmpeg",
-  "deeplabcut[tf]",          # removing dlc pin removes need to pin tf/numba
+    "ffmpeg",
+    "deeplabcut[tf]", # removing dlc pin removes need to pin tf/numba
 ]
 test = [
-    "click",                 # for CLI subpackage only
-    "docker",                # for tests in a container
+    "click",                  # for CLI subpackage only
+    "docker",                 # for tests in a container
     "ghostipy",
-    "kachery",               # database access
+    "kachery",                # database access
     "kachery-client",
     "kachery-cloud>=0.4.0",
     "opencv-python-headless", # for headless testing of Qt
-    "pre-commit",            # linting
-    "pytest",                # unit testing
-    "pytest-cov",            # code coverage
-    "pytest-xvfb",           # for headless testing of Qt
+    "pre-commit",             # linting
+    "pytest",                 # unit testing
+    "pytest-cov",             # code coverage
+    "pytest-xvfb",            # for headless testing of Qt
 ]
 docs = [
     "hatch",                 # Get version from env
@@ -134,7 +134,7 @@ addopts = [
     # "--no-dlc",      # don't run DLC tests
     "--show-capture=no",
     "--pdbcls=IPython.terminal.debugger:TerminalPdb", # use ipython debugger
-    "--doctest-modules", # run doctests in all modules
+    "--doctest-modules",                              # run doctests in all modules
     "--cov=spyglass",
     "--cov-report=term-missing",
     "--no-cov-on-fail",
@@ -143,9 +143,9 @@ testpaths = ["tests"]
 log_level = "INFO"
 env = [
     "QT_QPA_PLATFORM = offscreen", # QT fails headless without this
-    "DISPLAY = :0", # QT fails headless without this
-    "TF_ENABLE_ONEDNN_OPTS = 0", # TF disable approx calcs
-    "TF_CPP_MIN_LOG_LEVEL = 2", # Disable TF warnings
+    "DISPLAY = :0",                # QT fails headless without this
+    "TF_ENABLE_ONEDNN_OPTS = 0",   # TF disable approx calcs
+    "TF_CPP_MIN_LOG_LEVEL = 2",    # Disable TF warnings
 ]
 
 [tool.coverage.run]
@@ -175,4 +175,4 @@ omit = [ # which submodules have no tests
 line-length = 80
 
 [tool.ruff.lint]
-ignore = ["F401" , "E402", "E501"]
+ignore = ["F401", "E402", "E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "spyglass-neuro"
 description = "Neuroscience data analysis framework for reproducible research"
 readme = "README.md"
-requires-python = ">=3.9,<3.10"
+requires-python = ">=3.9,<3.13"
 license = { file = "LICENSE" }
 authors = [
     { name = "Loren Frank", email = "loren.frank@ucsf.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "matplotlib",
     "ndx_franklab_novela>=0.1.0",
     "non_local_detector",
-    "numpy<1.24",
+    "numpy",
     "opencv-python",
     "panel>=1.4.0",                  # panel #6325 resolved
     "position_tools>=0.1.0",


### PR DESCRIPTION
# Description

We previously restricted the maximum python version to be less than 3.10 due to the issue #408. This has now been fixed (see https://github.com/datajoint/datajoint-python/issues/1007) and datajoint is tested up to python 3.12. Therefore, I propose we allow up to 3.12 as well.

We also restricted numpy due to issues with numba (https://github.com/LorenFrankLab/spyglass/pull/462). Numba is now compatible with all recent numpy versions (https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information) although numpy 2.0 only has binary compatibility.

This PR will enable users to use more up to date packages with spyglass (see https://github.com/LorenFrankLab/spyglass/issues/831 for example).

Changes:
+ allow python versions up to 3.12
+ add testing for python versions 3.9-3.12.
+ remove importlib_metadata pin as twine 5.1.1 fixes that issue
+ remove pin on numpy version < 1.24

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] This PR should be accompanied by a release: (yes/**no**/unsure)
- [x] If release, I have updated the `CITATION.cff`
- [x] This PR makes edits to table definitions: (yes/**no**)
- [x] If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
