### PR TITLE
Spike group v1 label compatability

### DIFF
--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -189,8 +189,17 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
             ]
 
             # filter the spike times based on the labels if present
-            if "label" in nwb_file[nwb_field_name]:
-                group_label_list = nwb_file[nwb_field_name]["label"].to_list()
+            group_labels = getattr(
+                nwb_file[nwb_field_name],
+                "label",  # v0 compatibility
+                getattr(
+                    nwb_file[nwb_field_name],
+                    "curation_label",  # v1 compatibility
+                    None,
+                ),
+            )
+            if group_labels is not None:
+                group_label_list = group_labels.to_list()
                 include_unit = SortedSpikesGroup.filter_units(
                     group_label_list, include_labels, exclude_labels
                 )


### PR DESCRIPTION
# Description

- Fixes #1236 
    - nwb table column in v1 curation pipeline names `curation_label` in stead of `label` in v0 
    - use either value present when filtering units to include in `SortedSpikesGroup.fetch_spike_data()`

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] N This PR should be accompanied by a release: (yes/no/unsure)
- [ ] NA If release, I have updated the `CITATION.cff`
- [ ] N This PR makes edits to table definitions: (yes/no)
- [ ] NA If table edits, I have included an `alter` snippet for release notes.
- [ ] NA If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] NA I have added/edited docs/notebooks to reflect the changes
