### PR TITLE
Quickfix: spikesorting vo _use_transaction

### DIFF
--- a/src/spyglass/spikesorting/v0/spikesorting_curation.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_curation.py
@@ -324,7 +324,7 @@ class WaveformSelection(SpyglassMixin, dj.Manual):
 
 @schema
 class Waveforms(SpyglassMixin, dj.Computed):
-    use_transaction, _allow_insert = False, True
+    _use_transaction, _allow_insert = False, True
 
     definition = """
     -> WaveformSelection
@@ -525,7 +525,7 @@ class MetricSelection(SpyglassMixin, dj.Manual):
 
 @schema
 class QualityMetrics(SpyglassMixin, dj.Computed):
-    use_transaction, _allow_insert = False, True
+    _use_transaction, _allow_insert = False, True
 
     definition = """
     -> MetricSelection
@@ -963,7 +963,7 @@ class CuratedSpikeSorting(SpyglassMixin, dj.Computed):
     -> AnalysisNwbfile
     units_object_id: varchar(40)
     """
-    use_transaction, _allow_insert = False, True
+    _use_transaction, _allow_insert = False, True
 
     class Unit(SpyglassMixin, dj.Part):
         definition = """

--- a/src/spyglass/spikesorting/v0/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_recording.py
@@ -292,7 +292,7 @@ class SpikeSortingRecordingSelection(SpyglassMixin, dj.Manual):
 
 @schema
 class SpikeSortingRecording(SpyglassMixin, dj.Computed):
-    use_transaction, _allow_insert = False, True
+    _use_transaction, _allow_insert = False, True
 
     definition = """
     -> SpikeSortingRecordingSelection


### PR DESCRIPTION
# Description

`_use_transaction` was missing leading underscore in v0 spikesorting tables preventing disableing transactions by default

- Fixes #000: How this PR fixes the issue
    - `path/file.py`: Description of the change
    - `path/file.py`: Description of the change
- Fixes #000: How this PR fixes the issue
    - `path/file.py`: Description of the change
    - `path/file.py`: Description of the change

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] If release, I have updated the `CITATION.cff`
- [ ] This PR makes edits to table definitions: (yes/no)
- [ ] If table edits, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] I have added/edited docs/notebooks to reflect the changes
