### PR TITLE
Quickfix: PositionSource no entries

### DIFF
--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -579,13 +579,16 @@ def get_all_spatial_series(nwbf, verbose=False, incl_times=True) -> dict:
     if pos_interface is None:
         return None
 
-    return _get_pos_dict(
+    pos_dict = _get_pos_dict(
         position=pos_interface.spatial_series,
         epoch_groups=_get_epoch_groups(pos_interface),
         session_id=nwbf.session_id,
         verbose=verbose,
         incl_times=incl_times,
     )
+    if len(pos_dict) == 0:
+        return None
+    return pos_dict
 
 
 def get_nwb_copy_filename(nwb_file_name):


### PR DESCRIPTION
# Description

Fixes #1404 
- Ensure `get_all_spatial_series` returns None in all cases where no position data

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] NA If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [ ] NA If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [ ] NA If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
