### PR TITLE
Returned merge_id consistency for Merge.fetch_nwb 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ ImportedLFP().drop()
     - Disable make transactionsfor `CuratedSpikeSorting` #1288
     - Refactor `SpikeSortingOutput.get_restricted_merge_ids` #1304
     - Add burst merge curation #1209
+    - Ensure matching order of returned merge_ids and nwb files in
+      `SortedSpikesGroup.fetch_spike_data` #1320
 - Behavior
     - Implement pipeline for keypoint-moseq extraction of behavior syllables #1056
 - LFP

--- a/src/spyglass/utils/dj_merge_tables.py
+++ b/src/spyglass/utils/dj_merge_tables.py
@@ -560,7 +560,16 @@ class Merge(ExportMixin, dj.Manual):
                 .fetch_nwb()
             )
             if return_merge_ids:
-                merge_ids.extend([k[self._reserved_pk] for k in source_restr])
+                merge_ids.extend(
+                    [
+                        (
+                            self
+                            & self._merge_restrict_parts(file)
+                            & source_restr
+                        ).fetch1(self._reserved_pk)
+                        for file in nwb_list
+                    ]
+                )
         if return_merge_ids:
             return nwb_list, merge_ids
         return nwb_list

--- a/tests/position/test_pos_merge.py
+++ b/tests/position/test_pos_merge.py
@@ -27,7 +27,7 @@ def test_merge_dlc_fetch1_dataframe(merge_df):
 def test_merge_id_order(pos_merge):
     merge_keys = pos_merge.TrodesPosV1().fetch("KEY")
     assert len(merge_keys) > 1
-    nwb_file_list, merge_ids = (pos_merge.TrodesPosV1() & merge_keys).fetch_nwb(
+    nwb_file_list, merge_ids = (pos_merge & merge_keys).fetch_nwb(
         return_merge_ids=True
     )
     for nwb_file, merge_id in zip(nwb_file_list, merge_ids):

--- a/tests/position/test_pos_merge.py
+++ b/tests/position/test_pos_merge.py
@@ -22,3 +22,15 @@ def test_merge_dlc_fetch1_dataframe(merge_df):
     assert all(
         e in df_cols for e in exp_cols
     ), f"Unexpected cols in position merge dataframe: {df_cols}"
+
+
+def test_merge_id_order(pos_merge):
+    merge_keys = pos_merge.TrodesPosV1().fetch("KEY")
+    assert len(merge_keys) > 1
+    nwb_file_list, merge_ids = (pos_merge.TrodesPosV1() & merge_keys).fetch_nwb(
+        return_merge_ids=True
+    )
+    for nwb_file, merge_id in zip(nwb_file_list, merge_ids):
+        assert (pos_merge.TrodesPosV1() & nwb_file).fetch1(
+            "merge_id"
+        ) == merge_id, "Returned merge ID order does not match the order of returned nwb files"


### PR DESCRIPTION
# Description

Fixes #1319 
- In `Merge.fetch_nwb( return_merge_ids=True)` ensure that the merge ids are returned in the order corresponding with the nwb files
- Relevant for correct function of `SortedSpikeGroups.fetch_spike_data(key, return_unit_ids=True)`

Other:
- add `return_unit_ids` option to methods of `SortedSpikesGroup`
    - `get_spike_indicator`
    - `get_firing_rate`
     
# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
