### PR TITLE
Generalizations for nwb ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,25 @@ Table update script
 from spyglass.lfp.lfp_imported import ImportedLFP
 from spyglass.lfp.lfp_merge import LFPOutput
 
-if len(ImportedLFP()):
-    raise ValueError("Existing ImportedLFP entries found and would be dropped in update." +
-                     "Please delete entries or contact spyglass support for assistance migrating.")
-if len(LFPOutput.ImportedLFP()):
+if len(ImportedLFP()) or len(LFPOutput.ImportedLFP()):
     raise ValueError(
-        "Existing ImportedLFP entries found in merge table and would be dropped in update."
-        + "Please delete entries or contact spyglass support for assistance migrating."
+        "Existing entries found and would be dropped in update. Please delete "
+        + "entries or start a GitHub discussion for migration assistance."
+        + f"\nImportedLFP: {len(ImportedLFP())}"
+        + f"\nLFPOutput.ImportedLFP: {len(LFPOutput.ImportedLFP())}"
     )
+
 table = LFPOutput().ImportedLFP()
-if len(drop_list := table.connection.dependencies.descendants(table.full_table_name))>1:
-    drop_list = [x for x in drop_list if x != table.full_table_name]
-    raise ValueError("Downstream tables exist and would be dropped in update." +
-                     "Please drop the following tables first: \n" +
-                     "\n ".join([str(t) for t in drop_list])
+table_name = table.full_table_name
+
+if len(drop_list := table.connection.dependencies.descendants(table_name)) > 1:
+    drop_list = [x for x in drop_list if x != table_name]
+    raise ValueError(
+        "Downstream tables exist and would be dropped in update."
+        + "Please drop the following tables first: \n"
+        + "\n ".join([str(t) for t in drop_list])
     )
+
 LFPOutput().ImportedLFP().drop_quick()
 ImportedLFP().drop()
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [0.5.5] (Unreleased)
 
+Table update script
+
+```py
+from spyglass.lfp.lfp_imported import ImportedLFP
+from spyglass.lfp.lfp_merge import LFPOutput
+
+if len(ImportedLFP()):
+    raise ValueError("Existing ImportedLFP entries found and would be dropped in update." +
+                     "Please delete entries or contact spyglass support for assistance migrating.")
+if len(LFPOutput.ImportedLFP()):
+    raise ValueError(
+        "Existing ImportedLFP entries found in merge table and would be dropped in update."
+        + "Please delete entries or contact spyglass support for assistance migrating."
+    )
+table = LFPOutput().ImportedLFP()
+if len(drop_list := table.connection.dependencies.descendants(table.full_table_name))>1:
+    drop_list = [x for x in drop_list if x != table.full_table_name]
+    raise ValueError("Downstream tables exist and would be dropped in update." +
+                     "Please drop the following tables first: \n" +
+                     "\n ".join([str(t) for t in drop_list])
+    )
+LFPOutput().ImportedLFP().drop_quick()
+ImportedLFP().drop()
+```
+
 ### Infrastructure
 
 - Ensure merge tables are declared during file insertion #1205

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
     - Set `probe_id` as `probe_description` when inserting from nwb file #1220
     - Default `AnalysisNwbfile.create` permissions are now 777 #1226
     - Make `Nwbfile.fetch_nwb` functional # 1256
+    - Ingest all `ImageSeries` objects in nwb file to `VideoFile` #1278
+    - Allow ingestion of multi-row task epoch tables #1278
 - Position
     - Allow population of missing `PositionIntervalMap` entries during population
         of `DLCPoseEstimation` #1208
@@ -33,6 +35,8 @@
         `SortedSpikesGroup.fetch_spike_data` #1261
 - Behavior
     - Implement pipeline for keypoint-moseq extraction of behavior syllables #1056
+- LFP
+    - Implement `ImportedLFP.make()`  for ingestion from nwb files #1278
 
 ## [0.5.4] (December 20, 2024)
 

--- a/docs/src/ForDevelopers/UsingNWB.md
+++ b/docs/src/ForDevelopers/UsingNWB.md
@@ -202,8 +202,8 @@ pynwb.ecephys.LFP </b>
 | Spyglass Table     |        Key         |                                     NWBfile Location     | Config option | Notes |
 | :----------------- | :----------------: | -------------------------------------------------------: | ------------: | ----: |
 | ImportedLFP        | lfp_sampling_rate  | LFP.eseries.rate else, estimated from eseries.timestamps |               | float |
-| IntervalList (raw) | interval_list_name |                           "imported lfp {i} valid times" |               |   str |
-| IntervalList (raw) |    valid_times     |         get_valid_intervals(eseries.timestamps, ...)     |               |       |
+| IntervalList       | interval_list_name |                           "imported lfp {i} valid times" |               |   str |
+| IntervalList       |    valid_times     |         get_valid_intervals(LFP.eseries.timestamps, ...) |               |       |
 
 <b> NWBfile Location: nwbf.processing.sample_count </br> Object type:
 pynwb.base.TimeSeries </b>

--- a/docs/src/ForDevelopers/UsingNWB.md
+++ b/docs/src/ForDevelopers/UsingNWB.md
@@ -84,6 +84,9 @@ The following tables highlight the correspondence between NWB objects and
 Spyglass tables/fields and should be a useful reference for developers looking
 to adapt existing NWB files for Spyglass injestion.
 
+Note that for entries where the **NWBfile Location** is a pynwb class, all objects in
+the nwb file of this class will be inserted into the spyglass table
+
 Please contact the developers if you have any questions or need help with
 adapting your NWB files for use with Spyglass, especially items marked with
 'TODO' in the tables below.
@@ -193,6 +196,15 @@ pynwb.ecephys.ElectricalSeries </b>
 | IntervalList (raw) | interval_list_name |                               "raw data valid times" |               |   str |
 | IntervalList (raw) |    valid_times     |         get_valid_intervals(eseries.timestamps, ...) |               |       |
 
+<b> NWBfile Location: pynwb.ecephys.LFP </br> Object type:
+pynwb.ecephys.LFP </b>
+
+| Spyglass Table     |        Key         |                                     NWBfile Location     | Config option | Notes |
+| :----------------- | :----------------: | -------------------------------------------------------: | ------------: | ----: |
+| ImportedLFP        | lfp_sampling_rate  | LFP.eseries.rate else, estimated from eseries.timestamps |               | float |
+| IntervalList (raw) | interval_list_name |                           "imported lfp {i} valid times" |               |   str |
+| IntervalList (raw) |    valid_times     |         get_valid_intervals(eseries.timestamps, ...)     |               |       |
+
 <b> NWBfile Location: nwbf.processing.sample_count </br> Object type:
 pynwb.base.TimeSeries </b>
 
@@ -251,7 +263,7 @@ hdmf.common.table.DynamicTable </b>
 | :--------------------------- | :--------------------: | -------------------------------------------------------------------------------: | ------------: | --------------------: |
 | IntervalList (position)      |   interval_list_name   |                                                        "pos {index} valid times" |               |                       |
 | IntervalList (position)      |      valid_times       | get_valid_intervals(nwbf.processing.behavior.position.\[index\].timestamps, ...) |               |                       |
-| PositionSource               |         source         |                                                                         "trodes" |               | TODO: infer from file |
+| PositionSource               |         source         |                                                                       "imported" |               |  |
 | PositionSource               |   interval_list_name   |                                                     See: IntervalList (position) |               |                       |
 | PositionSource.SpatialSeries |           id           |   int(nwbf.processing.behavior.position.\[index\]) (the enumerated index number) |               |                       |
 | RawPosition.PosObject        | raw_position_object_id |                            nwbf.processing.behavior.position.\[index\].object_id |               |                       |
@@ -269,7 +281,7 @@ pynwb.image.ImageSeries </b>
 
 | Spyglass Table |     Key     |                                        NWBfile Location | Config option | Notes |
 | :------------- | :---------: | ------------------------------------------------------: | ------------: | ----: |
-| VideoFile      | camera_name | nwbf.processing.video_files.video.\[index\].camera_name |               |       |
+| VideoFile      | camera_name | pynwb.ImageSeries |               |       |
 
 <b> NWBfile Location: nwbf.processing.associated_files <br/> Object type:
 ndx_franklab_novela.AssociatedFiles </b>

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -395,14 +395,11 @@ class VideoFile(SpyglassMixin, dj.Imported):
         for obj_id, obj in nwbf.objects.items():
             if isinstance(obj, pynwb.image.ImageSeries):
                 videos[obj.name] = obj
-
-        if videos is None:
+        if not videos:
             logger.warning(
                 f"No video data interface found in {nwb_file_name}\n"
             )
             return
-        else:
-            videos = videos.time_series
 
         # get the interval for the current TaskEpoch
         interval_list_name = (TaskEpoch() & key).fetch1("interval_list_name")

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -390,9 +390,11 @@ class VideoFile(SpyglassMixin, dj.Imported):
         nwb_file_name = key["nwb_file_name"]
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         nwbf = get_nwb_file(nwb_file_abspath)
-        videos = get_data_interface(
-            nwbf, "video", pynwb.behavior.BehavioralEvents
-        )
+        # get all ImageSeries objects in the NWB file
+        videos = {}
+        for obj_id, obj in nwbf.objects.items():
+            if isinstance(obj, pynwb.image.ImageSeries):
+                videos[obj.name] = obj
 
         if videos is None:
             logger.warning(

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -388,10 +388,11 @@ class VideoFile(SpyglassMixin, dj.Imported):
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         nwbf = get_nwb_file(nwb_file_abspath)
         # get all ImageSeries objects in the NWB file
-        videos = {}
-        for obj_id, obj in nwbf.objects.items():
-            if isinstance(obj, pynwb.image.ImageSeries):
-                videos[obj.name] = obj
+        videos = {
+            obj.name: obj
+            for obj in nwbf.objects.values()
+            if isinstance(obj, pynwb.image.ImageSeries)
+        }
         if not videos:
             logger.warning(
                 f"No video data interface found in {nwb_file_name}\n"

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -376,11 +376,8 @@ class VideoFile(SpyglassMixin, dj.Imported):
 
     _nwb_table = Nwbfile
 
-    def make(self, key):
-        """Make without transaction"""
-        self._no_transaction_make(key)
-
-    def _no_transaction_make(self, key, verbose=True, skip_duplicates=False):
+    def make(self, key, verbose=True, skip_duplicates=False):
+        """Make without optional transaction"""
         if not self.connection.in_transaction:
             self.populate(key)
             return

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -235,7 +235,7 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
                 task_inserts.append(key.copy())
 
         # check if the task entries are in the Task table and if not, add it
-        Task.insert_from_task_table(task_table)
+        Task().insert_from_task_table(task_table)
         self.insert(task_inserts, allow_direct_insert=True)
 
     @classmethod

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -60,7 +60,8 @@ class Task(SpyglassMixin, dj.Manual):
         # Check if the task is already in the table
         # if so check that the secondary keys all match
         for task_dict in task_dicts:
-            if existing_task := (self & task_dict).fetch1("KEY"):
+            if len(existing_task := (self & task_dict).fetch("KEY")):
+                existing_task = existing_task[0]
                 for k, v in task_dict.items():
                     if existing_task[k] != v:
                         raise ValueError(

--- a/src/spyglass/common/common_task.py
+++ b/src/spyglass/common/common_task.py
@@ -142,10 +142,13 @@ class TaskEpoch(SpyglassMixin, dj.Imported):
             return
 
         task_inserts = []
-        for task in tasks_mod.data_interfaces.values():
-            if self.check_task_table(task):
-                # check if the task is in the Task table and if not, add it
-                Task.insert_from_task_table(task)
+        for task_table in tasks_mod.data_interfaces.values():
+            if not self.check_task_table(task_table):
+                continue
+            # check if the task entries are in the Task table and if not, add it
+            Task.insert_from_task_table(task_table)
+
+            for task in task_table:
                 key["task_name"] = task.task_name[0]
 
                 # get the CameraDevice used for this task (primary key is

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -20,6 +20,7 @@ from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session
 from spyglass.common.common_task import TaskEpoch
 from spyglass.common.common_usage import InsertError
+from spyglass.lfp import ImportedLFP
 from spyglass.utils import logger
 from spyglass.utils.dj_helper_fn import declare_all_merge_tables
 
@@ -140,6 +141,7 @@ def populate_all_common(
             DIOEvents,  # Depends on Session
             TaskEpoch,  # Depends on Session
             ImportedSpikeSorting,  # Depends on Session
+            ImportedLFP,  # Depends on Session
             # NwbfileKachery, # Not used by default
             # SensorData, # Not used by default. Generates large files
         ],

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -20,7 +20,6 @@ from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session
 from spyglass.common.common_task import TaskEpoch
 from spyglass.common.common_usage import InsertError
-from spyglass.lfp import ImportedLFP
 from spyglass.utils import logger
 from spyglass.utils.dj_helper_fn import declare_all_merge_tables
 
@@ -121,6 +120,7 @@ def populate_all_common(
     List
         A list of keys for InsertError entries if any errors occurred.
     """
+    from spyglass.lfp.lfp_imported import ImportedLFP
     from spyglass.position.v1.imported_pose import ImportedPose
     from spyglass.spikesorting.imported import ImportedSpikeSorting
 

--- a/src/spyglass/lfp/lfp_electrode.py
+++ b/src/spyglass/lfp/lfp_electrode.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import datajoint as dj
 from numpy import ndarray
 
@@ -60,3 +62,50 @@ class LFPElectrodeGroup(SpyglassMixin, dj.Manual):
                 LFPElectrodeGroup().LFPElectrode.insert1(
                     lfpelectdict, skip_duplicates=True
                 )
+
+    def cautious_insert(
+        self, session_key: dict, electrode_ids: List[int], group_name: str
+    ) -> str:
+        """Insert the electrode group, or return name if it already exists.
+
+        Parameters
+        ----------
+        session_key : dict
+            The session key associated with the electrode group.
+        electrode_ids : list
+            The set of electrode ids to insert into the group.
+        group_name : str
+            The name of the electrode group to insert.
+
+        Returns
+        ----------
+        dictionary
+            The key of the inserted group, or the existing group if it already exists.
+        """
+        e_ids = set(electrode_ids)  # remove duplicates
+
+        # Collect existing ids into comma separated string to avoid multi-fetch
+        aggregated = (self & session_key).aggr(
+            self.LFPElectrode,
+            ids="GROUP_CONCAT(electrode_id ORDER BY electrode_id ASC)",
+        )
+
+        # group for this set of electrodes already exists
+        sorted_str = ",".join(map(str, sorted(e_ids)))
+        if len(query := aggregated & f"ids='{sorted_str}'"):
+            return query.fetch("KEY")[0]  # could be mult
+
+        # group with this name already exists for a different set of electrodes
+        if len(aggregated & {"lfp_electrode_group_name": group_name}):
+            raise ValueError(
+                f"LFP Group name {group_name} already exists"
+                + "for a different set of electrode ids."
+            )
+
+        # Unique group and set of electrodes, insert
+        master_insert = dict(**session_key, lfp_electrode_group_name=group_name)
+        electrode_inserts = [dict(master_insert, electrode_id=e) for e in e_ids]
+
+        self.insert1(master_insert)
+        self.LFPElectrode.insert(electrode_inserts)
+        return master_insert

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -11,7 +11,11 @@ from spyglass.common.common_session import Session  # noqa: F401
 from spyglass.lfp.lfp_electrode import LFPElectrodeGroup  # noqa: F401
 from spyglass.utils import logger
 from spyglass.utils.dj_mixin import SpyglassMixin
-from spyglass.utils.nwb_helper_fn import estimate_sampling_rate, get_nwb_file
+from spyglass.utils.nwb_helper_fn import (
+    estimate_sampling_rate,
+    get_nwb_file,
+    get_valid_intervals,
+)
 
 schema = dj.schema("lfp_imported")
 
@@ -108,8 +112,9 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
             interval_key = {
                 "nwb_file_name": nwb_file_name,
                 "interval_list_name": f"imported lfp {i} valid times",
-                "valid_times": np.array(
-                    [[es_object.timestamps[0], es_object.timestamps[-1]]]
+                "valid_times": get_valid_intervals(
+                    es_object.timestamps,
+                    sampling_rate,
                 ),
                 "pipeline": "imported_lfp",
             }

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -1,10 +1,17 @@
 import datajoint as dj
+import numpy as np
+import pynwb
 
 from spyglass.common.common_interval import IntervalList  # noqa: F401
-from spyglass.common.common_nwbfile import AnalysisNwbfile  # noqa: F401
+from spyglass.common.common_nwbfile import (
+    AnalysisNwbfile,
+    Nwbfile,
+)  # noqa: F401
 from spyglass.common.common_session import Session  # noqa: F401
 from spyglass.lfp.lfp_electrode import LFPElectrodeGroup  # noqa: F401
+from spyglass.utils import logger
 from spyglass.utils.dj_mixin import SpyglassMixin
+from spyglass.utils.nwb_helper_fn import estimate_sampling_rate, get_nwb_file
 
 schema = dj.schema("lfp_imported")
 
@@ -15,14 +22,104 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
     -> Session                      # the session to which this LFP belongs
     -> LFPElectrodeGroup            # the group of electrodes to be filtered
     -> IntervalList                 # the original set of times to be filtered
-    lfp_object_id: varchar(40)      # object ID for loading from the NWB file
     ---
     lfp_sampling_rate: float        # the sampling rate, in samples/sec
-    -> AnalysisNwbfile
+    lfp_object_id: varchar(40)      # object ID of an lfp electrical series for loading from the NWB file
     """
+
+    _nwb_table = Nwbfile
 
     def make(self, key):
         """Placeholder for importing LFP."""
         raise NotImplementedError(
             "For `insert`, use `allow_direct_insert=True`"
         )
+
+    def _no_transaction_make(self, key):
+
+        nwb_file_name = key["nwb_file_name"]
+        nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
+        nwbf = get_nwb_file(nwb_file_abspath)
+
+        # get the set of lfp objects in the file
+        lfp_objects = []
+        for obj in nwbf.objects:
+            if isinstance(obj, pynwb.ecephys.LFP):
+                lfp_objects.append(obj)
+
+        if len(lfp_objects) == 0:
+            logger.warning(
+                f"No LFP objects found in {nwb_file_name}. Skipping."
+            )
+            return
+        # get the electrical series objects from the lfp objects
+        lfp_es_objects = []
+        for lfp_object in lfp_objects:
+            lfp_es_objects.extend(list(lfp_object.electrical_series.values()))
+
+        for i, es_object in enumerate(lfp_es_objects):
+            electrodes_df = es_object.electrodes.to_dataframe()
+            electrode_ids = electrodes_df.index.values
+
+            # check if existing electrode group for this set of electrodes exists
+            e_group_query = LFPElectrodeGroup() & {
+                "nwb_file_name": nwb_file_name,
+            }
+            group_key = None
+            for test_group_key in e_group_query.fetch("KEY"):
+                group_electodes = (
+                    LFPElectrodeGroup().LFPElectrode() & test_group_key
+                ).fetch("electrode_id")
+
+                if set(group_electodes) == set(electrode_ids):
+                    group_key = test_group_key
+                    break
+
+            if group_key is None:
+                # need to create a new group
+                group_num = len(
+                    e_group_query
+                    & "lfp_electrode_group_name LIKE 'imported_lfp_%'"
+                )
+                group_name = f"imported_lfp_{group_num:03}"
+                group_key = {
+                    "nwb_file_name": nwb_file_name,
+                    "lfp_electrode_group_name": group_name,
+                }
+                if len(LFPElectrodeGroup() & group_key):
+                    raise ValueError(
+                        f"LFPElectrodeGroup {group_key} already exists with different electrode entries."
+                    )
+
+                LFPElectrodeGroup().create_lfp_electrode_group(
+                    nwb_file_name=nwb_file_name,
+                    group_name=group_name,
+                    electrode_ids=electrode_ids,
+                )
+
+            # estimate the sampling rate or read in if available
+            sampling_rate = (
+                estimate_sampling_rate(es_object.timestamps[: int(1e6)])
+                if es_object.rate is None
+                else es_object.rate
+            )
+
+            # create a new interval list for the valid times
+            interval_key = {
+                "nwb_file_name": nwb_file_name,
+                "interval_list_name": f"imported lfp {i} valid times",
+                "valid_times": np.array(
+                    [[es_object.timestamps[0], es_object.timestamps[-1]]]
+                ),
+                "pipeline": "imported_lfp",
+            }
+            IntervalList().insert1(interval_key)
+
+            # build key to insert into ImportedLFP
+            insert_key = {
+                **group_key,
+                "interval_list_name": interval_key["interval_list_name"],
+                "lfp_sampling_rate": sampling_rate,
+                "lfp_object_id": es_object.object_id,
+            }
+            self.insert1(insert_key, allow_direct_insert=True)

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -34,22 +34,14 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
     _nwb_table = Nwbfile
 
     def make(self, key):
-        """Placeholder for importing LFP."""
-        raise NotImplementedError(
-            "For `insert`, use `allow_direct_insert=True`"
-        )
-
-    def _no_transaction_make(self, key):
-
         nwb_file_name = key["nwb_file_name"]
         nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
         nwbf = get_nwb_file(nwb_file_abspath)
 
         # get the set of lfp objects in the file
-        lfp_objects = []
-        for obj in nwbf.objects:
-            if isinstance(obj, pynwb.ecephys.LFP):
-                lfp_objects.append(obj)
+        lfp_objects = [
+            obj for obj in nwbf.objects if isinstance(obj, pynwb.ecephys.LFP)
+        ]
 
         if len(lfp_objects) == 0:
             logger.warning(
@@ -102,10 +94,8 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
                 )
 
             # estimate the sampling rate or read in if available
-            sampling_rate = (
-                estimate_sampling_rate(es_object.timestamps[: int(1e6)])
-                if es_object.rate is None
-                else es_object.rate
+            sampling_rate = es_object.rate or estimate_sampling_rate(
+                es_object.timestamps[: int(1e6)]
             )
 
             # create a new interval list for the valid times

--- a/src/spyglass/position/v1/dlc_utils.py
+++ b/src/spyglass/position/v1/dlc_utils.py
@@ -362,7 +362,7 @@ def get_video_info(key):
     video_query = VideoFile & vf_key
 
     if not video_query:
-        VideoFile()._no_transaction_make(vf_key, verbose=False)
+        VideoFile().make(vf_key, verbose=False)
 
     if len(video_query) != 1:
         logger.warning(f"Found {len(video_query)} videos for {vf_key}")

--- a/tests/lfp/test_lfp.py
+++ b/tests/lfp/test_lfp.py
@@ -102,6 +102,9 @@ def test_artifact_detection(lfp, pop_art_detection):
     pass
 
 
+@pytest.mark.skip(
+    reason="Implemented in #1278, but no importable entry in test dataset"
+)
 def test_pop_imported_lfp(lfp):
     with pytest.raises(NotImplementedError):
         lfp.lfp_imported.ImportedLFP().populate()


### PR DESCRIPTION
# Description

Resolution of several issues regarding nwb ingestion by other groups.

- Fixes #1224 
  - When finding videos for population of `VideoFile` get all `ImageSeries` objects in the nwb file rather than looking specifically in `nwbf.processing['video']`
  - Less arbitrarily restrictive for other labs' nwb generation  

- Fixes #1221 
    - Allow complete ingestion of task tables with more than one row
 
- Fixes #1229 
    - Modify definition of `ImportedLFP`
        - No longer dependent on `AnalysisNwbfile`
        - Instead, expected to point to an e-series object containing lfp data in the raw nwb  
    - Implement `ImportedLFP._no_transaction_make`
        - Find  LFP objects in the raw file and the eseries contained within. For each object
            - Determine the electrodes of the eseries, making a new `LFPElectrodeGroup` entry if necessary
            - Make a `IntervalList` entry spanning the lfp times
            - insert into `ImportedLFP` 

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] Unsure This PR should be accompanied by a release: (yes/no/unsure)
- [x] N If release, I have updated the `CITATION.cff`
- [x] YES This PR makes edits to table definitions: (yes/no)
- [x] Y If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes
