### PR TITLE
Make sure parent directory exists

### DIFF
--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -288,6 +288,7 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
                 / f"{nwb_file_name}_{str(uuid.uuid4())}.nc"
             )
             path_exists = results_path.exists()
+        results_path.parent.mkdir(parents=True, exist_ok=True)
         classifier.save_results(
             results,
             results_path,

--- a/src/spyglass/decoding/v1/sorted_spikes.py
+++ b/src/spyglass/decoding/v1/sorted_spikes.py
@@ -245,6 +245,7 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
                 / f"{nwb_file_name}_{str(uuid.uuid4())}.nc"
             )
             path_exists = results_path.exists()
+        results_path.parent.mkdir(parents=True, exist_ok=True)
         classifier.save_results(
             results,
             results_path,


### PR DESCRIPTION
# Description

This pull request ensures that the parent directories for results files are created if they do not already exist before saving decoding results. This change helps prevent errors when writing results to new locations.

Directory creation for results files:

* Added `results_path.parent.mkdir(parents=True, exist_ok=True)` to both `src/spyglass/decoding/v1/clusterless.py` and `src/spyglass/decoding/v1/sorted_spikes.py` in the `make` method, ensuring parent directories exist before saving results. [[1]](diffhunk://#diff-9fc3b9eac3aeda224b34b493e455f3b2ec001eb2b79208ba66c35b71a9e48b5bR291) [[2]](diffhunk://#diff-04563ba80ec835a69a95204a54f9652c7adb3e4a293a76ea68813d503a6c625eR248
Fixes https://github.com/LorenFrankLab/spyglass/issues/1358

# Checklist:

<!--
For items below with choices, select one (e.g., yes, no) 
and check the box to indicate that a choice was selected.
If not applicable, check the box and add `N/A` after the box.
For example:
- [X] This has a choice: no
- [X] N/A. If choice, other item.
This comment may be deleted on submission.

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] This PR should be accompanied by a release: (yes/**no**/unsure)
- [x] If release, I have updated the `CITATION.cff`
- [x] This PR makes edits to table definitions: (yes/**no**)
- [x] If table edits, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [x] I have added/edited docs/notebooks to reflect the changes

