### PR TITLE
Spikeinterface channel_id ambiguity

### DIFF
--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -539,10 +539,13 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             ]
 
         # slice in channels; include ref channel in first slice, then exclude it in second slice
-        all_spikeinterface_channel_ids = self._get_spikeinterface_channel_ids(
-            nwb_file_name, all_channel_ids
-        )
+
         if ref_channel_id >= 0:
+            all_spikeinterface_channel_ids = (
+                self._get_spikeinterface_channel_ids(
+                    nwb_file_name, all_channel_ids
+                )
+            )
             recording = recording.channel_slice(
                 channel_ids=all_spikeinterface_channel_ids,
                 renamed_channel_ids=all_channel_ids,
@@ -557,9 +560,14 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
                 channel_ids=recording_channel_ids
             )
         elif ref_channel_id == -2:
+            recording_spikeinterface_channel_ids = (
+                self._get_spikeinterface_channel_ids(
+                    nwb_file_name, recording_channel_ids
+                )
+            )
             recording = recording.channel_slice(
-                channel_ids=all_spikeinterface_channel_ids,
-                renamed_channel_ids=all_channel_ids,
+                channel_ids=recording_spikeinterface_channel_ids,
+                renamed_channel_ids=recording_channel_ids,
             )
             recording = si.preprocessing.common_reference(
                 recording,
@@ -568,9 +576,14 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
                 dtype=np.float64,
             )
         elif ref_channel_id == -1:
+            recording_spikeinterface_channel_ids = (
+                self._get_spikeinterface_channel_ids(
+                    nwb_file_name, recording_channel_ids
+                )
+            )
             recording = recording.channel_slice(
-                channel_ids=all_spikeinterface_channel_ids,
-                renamed_channel_ids=all_channel_ids,
+                channel_ids=recording_spikeinterface_channel_ids,
+                renamed_channel_ids=recording_channel_ids,
             )
         else:
             raise ValueError(

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -539,8 +539,14 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             ]
 
         # slice in channels; include ref channel in first slice, then exclude it in second slice
+        all_spikeinterface_channel_ids = self._get_spikeinterface_channel_ids(
+            nwb_file_name, all_channel_ids
+        )
         if ref_channel_id >= 0:
-            recording = recording.channel_slice(channel_ids=all_channel_ids)
+            recording = recording.channel_slice(
+                channel_ids=all_spikeinterface_channel_ids,
+                renamed_channel_ids=all_channel_ids,
+            )
             recording = si.preprocessing.common_reference(
                 recording,
                 reference="single",
@@ -552,7 +558,8 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             )
         elif ref_channel_id == -2:
             recording = recording.channel_slice(
-                channel_ids=recording_channel_ids
+                channel_ids=all_spikeinterface_channel_ids,
+                renamed_channel_ids=all_channel_ids,
             )
             recording = si.preprocessing.common_reference(
                 recording,
@@ -562,7 +569,8 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             )
         elif ref_channel_id == -1:
             recording = recording.channel_slice(
-                channel_ids=recording_channel_ids
+                channel_ids=all_spikeinterface_channel_ids,
+                renamed_channel_ids=all_channel_ids,
             )
         else:
             raise ValueError(
@@ -629,6 +637,35 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             primary key of SpikeSortingRecording table
         """
         raise NotImplementedError("Recompute not implemented.")
+
+    @staticmethod
+    def _get_spikeinterface_channel_ids(
+        nwb_file_name: str, channel_ids: List[int]
+    ):
+        """Spikinterface uses channel_names instead of index number if present in
+        nwb electrodes tablle. This function ensures match in channel_id values
+        for indexing.
+
+        Parameters
+        ----------
+        nwb_file_name : str
+            file name of the NWB file
+        channel_ids : List[int]
+            list of channel indexes (electrode_id) to be converted
+
+        Returns
+        -------
+        List[str]
+            list of channel_id values used by spikeinterface
+        """
+        nwb_file_abs_path = Nwbfile.get_abs_path(nwb_file_name)
+        with pynwb.NWBHDF5IO(nwb_file_abs_path, mode="r") as io:
+            nwbfile = io.read()
+            electrodes_table = nwbfile.electrodes
+            if "channel_name" not in electrodes_table.colnames:
+                return channel_ids
+            channel_names = electrodes_table["channel_name"]
+            return [channel_names[ch] for ch in channel_ids]
 
 
 def _consolidate_intervals(intervals, timestamps):


### PR DESCRIPTION
# Description

- Fixes #1309 
    - match spikeinterface nameing convention for `channel_id` 
        - in `v1.SpikeSortingRecording` check for presence of `channel_name`  in electrodes table in nwb file
        - if present, get those names from the `electrode_id ` index
    - rename the channels to be the index number in the spikeinterface recording object to make consistent for downstream processes 

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] This PR should be accompanied by a release: (yes/no/unsure)
- [ ] If release, I have updated the `CITATION.cff`
- [ ] This PR makes edits to table definitions: (yes/no)
- [ ] If table edits, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [ ] I have added/edited docs/notebooks to reflect the changes
