### PR TITLE
Fix spikeinterface channel names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ ImportedLFP().drop()
     - Refactor `SpikeSortingOutput.get_restricted_merge_ids` #1304
     - Add burst merge curation #1209
     - Reconcile spikeinterface value for `channel_id` when `channel_name` column
-      present in nwb file electrodes table #1310
+      present in nwb file electrodes table #1310, #1334
     - Ensure matching order of returned merge_ids and nwb files in
       `SortedSpikesGroup.fetch_spike_data` #1320
 - Behavior

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -659,9 +659,9 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
         with pynwb.NWBHDF5IO(nwb_file_abs_path, mode="r") as io:
             nwbfile = io.read()
             electrodes_table = nwbfile.electrodes
-            channel_names = electrodes_table.get("colnames")
-            if channel_names is None:
+            if "channel_name" not in electrodes_table.colnames:
                 return channel_ids
+            channel_names = electrodes_table["channel_name"]
             return [channel_names[ch] for ch in channel_ids]
 
 


### PR DESCRIPTION
# Description

Commits in review of #1310 negated the fix for #1309 . This reverts to accurately check for `channel_name` column in electrodes table of nwb file

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] N This PR should be accompanied by a release: (yes/no/unsure)
- [x] NA If release, I have updated the `CITATION.cff`
- [x] N This PR makes edits to table definitions: (yes/no)
- [x] NA If table edits, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [x] NA I have added/edited docs/notebooks to reflect the changes
