### PR TITLE
Fix recompute `update_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,36 @@
 Table update script
 
 ```python
-# -- For recompute --
-import datajoint as dj
-from spyglass.spikesorting.v1 import recording as v1rec  # noqa
-from spyglass.spikesorting.v0 import spikesorting_recording as v0rec  # noqa
+# -- For TrackGraph --
 from spyglass.linearization.v1.main import TrackGraph  # noqa
+
+TrackGraph.alter()  # Add edge map parameter
+
+# -- For dropping deprecated tables --
+import datajoint as dj
 
 dj.FreeTable(dj.conn(), "common_nwbfile.analysis_nwbfile_log").drop()
 dj.FreeTable(dj.conn(), "common_session.session_group").drop()
-TrackGraph.alter()  # Add edge map parameter
-v0rec.SpikeSortingRecording().alter()
-v0rec.SpikeSortingRecording().update_ids()
-v1rec.SpikeSortingRecording().alter()
-v1rec.SpikeSortingRecording().update_ids()
+
+# -- For v0 recompute --
+from spyglass.spikesorting.v0.spikesorting_recording import (
+    SpikeSortingRecording,
+    SpikeSortingRecordingSelection,
+    IntervalList,
+)
+
+SpikeSortingRecording().alter()
+SpikeSortingRecording().update_ids()
+
+# -- For v1 recompute --
+from spyglass.spikesorting.v1.recording import (
+    SpikeSortingRecording,
+    SpikeSortingRecordingSelection,
+    AnalysisNwbfile,
+)
+
+SpikeSortingRecording().alter()
+SpikeSortingRecording().update_ids()
 
 # -- For LFP pipeline --
 from spyglass.lfp.lfp_imported import ImportedLFP
@@ -62,7 +79,8 @@ ImportedLFP().drop()
 - Only add merge parts to `source_class_dict` if present in codebase #1237
 - Remove cli module #1250
 - Fix column error in `check_threads` method #1256
-- Add recompute ability for `SpikeSortingRecording` for both v0 and v1 #1093
+- Add recompute ability for `SpikeSortingRecording` for both v0 and v1 #1093,
+    #1XXX
 - Track Spyglass version in dedicated table for enforcing updates #1281
 - Pin to `datajoint>=0.14.4` for `dj.Top` and long make call fix #1281
 - Remove outdated code comments #1304

--- a/src/spyglass/spikesorting/v0/spikesorting_recording.py
+++ b/src/spyglass/spikesorting/v0/spikesorting_recording.py
@@ -445,7 +445,7 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
         """Update file hashes for all entries in the table.
 
         Only used for transitioning to recompute NWB files, see #1093."""
-        for key in tqdm(self & 'hash=""', desc="Updating hashes"):
+        for key in tqdm(self & "hash is NULL", desc="Updating hashes"):
             key["hash"] = self._dir_hash(key["recording_path"])
             self.update1(key)
 

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -603,7 +603,7 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
         Only used for transitioning to recompute NWB files, see #1093.
         """
         elect_attr = "acquisition/ProcessedElectricalSeries/electrodes"
-        needs_update = self & ["electrodes_id=''", "hash=''"]
+        needs_update = self & "electrodes_id is NULL or hash is NULL"
 
         for key in tqdm(needs_update):
             analysis_file_path = AnalysisNwbfile.get_abs_path(


### PR DESCRIPTION
# Description

This PR ...
- changes the alter script to ensure all fk dependencies are imported before running alter
- changes `update_id` process to run on null entries rather than empty strings

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [X] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
