### PR TITLE
Skip empty timestamp objs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ ImportedLFP().drop()
     - Allow insert with dio events but no e-series data #1318
     - Prompt user to verify compatibility between new insert and existing table
         entries # 1318
-    - Skip empty timeseries ingestion (`PositionSource`, `DioEvents`) #XXXX
+    - Skip empty timeseries ingestion (`PositionSource`, `DioEvents`) #1347
 - Position
     - Allow population of missing `PositionIntervalMap` entries during population
         of `DLCPoseEstimation` #1208
@@ -150,7 +150,7 @@ ImportedLFP().drop()
     - Updating the LFPBandSelection logic with comprehensive validation and batch
         insertion for electrodes and references. #1280
     - Implement `ImportedLFP.make()` for ingestion from nwb files #1278, #1302
-    - Skip empty timeseries ingestion for `ImportedLFP` #XXXX
+    - Skip empty timeseries ingestion for `ImportedLFP` #1347
 
 ## [0.5.4] (December 20, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,8 @@ ImportedLFP().drop()
 - Common
     - Default `AnalysisNwbfile.create` permissions are now 777 #1226
     - Make `Nwbfile.fetch_nwb` functional # 1256
-    - Calculate mode of timestep size in log scale when estimating sampling rate #1270
+    - Calculate mode of timestep size in log scale when estimating sampling rate
+        #1270
     - Ingest all `ImageSeries` objects in nwb file to `VideoFile` #1278
     - Allow ingestion of multi-row task epoch tables #1278
     - Add `SensorData` to `populate_all_common` #1281
@@ -107,8 +108,9 @@ ImportedLFP().drop()
     - `IntervalList.fetch_interval` now returns `Interval` object #1293
     - Correct name parsing in Session.Experimenter insertion #1306
     - Allow insert with dio events but no e-series data #1318
-    - Prompt user to verify compatibility between new insert and existing
-      table entries # 1318
+    - Prompt user to verify compatibility between new insert and existing table
+        entries # 1318
+    - Skip empty timeseries ingestion (`PositionSource`, `DioEvents`) #XXXX
 - Position
     - Allow population of missing `PositionIntervalMap` entries during population
         of `DLCPoseEstimation` #1208
@@ -129,14 +131,14 @@ ImportedLFP().drop()
     - Fix type compatibility of `time_slice` in
         `SortedSpikesGroup.fetch_spike_data` #1261
     - Update transaction and parallel make settings for `v0` and `v1`
-      `SpikeSorting` tables #1270
+        `SpikeSorting` tables #1270
     - Disable make transactionsfor `CuratedSpikeSorting` #1288
     - Refactor `SpikeSortingOutput.get_restricted_merge_ids` #1304
     - Add burst merge curation #1209
     - Reconcile spikeinterface value for `channel_id` when `channel_name` column
-      present in nwb file electrodes table #1310, #1334
+        present in nwb file electrodes table #1310, #1334
     - Ensure matching order of returned merge_ids and nwb files in
-      `SortedSpikesGroup.fetch_spike_data` #1320
+        `SortedSpikesGroup.fetch_spike_data` #1320
 - Behavior
     - Implement pipeline for keypoint-moseq extraction of behavior syllables #1056
 - LFP
@@ -148,6 +150,7 @@ ImportedLFP().drop()
     - Updating the LFPBandSelection logic with comprehensive validation and batch
         insertion for electrodes and references. #1280
     - Implement `ImportedLFP.make()` for ingestion from nwb files #1278, #1302
+    - Skip empty timeseries ingestion for `ImportedLFP` #XXXX
 
 ## [0.5.4] (December 20, 2024)
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -82,6 +82,7 @@ class PositionSource(SpyglassMixin, dj.Manual):
         src_key = dict(**sess_key, source="imported", import_file_name="")
 
         if all_pos is None:
+            logger.info(f"No position data found in {nwb_file_name}. Skipping.")
             return
 
         sources = []

--- a/src/spyglass/common/common_dio.py
+++ b/src/spyglass/common/common_dio.py
@@ -54,6 +54,12 @@ class DIOEvents(SpyglassMixin, dj.Imported):
         dio_inserts = []
         time_range_list = []
         for event_series in behav_events.time_series.values():
+            if not event_series.timestamps:
+                logger.warning(
+                    f"No timestamps found for DIO event {event_series.name} "
+                    + f"in {nwb_file_name}. Skipping."
+                )
+                continue
             key["dio_event_name"] = event_series.name
             key["dio_object_id"] = event_series.object_id
             dio_inserts.append(key.copy())

