### PR TITLE
Limit spikesorting artifacts to valid timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ dj.FreeTable(dj.conn(), "common_session.session_group").drop()
     - Fix bug in `_compute_metric` #1099
     - Fix bug in `insert_curation` returned key #1114
     - Fix handling of waveform extraction sparse parameter #1132
+    - Limit Artifact detection intervals to valid times #1196
 
 ## [0.5.3] (August 27, 2024)
 

--- a/src/spyglass/spikesorting/v0/spikesorting_artifact.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_artifact.py
@@ -276,7 +276,10 @@ def _get_artifact_times(
     for interval_idx, interval in enumerate(artifact_intervals):
         artifact_intervals_s[interval_idx] = [
             valid_timestamps[interval[0]] - half_removal_window_s,
-            valid_timestamps[interval[1]] + half_removal_window_s,
+            np.minimum(
+                valid_timestamps[interval[1]] + half_removal_window_s,
+                valid_timestamps[-1],
+            ),
         ]
     # make the artifact intervals disjoint
     if len(artifact_intervals_s) > 1:

--- a/src/spyglass/spikesorting/v1/artifact.py
+++ b/src/spyglass/spikesorting/v1/artifact.py
@@ -308,7 +308,10 @@ def _get_artifact_times(
             ),
             np.searchsorted(
                 valid_timestamps,
-                valid_timestamps[interval[1]] + half_removal_window_s,
+                np.minimum(
+                    valid_timestamps[interval[1]] + half_removal_window_s,
+                    valid_timestamps[-1],
+                ),
             ),
         ]
         artifact_intervals_s[interval_idx] = [


### PR DESCRIPTION
# Description

Fixes #1176
- In artifact detection, clip intervals going past the valid timestamps to the last valid timepoint
- prevents error when artifact interval window buffer goes past the end of the timestamps

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
