### PR TITLE
Fix call to 'upper' in common_behav.py

### DIFF
--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -336,7 +336,7 @@ class StateScriptFile(SpyglassMixin, dj.Imported):
             epoch_list = associated_file_obj.task_epochs.split(",")
             # only insert if this is the statescript file
             logger.info(associated_file_obj.description)
-            this_desc = associated_file_obj.description.upper
+            this_desc = associated_file_obj.description.upper()
 
             if (
                 "statescript".upper() in this_desc


### PR DESCRIPTION
# Description

- Fixes: 
    - `src/spyglass/common/common_behav.py`: changed line 339, call to upper had no parentheses
   
# Checklist:

- [ no ] This PR should be accompanied by a release: (yes/no/unsure)
- [ X ] N/A If release, I have updated the `CITATION.cff`
- [ no ] This PR makes edits to table definitions: (yes/no)
- [ X ] N/A If table edits, I have included an `alter` snippet for release notes.
- [ X ] N/A If this PR makes changes to position, I ran the relevant tests locally.
- [ no ] I have updated the `CHANGELOG.md` with PR number and description.
- [ no ] I have added/edited docs/notebooks to reflect the changes
