### PR TITLE
Generate timestamps from rate and start time

### DIFF
--- a/src/spyglass/position/v1/imported_pose.py
+++ b/src/spyglass/position/v1/imported_pose.py
@@ -8,7 +8,6 @@ from spyglass.common import IntervalList, Nwbfile
 from spyglass.utils.dj_mixin import SpyglassMixin
 from spyglass.utils.nwb_helper_fn import (
     estimate_sampling_rate,
-    get_object_timestamps,
     get_valid_intervals,
 )
 
@@ -60,9 +59,9 @@ class ImportedPose(SpyglassMixin, dj.Manual):
                     continue
 
                 # use the timestamps from the first body part to define valid times
-                timestamps = get_object_timestamps(
-                    list(obj.pose_estimation_series.values())[0]
-                )
+                timestamps = list(obj.pose_estimation_series.values())[
+                    0
+                ].get_timestamps()
                 sampling_rate = estimate_sampling_rate(
                     timestamps, filename=nwb_file_name
                 )
@@ -129,10 +128,7 @@ class ImportedPose(SpyglassMixin, dj.Manual):
         index = None
         pose_df = {}
         body_parts = list(pose_estimations.keys())
-        index = pd.Index(
-            get_object_timestamps(pose_estimations[body_parts[0]]),
-            name="time",
-        )
+        index = pose_estimations[body_parts[0]].get_timestamps()
         for body_part in body_parts:
             bp_data = pose_estimations[body_part].data
             part_df = {

--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -292,37 +292,6 @@ def get_raw_eseries(nwbfile):
     return ret
 
 
-def get_object_timestamps(nwb_object):
-    """Return timestamps of a given NWB object.
-
-    Parameters
-    ----------
-    nwb_object : pynwb.NWBDataInterface or pynwb.DynamicTable
-        The NWB object to get timestamps from.
-
-    Returns
-    -------
-    timestamps : numpy.ndarray
-        1D numpy array of timestamps.
-    """
-    timestamps = nwb_object.timestamps
-    if timestamps is None:
-        # if timestamps are not set, generate from starting_time and rate
-        if hasattr(nwb_object, "starting_time") and hasattr(nwb_object, "rate"):
-            timestamps = np.arange(
-                nwb_object.starting_time,
-                nwb_object.starting_time
-                + len(nwb_object.data) / nwb_object.rate,
-                1 / nwb_object.rate,
-            )
-        else:
-            raise ValueError(
-                f"Object {nwb_object.object_id} does not have timestamps or "
-                + "starting_time and rate attributes."
-            )
-    return timestamps
-
-
 def estimate_sampling_rate(
     timestamps, multiplier=1.75, verbose=False, filename="file"
 ):


### PR DESCRIPTION
# Description

Fixes #1321 
- timestamps in pose estimation series nwb objects can be defined by `rate` and `start_time` values rather than a `timestamps` vector
- In these cases, make a timestamps array from `rate` and `start_time`

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
