### PR TITLE
Quickfix: pass config_probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 - Import `datajoint.dependencies.unite_master_parts` -> `topo_sort` #1116,
     #1137, #1162
 - Fix bool settings imported from dj config file #1117
-- Allow definition of tasks and new probe entries from config #1074, #1120
+- Allow definition of tasks and new probe entries from config #1074, #1120, #1179
 - Enforce match between ingested nwb probe geometry and existing table entry
     #1074
 - Update DataJoint install and password instructions #1131

--- a/src/spyglass/common/common_device.py
+++ b/src/spyglass/common/common_device.py
@@ -402,6 +402,7 @@ class Probe(SpyglassMixin, dj.Manual):
             elif probe_type in config_probes:
                 cls._read_config_probe_data(
                     config,
+                    config_probes,
                     probe_type,
                     new_probe_type_dict,
                     new_probe_dict,
@@ -562,6 +563,7 @@ class Probe(SpyglassMixin, dj.Manual):
     def _read_config_probe_data(
         cls,
         config,
+        config_probes,
         probe_type,
         new_probe_type_dict,
         new_probe_dict,


### PR DESCRIPTION
# Description
Fixes issue raised in #1074 where the dictionary `config_probes` was not properly passe

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