--- a/src/spyglass/common/common_dio.py
+++ b/src/spyglass/common/common_dio.py
@@ -54,7 +54,8 @@ class DIOEvents(SpyglassMixin, dj.Imported):
         dio_inserts = []
         time_range_list = []
         for event_series in behav_events.time_series.values():
-            if not event_series.timestamps:
+            timestamps = event_series.get_timestamps()
+            if not timestamps.any():
                 logger.warning(
                     f"No timestamps found for DIO event {event_series.name} "
                     + f"in {nwb_file_name}. Skipping."
@@ -63,9 +64,7 @@ class DIOEvents(SpyglassMixin, dj.Imported):
             key["dio_event_name"] = event_series.name
             key["dio_object_id"] = event_series.object_id
             dio_inserts.append(key.copy())
-            time_range_list.extend(
-                [event_series.timestamps[0], event_series.timestamps[-1]]
-            )
+            time_range_list.extend([timestamps[0], timestamps[-1]])
 
         if key["interval_list_name"] == "dio data valid times":
             # insert a default interval list for DIO events if no raw data

--- a/src/spyglass/common/common_dio.py
+++ b/src/spyglass/common/common_dio.py
@@ -45,7 +45,8 @@ class DIOEvents(SpyglassMixin, dj.Imported):
             return  # See #849
 
         # Times for these events correspond to the valid times for the raw data
-        # If no raw data found, create a default interval list named "dio data valid times"
+        # If no raw data found, create a default interval list named
+        # "dio data valid times"
         if raw_query := (Raw() & {"nwb_file_name": nwb_file_name}):
             key["interval_list_name"] = (raw_query).fetch1("interval_list_name")
         else:
@@ -55,7 +56,7 @@ class DIOEvents(SpyglassMixin, dj.Imported):
         time_range_list = []
         for event_series in behav_events.time_series.values():
             timestamps = event_series.get_timestamps()
-            if not timestamps.any():
+            if len(timestamps) == 0:  # Can be either np array or HDMF5 dataset
                 logger.warning(
                     f"No timestamps found for DIO event {event_series.name} "
                     + f"in {nwb_file_name}. Skipping."

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -58,13 +58,19 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
         for i, es_object in enumerate(lfp_es_objects):
             if len(self & {"lfp_object_id": es_object.object_id}) > 0:
                 logger.warning(
-                    f"Skipping {es_object.object_id} because it already exists in ImportedLFP."
+                    f"Skipping {es_object.object_id} because it already exists "
+                    + "in ImportedLFP."
+                )
+                continue
+            if es_object.timestamps is None:
+                logger.warning(
+                    f"Skipping lfp without timestamps: {es_object.object_id}"
                 )
                 continue
             electrodes_df = es_object.electrodes.to_dataframe()
             electrode_ids = electrodes_df.index.values
 
-            # check if existing electrode group for this set of electrodes exists
+            # check if existing group for this set of electrodes exists
             session_key = {
                 "nwb_file_name": nwb_file_name,
             }

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -62,7 +62,8 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
                     + "in ImportedLFP."
                 )
                 continue
-            if es_object.timestamps is None:
+            timestamps = es_object.get_timestamps()
+            if not timestamps.any():
                 logger.warning(
                     f"Skipping lfp without timestamps: {es_object.object_id}"
                 )
@@ -88,17 +89,14 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
 
             # estimate the sampling rate or read in if available
             sampling_rate = es_object.rate or estimate_sampling_rate(
-                es_object.timestamps[: int(1e6)]
+                timestamps[: int(1e6)]
             )
 
             # create a new interval list for the valid times
             interval_key = {
                 "nwb_file_name": nwb_file_name,
                 "interval_list_name": f"imported lfp {i} valid times",
-                "valid_times": get_valid_intervals(
-                    es_object.timestamps,
-                    sampling_rate,
-                ),
+                "valid_times": get_valid_intervals(timestamps, sampling_rate),
                 "pipeline": "imported_lfp",
             }
             IntervalList().insert1(interval_key)

--- a/src/spyglass/lfp/lfp_imported.py
+++ b/src/spyglass/lfp/lfp_imported.py
@@ -63,7 +63,7 @@ class ImportedLFP(SpyglassMixin, dj.Imported):
                 )
                 continue
             timestamps = es_object.get_timestamps()
-            if not timestamps.any():
+            if len(timestamps) == 0:
                 logger.warning(
                     f"Skipping lfp without timestamps: {es_object.object_id}"
                 )


### PR DESCRIPTION
# Description

In ingesting a file from DandiSet 001457, I hit a number of errors related to ingesting empty timeseries

Electing not to add coverage for cases not covered by the demo data. If needed, I can look into monkeypatching these `make`s

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
