### PR TITLE
Cleanup IntervalList orphans in weekly job only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
 - Remove numpy version restriction #1169
 - Merge table delete removes orphaned master entries #1164
 - Edit `merge_fetch` to expect positional before keyword arguments #1181
+- Move cleanup of `IntervalList` orphan entries to nightly cleanup #1195
 
 ### Pipelines
 

--- a/docs/src/ForDevelopers/Management.md
+++ b/docs/src/ForDevelopers/Management.md
@@ -228,10 +228,14 @@ disk. There are several tables that retain lists of files that have been
 generated during analyses. If someone deletes analysis entries, files will still
 be on disk.
 
-To remove orphaned files, we run the following commands in our cron jobs:
+Additionally, there are periphery tables such as `IntervalList` which are used
+to store entries created by downstream tables. These entries are not
+automatically deleted when the downstream entry is removed,
+
+To remove orphaned files and entries, we run the following commands in our cron jobs:
 
 ```python
-from spyglass.common import AnalysisNwbfile
+from spyglass.common import AnalysisNwbfile, IntervalList
 from spyglass.spikesorting import SpikeSorting
 from spyglass.common.common_nwbfile import schema as nwbfile_schema
 from spyglass.decoding.v1.sorted_spikes import schema as spikes_schema
@@ -241,8 +245,9 @@ from spyglass.decoding.v1.clusterless import schema as clusterless_schema
 def main():
     AnalysisNwbfile().nightly_cleanup()
     SpikeSorting().nightly_cleanup()
+    IntervalList().nightly_cleanup()
     nwbfile_schema.external['analysis'].delete(delete_external_files=True))
-    nwbfile_schema.external['raw'].delete(delete_external_files=True))
+    **nwbfile_schema**.external['raw'].delete(delete_external_files=True))
     spikes_schema.external['analysis'].delete(delete_external_files=True))
     clusterless_schema.external['analysis'].delete(delete_external_files=True))
 ```

--- a/docs/src/ForDevelopers/Management.md
+++ b/docs/src/ForDevelopers/Management.md
@@ -247,7 +247,7 @@ def main():
     SpikeSorting().nightly_cleanup()
     IntervalList().nightly_cleanup()
     nwbfile_schema.external['analysis'].delete(delete_external_files=True))
-    **nwbfile_schema**.external['raw'].delete(delete_external_files=True))
+    nwbfile_schema.external['raw'].delete(delete_external_files=True))
     spikes_schema.external['analysis'].delete(delete_external_files=True))
     clusterless_schema.external['analysis'].delete(delete_external_files=True))
 ```

--- a/docs/src/ForDevelopers/Management.md
+++ b/docs/src/ForDevelopers/Management.md
@@ -230,7 +230,9 @@ be on disk.
 
 Additionally, there are periphery tables such as `IntervalList` which are used
 to store entries created by downstream tables. These entries are not
-automatically deleted when the downstream entry is removed,
+automatically deleted when the downstream entry is removed. To minimize interference
+with ongoing user entry creation, we recommend running these cleanups on a less frequent
+basis (e.g. weekly).
 
 To remove orphaned files and entries, we run the following commands in our cron jobs:
 
@@ -245,7 +247,7 @@ from spyglass.decoding.v1.clusterless import schema as clusterless_schema
 def main():
     AnalysisNwbfile().nightly_cleanup()
     SpikeSorting().nightly_cleanup()
-    IntervalList().nightly_cleanup()
+    IntervalList().cleanup()
     nwbfile_schema.external['analysis'].delete(delete_external_files=True))
     nwbfile_schema.external['raw'].delete(delete_external_files=True))
     spikes_schema.external['analysis'].delete(delete_external_files=True))

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -158,7 +158,7 @@ class IntervalList(SpyglassMixin, dj.Manual):
         if return_fig:
             return fig
 
-    def nightly_cleanup(self, dry_run=True):
+    def cleanup(self, dry_run=True):
         """Clean up orphaned IntervalList entries."""
         orphans = self - get_child_tables(self)
         if dry_run:

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -485,9 +485,6 @@ class SpyglassMixin(ExportMixin):
                 delete_external_files=True, display_progress=False
             )
 
-        if not self._test_mode:
-            _ = IntervalList().nightly_cleanup(dry_run=False)
-
     def delete(self, *args, **kwargs):
         """Alias for cautious_delete, overwrites datajoint.table.Table.delete"""
         self.cautious_delete(*args, **kwargs)


### PR DESCRIPTION
# Description

Fixes #1194 (solution 2)
- remove `IntervalList` cleanup from `Mixin.delete()`
- Add `IntervalList.cleanup()` to documentation for nightly cron job


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
