### PR TITLE
PR QoL: codecov fail limit, PR template edits

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 68%

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,13 +14,12 @@ This PR.
 # Checklist:
 
 <!--
-For items below with choices, select one (e.g., yes, no) 
-and check the box to indicate that a choice was selected.
-If not applicable, check the box and add `N/A` after the box.
+For items below with `if`, please mark those that do not apply with N/A
+
 For example:
-- [X] This has a choice: no
-- [X] N/A. If choice, other item.
-This comment may be deleted on submission.
+- [X] N/A. If this PR X, related item.
+- [X] If this PR Y, other item.
+- [X] I have updated the `CHANGELOG.md` ...
 
 Alter notes example:
 ```python
@@ -29,10 +28,8 @@ Table.alter() # Comment regarding the change
 ```
 -->
 
-- [ ] This PR should be accompanied by a release: (yes/no/unsure)
-- [ ] If release, I have updated the `CITATION.cff`
-- [ ] This PR makes edits to table definitions: (yes/no)
-- [ ] If table edits, I have included an `alter` snippet for release notes.
+- [ ] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
+- [ ] If this PR edits table definitions, I have included an `alter` snippet for release notes.
 - [ ] If this PR makes changes to position, I ran the relevant tests locally.
+- [ ] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
 - [ ] I have updated the `CHANGELOG.md` with PR number and description.
-- [ ] I have added/edited docs/notebooks to reflect the changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ When altering tables, import all foreign key references.
 
 ### Infrastructure
 
-- Set default codecov threshold for test fail #13XX
+- Set default codecov threshold for test fail #1370
+- Simplify PR template #1370
 
 ### Decoding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ When altering tables, import all foreign key references.
 
 - Delete extra pyscripts that were renamed # 1363
 
+### Infrastructure
+
+- Set default codecov threshold for test fail #13XX
+
 ### Decoding
 
 - Ensure results directory is created if it doesn't exist #1362


### PR DESCRIPTION
# Description

This PR adds a [coverage target](https://docs.codecov.com/docs/gitlab-3-customizing-codecov#set-coverage-standards) to prevent a failing test on small edits. PRs that add more than 1-2% to the code base will trigger this fail

This PR also simplifies the checklist below for a more streamlined pattern of `If A, B // If C, D // changelog`

# Checklist:

- [X] No. This PR should be accompanied by a release: (yes/no/unsure)
- [X] N/a. If release, I have updated the `CITATION.cff`
- [X] No. This PR makes edits to table definitions: (yes/no)
- [X] N/a. If table edits, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [x] I have updated the `CHANGELOG.md` with PR number and description.
- [X] N/a. I have added/edited docs/notebooks to reflect the changes
