### PR TITLE
Minor DLC Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ When altering tables, import all foreign key references.
 
 ### Position
 
-- Ensure video files are properly added to `DLCProject` # 1367
+- Ensure video files are properly added to `DLCProject` #1367
+- DLC parameter handling improvements and default value corrections #1379
 
 ### Spikesorting
 

--- a/src/spyglass/position/v1/position_dlc_position.py
+++ b/src/spyglass/position/v1/position_dlc_position.py
@@ -219,7 +219,8 @@ class DLCSmoothInterp(SpyglassMixin, dj.Computed):
 
         nan_spans = get_span_start_stop(np.where(bad_inds)[0])
 
-        if interp_params := params.get("interpolate"):
+        if params.get("interpolate"):
+            interp_params = params.get("interp_params", dict())
             logger.info("interpolating across low likelihood times")
             interp_df = interp_pos(df_w_nans.copy(), nan_spans, **interp_params)
         else:

--- a/src/spyglass/position/v1/position_dlc_selection.py
+++ b/src/spyglass/position/v1/position_dlc_selection.py
@@ -431,6 +431,8 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             "pose_estimation_output_dir",
             "meters_per_pixel",
         )
+        if pose_estimation_params is None:
+            pose_estimation_params = dict()
 
         logger.info(f"video filename: {video_filename}")
         logger.info("Loading position data...")
@@ -508,7 +510,7 @@ class DLCPosVideo(SpyglassMixin, dj.Computed):
             cm_to_pixels=meters_per_pixel * M_TO_CM,
             crop=pose_estimation_params.get("cropping"),
             key_hash=dj.hash.key_hash(key),
-            debug=params.get("debug", True),  # REVERT TO FALSE
+            debug=params.get("debug", False),
             **params.get("video_params", {}),
         )
 


### PR DESCRIPTION
# Description

A couple of minor errors were introduced in PR #870.

Parameter handling improvements:

* In `src/spyglass/position/v1/position_dlc_selection.py`, the code now ensures that `pose_estimation_params` is always a dictionary, preventing potential errors when accessing its values.
* In `src/spyglass/position/v1/position_dlc_position.py`, the interpolation parameters are now correctly fetched from `interp_params` instead of being tied to the existence of the `interpolate` flag, improving clarity and flexibility in parameter usage.

Default value corrections:

* The default value for the `debug` parameter in the position estimation call within `src/spyglass/position/v1/position_dlc_selection.py` has been changed from `True` to `False`, aligning with expected production behavior.

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
