### PR TITLE
set close_file to False to allow fetching position info df

### DIFF
--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -463,7 +463,7 @@ class IntervalPositionInfo(SpyglassMixin, dj.Computed):
         }
 
     def fetch1_dataframe(self):
-        return self._data_to_df(self.fetch_nwb()[0])
+        return self._data_to_df(self.fetch_nwb(close_file=False)[0])  # !!! JAG changed
 
     @staticmethod
     def _data_to_df(data, prefix="head_", add_frame_ind=False):

--- a/src/spyglass/common/common_position.py
+++ b/src/spyglass/common/common_position.py
@@ -463,7 +463,7 @@ class IntervalPositionInfo(SpyglassMixin, dj.Computed):
         }
 
     def fetch1_dataframe(self):
-        return self._data_to_df(self.fetch_nwb(close_file=False)[0])  # !!! JAG changed
+        return self._data_to_df(self.fetch_nwb(close_file=False)[0])
 
     @staticmethod
     def _data_to_df(data, prefix="head_", add_frame_ind=False):


### PR DESCRIPTION
Without this change, fetch1_dataframe in IntervalPositionInfo results in the following error:
RuntimeError: Unable to synchronously get dataspace (invalid dataset identifier)