### PR TITLE
Test fail quickfix from func removed in review of #1380

### DIFF
--- a/tests/utils/test_hashers.py
+++ b/tests/utils/test_hashers.py
@@ -78,7 +78,7 @@ def test_nwb_hasher(nwb_hasher):
     assert "acquisition" in cache
     assert "processing" in cache
 
-    precision = nwb_hasher.get_precision("ProcessedElectricalSeries")
+    precision = nwb_hasher.precision.get("ProcessedElectricalSeries")
     assert precision == 5
 
     roundable = nwb_hasher.is_roundable(5)


### PR DESCRIPTION
# Description

Review of #1380 resulted in removal of the `get_precision` function run in tests. This addresses that issue

# Checklist:

- [X] N/a. If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [X] N/a. If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [X] N/a. If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
