### PR TITLE
Quickfix: Remove optogenetic epochs from analysis files

### DIFF
--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -211,6 +211,10 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
                     if isinstance(nwb_object, pynwb.core.LabelledDict):
                         for module in list(nwb_object.keys()):
                             nwb_object.pop(module)
+
+            # pop off optogenetic_epochs if it exists
+            nwbf.intervals.pop("optogenetic_epochs")
+
             # add the version of spyglass that created this file
             if nwbf.source_script is None:
                 nwbf.source_script = self._logged_env_info()


### PR DESCRIPTION
# Description

- Fixes #1395 
    - Pop off optogenetic epochs in created analysis nwb files
    - Missing referenced dio data (removed in the analysis file) was creating the problem

- Partial for #1329 
   - Solves immediate error
   - Can pop up again in data with different/unique extensions
   - Should still make a more robust fix by only adding a select set of objects to the new analysis file (rather than popping off unwanted  

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [ ] If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [ ] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
