### PR TITLE
LFP Import fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,10 @@ ImportedLFP().drop()
     - Adding a condition in the MAD detector to replace zero, NaN, or infinite
         MAD values with 1.0. #1280
     - Refactoring the creation of LFPElectrodeGroup with added input validation
-        and transactional insertion. #1280
+        and transactional insertion. #1280, #1302
     - Updating the LFPBandSelection logic with comprehensive validation and batch
         insertion for electrodes and references. #1280
-    - Implement `ImportedLFP.make()`  for ingestion from nwb files #1278
+    - Implement `ImportedLFP.make()`  for ingestion from nwb files #1278, #1302
 
 ## [0.5.4] (December 20, 2024)
 

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -86,7 +86,7 @@ def single_transaction_make(
             if table_name == "PositionSource":
                 # PositionSource only uses nwb_file_name - full calls redundant
                 key_source = dj.U("nwb_file_name") & key_source
-            if table_name == "ImportedPose":
+            if table_name in ["ImportedPose", "ImportedLFP"]:
                 key_source = Nwbfile()
 
             for pop_key in (key_source & file_restr).fetch("KEY"):
@@ -142,7 +142,6 @@ def populate_all_common(
             DIOEvents,  # Depends on Session
             TaskEpoch,  # Depends on Session
             ImportedSpikeSorting,  # Depends on Session
-            ImportedLFP,  # Depends on Session
             SensorData,  # Depends on Session
             # NwbfileKachery, # Not used by default
         ],
@@ -152,6 +151,7 @@ def populate_all_common(
             VideoFile,  # Depends on TaskEpoch
             StateScriptFile,  # Depends on TaskEpoch
             ImportedPose,  # Depends on Session
+            ImportedLFP,  # Depends on ElectrodeGroup
         ],
         [
             RawPosition,  # Depends on PositionSource

--- a/src/spyglass/lfp/lfp_electrode.py
+++ b/src/spyglass/lfp/lfp_electrode.py
@@ -164,7 +164,9 @@ class LFPElectrodeGroup(SpyglassMixin, dj.Manual):
         # Unique group and set of electrodes, insert
         master_insert = dict(**session_key, lfp_electrode_group_name=group_name)
         electrode_inserts = (
-            Electrode() & session_key & f"electrode_id in {tuple(e_ids)}"
+            Electrode()
+            & session_key
+            & [{"electrode_id": e_id} for e_id in e_ids]
         ).fetch("KEY")
         electrode_inserts = [
             {**electrode_insert, "lfp_electrode_group_name": group_name}

--- a/src/spyglass/lfp/lfp_electrode.py
+++ b/src/spyglass/lfp/lfp_electrode.py
@@ -163,7 +163,13 @@ class LFPElectrodeGroup(SpyglassMixin, dj.Manual):
 
         # Unique group and set of electrodes, insert
         master_insert = dict(**session_key, lfp_electrode_group_name=group_name)
-        electrode_inserts = [dict(master_insert, electrode_id=e) for e in e_ids]
+        electrode_inserts = (
+            Electrode() & session_key & f"electrode_id in {tuple(e_ids)}"
+        ).fetch("KEY")
+        electrode_inserts = [
+            {**electrode_insert, "lfp_electrode_group_name": group_name}
+            for electrode_insert in electrode_inserts
+        ]
 
         self.insert1(master_insert)
         self.LFPElectrode.insert(electrode_inserts)

--- a/src/spyglass/lfp/lfp_electrode.py
+++ b/src/spyglass/lfp/lfp_electrode.py
@@ -163,14 +163,14 @@ class LFPElectrodeGroup(SpyglassMixin, dj.Manual):
 
         # Unique group and set of electrodes, insert
         master_insert = dict(**session_key, lfp_electrode_group_name=group_name)
-        electrode_inserts = (
+        electrode_keys = (
             Electrode()
             & session_key
             & [{"electrode_id": e_id} for e_id in e_ids]
         ).fetch("KEY")
+        e_group_dict = dict(lfp_electrode_group_name=group_name)
         electrode_inserts = [
-            {**electrode_insert, "lfp_electrode_group_name": group_name}
-            for electrode_insert in electrode_inserts
+            dict(e_key, **e_group_dict) for e_key in electrode_keys
         ]
 
         self.insert1(master_insert)

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -56,6 +56,11 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
             lfp_es_objects.extend(list(lfp_object.electrical_series.values()))
 
         for i, es_object in enumerate(lfp_es_objects):
+            if len(self & {"lfp_object_id": es_object.object_id}) > 0:
+                logger.warning(
+                    f"Skipping {es_object.object_id} because it already exists in ImportedLFP."
+                )
+                continue
             electrodes_df = es_object.electrodes.to_dataframe()
             electrode_ids = electrodes_df.index.values
 

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -40,7 +40,9 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
 
         # get the set of lfp objects in the file
         lfp_objects = [
-            obj for obj in nwbf.objects if isinstance(obj, pynwb.ecephys.LFP)
+            obj
+            for obj in nwbf.objects.values()
+            if isinstance(obj, pynwb.ecephys.LFP)
         ]
 
         if len(lfp_objects) == 0:

--- a/tests/common/test_behav.py
+++ b/tests/common/test_behav.py
@@ -101,7 +101,7 @@ def test_pos_interval_no_transaction(verbose_context, common, mini_restr):
         common.PositionIntervalMap()._no_transaction_make(mini_restr)
     after = common.PositionIntervalMap().fetch()
     assert (
-        len(after) == len(before) + 3
+        len(after) == len(before) + 4
     ), "PositionIntervalMap no_transaction had unexpected effect"
     assert (
         "" in after["position_interval_name"]

--- a/tests/lfp/test_lfp.py
+++ b/tests/lfp/test_lfp.py
@@ -103,6 +103,10 @@ def test_artifact_detection(lfp, pop_art_detection):
 
 
 def test_pop_imported_lfp(lfp, common):
-    key = common.common_nwbfile.NWBFile().fetch("KEY")
-    lfp.lfp_imported.ImportedLFP().make(key)
+    # check that populated from populate_all_common
     assert len(lfp.lfp_imported.ImportedLFP()) == 1
+    assert len(lfp.lfp_imported.LFPElectrodeGroup()) == 1
+    # check that rerunning doesn't add duplicates
+    key = common.common_nwbfile.Nwbfile().fetch1("KEY")
+    lfp.lfp_imported.ImportedLFP().make(key)
+    assert len(lfp.lfp_imported.LFPElectrodeGroup()) == 1

--- a/tests/lfp/test_lfp.py
+++ b/tests/lfp/test_lfp.py
@@ -105,8 +105,14 @@ def test_artifact_detection(lfp, pop_art_detection):
 def test_pop_imported_lfp(lfp, common):
     # check that populated from populate_all_common
     assert len(lfp.lfp_imported.ImportedLFP()) == 1
-    assert len(lfp.lfp_imported.LFPElectrodeGroup()) == 1
+    assert (
+        len(
+            lfp.lfp_imported.LFPElectrodeGroup
+            & "lfp_electrode_group_name LIKE 'imported_lfp_%'"
+        )
+        == 1
+    )
     # check that rerunning doesn't add duplicates
     key = common.common_nwbfile.Nwbfile().fetch1("KEY")
     lfp.lfp_imported.ImportedLFP().make(key)
-    assert len(lfp.lfp_imported.LFPElectrodeGroup()) == 1
+    assert len(lfp.lfp_imported.ImportedLFP()) == 1

--- a/tests/lfp/test_lfp.py
+++ b/tests/lfp/test_lfp.py
@@ -102,9 +102,7 @@ def test_artifact_detection(lfp, pop_art_detection):
     pass
 
 
-@pytest.mark.skip(
-    reason="Implemented in #1278, but no importable entry in test dataset"
-)
-def test_pop_imported_lfp(lfp):
-    with pytest.raises(NotImplementedError):
-        lfp.lfp_imported.ImportedLFP().populate()
+def test_pop_imported_lfp(lfp, common):
+    key = common.common_nwbfile.NWBFile().fetch("KEY")
+    lfp.lfp_imported.ImportedLFP().make(key)
+    assert len(lfp.lfp_imported.ImportedLFP()) == 1


### PR DESCRIPTION
# Description

Fixes several errors in ImportedLFP ingestion
- object search
- `LFPElectrodeGroup.LFPElectrode` entry
- key source

Adds Test of LFP ingestion:
- added a pynwb `LFP` object to the testing rec file. Is now ingested in the test fixtures
- implement `test_pop_imported_lfp` and remove skiptest


# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
