### PR TITLE
Fix mismatch in `time_slice` typing in `SortedSpikesGroup.fetch_spike_data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
     - Fix compatibility bug between v1 pipeline and `SortedSpikesGroup` unit
         filtering #1238, #1249
     - Speedup `get_sorting` on `CurationV1` #1246
-    - Fix type compatability of `time_slice` in `SortedSpikesGroup.fetch_spike_data` #1261
+    - Fix type compatibility of `time_slice` in `SortedSpikesGroup.fetch_spike_data` #1261
 - Behavior
     - Implement pipeline for keypoint-moseq extraction of behavior syllables #1056
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     - Fix compatibility bug between v1 pipeline and `SortedSpikesGroup` unit
         filtering #1238, #1249
     - Speedup `get_sorting` on `CurationV1` #1246
+    - Fix type compatability of `time_slice` in `SortedSpikesGroup.fetch_spike_data` #1261
 - Behavior
     - Implement pipeline for keypoint-moseq extraction of behavior syllables #1056
 

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -208,7 +208,7 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
 
             # filter the spike times based on the time slice if provided
             if time_slice is not None:
-                if isinstance(time_slice, list):
+                if isinstance(time_slice, (list, tuple)):
                     time_slice = slice(*time_slice)
                 sorting_spike_times = [
                     times[

--- a/src/spyglass/spikesorting/analysis/v1/group.py
+++ b/src/spyglass/spikesorting/analysis/v1/group.py
@@ -130,7 +130,7 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
     def fetch_spike_data(
         cls,
         key: dict,
-        time_slice: list[float] = None,
+        time_slice: Union[list[float], slice] = None,
         return_unit_ids: bool = False,
     ) -> Union[list[np.ndarray], Optional[list[dict]]]:
         """fetch spike times for units in the group
@@ -139,7 +139,7 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
         ----------
         key : dict
             dictionary containing the group key
-        time_slice : list of float, optional
+        time_slice : list of float or slice, optional
             if provided, filter for spikes occurring in the interval [start, stop], by default None
         return_unit_ids : bool, optional
             if True, return the unit_ids along with the spike times, by default False
@@ -208,6 +208,8 @@ class SortedSpikesGroup(SpyglassMixin, dj.Manual):
 
             # filter the spike times based on the time slice if provided
             if time_slice is not None:
+                if isinstance(time_slice, list):
+                    time_slice = slice(*time_slice)
                 sorting_spike_times = [
                     times[
                         np.logical_and(


### PR DESCRIPTION
# Description

- Fixes #1260 
    - enable `time_slice` to be either a `slice` or a `list` of start and stop time
    - Update docstring

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
