### PR TITLE
Store arrays in AnalysisNwbfile

### DIFF
--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pynwb
 import spikeinterface as si
 from hdmf.common import DynamicTable
+from pynwb.core import ScratchData
 
 from spyglass import __version__ as sg_version
 from spyglass.settings import analysis_dir, raw_dir
@@ -416,6 +417,15 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
             if isinstance(nwb_object, pd.DataFrame):
                 nwb_object = DynamicTable.from_dataframe(
                     name=table_name, df=nwb_object
+                )
+            elif isinstance(nwb_object, np.ndarray):
+                nwb_object = ScratchData(
+                    name=(
+                        "numpy_array"
+                        if table_name == "pandas_table"
+                        else table_name
+                    ),
+                    data=nwb_object,
                 )
             nwbf.add_scratch(nwb_object)
             io.write(nwbf)


### PR DESCRIPTION
# Description

Fixes #1297 
- Allows passing numpy arrays to `AnalysisNwbfile.add_nw_object() for external file storage
- Stores these in a pynwb `ScratchData` object in the nwb file

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] N This PR should be accompanied by a release: (yes/no/unsure)
- [ ] NA If release, I have updated the `CITATION.cff`
- [ ] N This PR makes edits to table definitions: (yes/no)
- [ ] NA If table edits, I have included an `alter` snippet for release notes.
- [ ] NA If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] NA I have added/edited docs/notebooks to reflect the changes
