### PR TITLE
Update URL for DANDI Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.5.5] (TBD)
+
+### Infrastructure
+
+- Update URL for DANDI Docs #1210
+
 ## [0.5.4] (December 20, 2024)
 
 ### Infrastructure

--- a/notebooks/05_Export.ipynb
+++ b/notebooks/05_Export.ipynb
@@ -928,9 +928,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first step you will need to do is to [create a Dandi account](https://www.dandiarchive.org/handbook/16_account/). \n",
+    "The first step you will need to do is to [create a Dandi account](https://docs.dandiarchive.org/16_account/). \n",
     "With this account you can then [register a new dandiset](https://dandiarchive.org/dandiset/create) by providing a name and basic metadata. \n",
-    "Dandi's instructions for these steps are available [here](https://www.dandiarchive.org/handbook/13_upload/).\n",
+    "Dandi's instructions for these steps are available [here](https://docs.dandiarchive.org/13_upload/).\n",
     "\n",
     "The key information you will need from your registration is the `dandiset ID` and your account `api_key`, both of which are available from your registered account.\n",
     "\n",

--- a/notebooks/py_scripts/05_Export.py
+++ b/notebooks/py_scripts/05_Export.py
@@ -252,9 +252,9 @@ Export().populate_paper(**paper_key)
 
 # ### Dandiset Upload
 
-# The first step you will need to do is to [create a Dandi account](https://www.dandiarchive.org/handbook/16_account/).
+# The first step you will need to do is to [create a Dandi account](https://docs.dandiarchive.org/16_account/).
 # With this account you can then [register a new dandiset](https://dandiarchive.org/dandiset/create) by providing a name and basic metadata.
-# Dandi's instructions for these steps are available [here](https://www.dandiarchive.org/handbook/13_upload/).
+# Dandi's instructions for these steps are available [here](https://docs.dandiarchive.org/13_upload/).
 #
 # The key information you will need from your registration is the `dandiset ID` and your account `api_key`, both of which are available from your registered account.
 #


### PR DESCRIPTION
# Description

The DANDI Docs URL recently changed from www.dandiarchive.org/handbook to docs.dandiarchive.org

# Checklist

- [x] This PR should be accompanied by a release: unsure
- [ ] If release, I have updated the `CITATION.cff`
- [x] This PR makes edits to table definitions: no
- [x] N/A If table edits, I have included an `alter` snippet for release notes.
- [x] N/A If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description: yes
- [x] I have added/edited docs/notebooks to reflect the changes: yes
