### PR TITLE
Speedup get_sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,9 @@
 - Spikesorting
     - Fix compatibility bug between v1 pipeline and `SortedSpikesGroup` unit
         filtering #1238
-
+    - Speedup `get_sorting` on `CurationV1` #1246
 - Behavior
     - Implement pipeline for keypoint-moseq extraction of behavior syllables #1056
-
 
 ## [0.5.4] (December 20, 2024)
 

--- a/src/spyglass/spikesorting/v1/curation.py
+++ b/src/spyglass/spikesorting/v1/curation.py
@@ -203,25 +203,22 @@ class CurationV1(SpyglassMixin, dj.Manual):
         analysis_file_abs_path = AnalysisNwbfile.get_abs_path(
             analysis_file_name
         )
+
         with pynwb.NWBHDF5IO(
             analysis_file_abs_path, "r", load_namespaces=True
         ) as io:
             nwbf = io.read()
             units = nwbf.units.to_dataframe()
-        units_dict_list = [
-            {
-                unit_id: np.searchsorted(recording.get_times(), spike_times)
-                for unit_id, spike_times in zip(
-                    units.index, units["spike_times"]
-                )
-            }
-        ]
 
-        sorting = si.NumpySorting.from_unit_dict(
-            units_dict_list, sampling_frequency=sampling_frequency
+        recording_times = recording.get_times()
+        units_dict = {
+            unit.Index: np.searchsorted(recording_times, unit.spike_times)
+            for unit in units.itertuples()
+        }
+
+        return si.NumpySorting.from_unit_dict(
+            [units_dict], sampling_frequency=sampling_frequency
         )
-
-        return sorting
 
     @classmethod
     def get_merged_sorting(cls, key: dict) -> si.BaseSorting:


### PR DESCRIPTION
# Description

4x speedup on `get_sorting` method.

+ Eliminate repeated calls to recording.get_times()
+ Use pandas dataframe method `itertuples`

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] This PR should be accompanied by a release: (yes/**no**/unsure)
- [x] If release, I have updated the `CITATION.cff`
- [x] This PR makes edits to table definitions: (yes/**no**)
- [x] If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
