### PR TITLE
Ensure merge tables declared in new database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.5.5] (Unreleased)
+
+### Infrastructure
+
+- Ensure merge tables are declared during file insertion #1205
+
 ## [0.5.4] (December 20, 2024)
 
 ### Infrastructure

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -20,6 +20,7 @@ from spyglass.common.common_session import Session
 from spyglass.common.common_task import TaskEpoch
 from spyglass.common.common_usage import InsertError
 from spyglass.utils import logger
+from spyglass.utils.dj_helper_fn import declare_all_merge_tables
 
 
 def log_insert_error(
@@ -116,6 +117,8 @@ def populate_all_common(
         A list of keys for InsertError entries if any errors occurred.
     """
     from spyglass.spikesorting.imported import ImportedSpikeSorting
+
+    declare_all_merge_tables()
 
     error_constants = dict(
         dj_user=dj.config["database.user"],

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -68,6 +68,20 @@ def ensure_names(
     return getattr(table, "full_table_name", None)
 
 
+def declare_all_merge_tables():
+    """Ensures all merge tables in the spyglass core package are declared.
+    - Prevents circular imports
+    - Prevents errors from table declaration within a transaction
+    - Run during nwb insertion
+    """
+    from spyglass.decoding.decoding_merge import DecodingOutput  # noqa: F401
+    from spyglass.lfp.lfp_merge import LFPOutput  # noqa: F401
+    from spyglass.position.position_merge import PositionOutput  # noqa: F401
+    from spyglass.spikesorting.spikesorting_merge import (  # noqa: F401
+        SpikeSortingOutput,
+    )
+
+
 def fuzzy_get(index: Union[int, str], names: List[str], sources: List[str]):
     """Given lists of items/names, return item at index or by substring."""
     if isinstance(index, int):


### PR DESCRIPTION
# Description

Fixes #1204, #872
- Merge tables not guaranteed to be declared before imported by their parent_source make call
    - Can cause error in fresh database when tries to declare within the make transaction
    - Done to avoid circular imports
- Add new util `declare_all_merge_tables` which imports all core spyglass merge tables to ensure declaration
- Run during `populate_all_common` (part of `insert_sessions`) to ensure tables are declared once data is in the database  


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
