### PR TITLE
Spawn missing tables on cascading RestrGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,16 @@ When altering tables, import all foreign key references.
 
 - Delete extra pyscripts that were renamed # 1363
 
-### Decoding
+### Infrastructure
 
-- Ensure results directory is created if it doesn't exist #1362
+- Auto-load within-Spyglass tables for graph operations #XXXX
 
-### Spikesorting
+### Pipelines
 
-- Implement short-transaction `SpikeSortingRecording.make` for v0 #1338
+- Decoding
+    - Ensure results directory is created if it doesn't exist #1362
+- Spikesorting
+    - Implement short-transaction `SpikeSortingRecording.make` for v0 #1338
 
 ## [0.5.5] (Aug 6, 2025)
 

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -853,6 +853,29 @@ class SpyglassMixin(ExportMixin):
 
         return ret
 
+    def restrict_all(
+        self,
+        restriction: str = True,
+        direction: str = "down",
+        return_graph: bool = False,
+        verbose: bool = False,
+    ) -> List:
+        RestrGraph = self._graph_deps[1]
+        rg = RestrGraph(
+            seed_table=self,
+            leaves=dict(
+                table_name=self.full_table_name,
+                restriction=self.restriction or restriction,
+            ),
+            direction=direction,
+            banned_tables=list(self._banned_search_tables),
+            cascade=True,
+            verbose=verbose,
+        )
+        if return_graph:
+            return rg
+        print(rg.restr_ft)
+
     # ------------------------------ Check locks ------------------------------
 
     def exec_sql_fetchall(self, query):


### PR DESCRIPTION
# Description

- Long distance restrictions require tables to be imported to be checked in the cascade
- Unexpected or unimportable tables on shared prefixes make unusable in the window between development and merging (or patch release)
- On initial development, auto-import was dismissed as too slow and would not adhere to the user's import conventions
- With hindsight, the process of finding/importing the table is much slower
- This PR sets `dj.VirtualModule` as a fallback for within-Spyglass schema names

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [X] No. If this PR makes changes to position, I ran the relevant tests locally.
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
