### PR TITLE
Allow return of Interval obj from `to_indices` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ ImportedLFP().drop()
     - Add `SensorData` to `populate_all_common` #1281
     - Add `fetch1_dataframe` to `SensorData` #1291
     - Allow storage of numpy arrays using `AnalysisNwbfile.add_nwb_object` #1298
-    - `IntervalList.fetch_interval` now returns `Interval` object #1293
+    - `IntervalList.fetch_interval` now returns `Interval` object #1293, #13XX
     - Correct name parsing in Session.Experimenter insertion #1306
     - Allow insert with dio events but no e-series data #1318
     - Prompt user to verify compatibility between new insert and existing table

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -870,20 +870,30 @@ class Interval:
             else Interval(new_interval, **self.kwargs)
         )
 
-    def to_indices(self, timestamps: np.ndarray) -> List[List[int]]:
+    def to_indices(
+        self, timestamps: np.ndarray, as_interval: bool = False
+    ) -> List[List[int]]:
         """Convert intervals to indices in the given timestamps.
 
         Parameters
         ----------
         timestamps : array_like
             The timestamps to convert the intervals to indices in.
+        as_interval : bool, optional
+            If True, return as an Interval object. Defaults to False.
 
         Returns
         -------
         np.ndarray
             The indices of the intervals in the given timestamps.
         """
-        return np.searchsorted(timestamps, self.times.ravel()).reshape(-1, 2)
+        ret = np.searchsorted(timestamps, self.times.ravel()).reshape(-1, 2)
+        if as_interval:
+            if not hasattr(ret[0], "__len__"):
+                # handle list of ints case from v0.spikesorting_artifact
+                ret = [ret]
+            ret = Interval(ret)
+        return ret
 
     def to_seconds(self, timestamps: np.ndarray) -> List[Tuple[float]]:
         """Convert intervals to seconds in the given timestamps.
@@ -1147,15 +1157,12 @@ def interval_set_difference_inds(intervals1, intervals2):
 
     Parameters
     ----------
-    intervals1 : _type_
-        _description_
-    intervals2 : _type_
-        _description_
+    intervals1 : IntervalLike
+    intervals2 : IntervalLike
 
     Returns
     -------
-    _type_
-        _description_
+    np.ndarray
     """
     from spyglass.common.common_usage import ActivityLog
 


### PR DESCRIPTION
# Description

#1354 highlighted a but introduced in #1293 that expected an `IntervalList` object to be returned from the `to_indices` method. This PR...
- introduces an optional flag to this method that allows for further computation on the returned indices
- cleans up the dictionary declaration for insert

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [X] No. If this PR makes changes to position, I ran the relevant tests locally.
- [] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
