### PR TITLE
Standardize import: tests, map on doc build, allow multi-table insert, quiet false-positive divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ When altering tables, import all foreign key references.
 
 - Set default codecov threshold for test fail, disable patch check #1370, #1372
 - Simplify PR template #1370
+- Add `SpyglassIngestion` class to centralize functionality #1377, #1419
 
 ### Decoding
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
     - Understanding a Schema: ForDevelopers/Schema.md
     - Custom Pipelines: ForDevelopers/CustomPipelines.md
     - Using NWB: ForDevelopers/UsingNWB.md
+    - Ingestion Mapping: ForDevelopers/ingestion_mapping.md
   - API Reference: api/ # defer to gen-files + literate-nav
   - Change Log: CHANGELOG.md
   - Copyright: LICENSE.md
@@ -123,6 +124,7 @@ plugins:
   - gen-files:
       scripts:
         - ./src/api/make_pages.py
+        - ./src/api/ingestion_mapping_generate.py
   - mkdocs-jupyter: # Comment this block during dev to reduce build time
       execute: False # Very slow, needs gh-action edit to work/link to db
       include_source: False

--- a/src/spyglass/common/common_device.py
+++ b/src/spyglass/common/common_device.py
@@ -100,74 +100,8 @@ class DataAcquisitionDevice(SpyglassIngestion, dj.Manual):
         config = config or dict()
         entries = super().insert_from_nwbfile(
             nwb_file_name=nwb_file_name, config=config, dry_run=dry_run
-        )
-        if entries:
-            vals = [e["data_acquisition_device_name"] for e in entries]
-            logger.info(
-                f"Inserted or referenced data acquisition device(s): {vals}"
-            )
-        else:
-            logger.warning(
-                "No conforming data acquisition device metadata found."
-            )
+        )[self]
         return entries
-
-    @classmethod
-    def old_insert_from_nwbfile(cls, nwbf, config=None):
-        """Insert data acquisition devices from an NWB file.
-
-        Note that this does not link the DataAcquisitionDevices with a Session.
-        For that, see DataAcquisitionDeviceList.
-
-        Parameters
-        ----------
-        nwbf : pynwb.NWBFile
-            The source NWB file object.
-        config : dict
-            Dictionary read from a user-defined YAML file containing values to
-            replace in the NWB file.
-        """
-        config = config or dict()
-        _, ndx_devices, _ = cls.get_all_device_names(nwbf, config)
-
-        for device_name in ndx_devices:
-            # read device properties into new_device_dict from PyNWB extension
-            # device object
-            nwb_device_obj = ndx_devices[device_name]
-
-            name = nwb_device_obj.name
-            adc_circuit = nwb_device_obj.adc_circuit
-
-            # transform system value. check if value is in DB. if not, prompt
-            # user to add an entry or cancel.
-            system = cls._add_system(nwb_device_obj.system)
-
-            # transform amplifier value. check if value is in DB. if not, prompt
-            # user to add an entry or cancel.
-            amplifier = cls._add_amplifier(nwb_device_obj.amplifier)
-
-            # standardize how Intan is represented in the database
-            if adc_circuit.title() == "Intan":
-                adc_circuit = "Intan"
-
-            cls._add_device(
-                dict(
-                    data_acquisition_device_name=name,
-                    data_acquisition_device_system=system,
-                    data_acquisition_device_amplifier=amplifier,
-                    adc_circuit=adc_circuit,
-                )
-            )
-
-        if ndx_devices:
-            logger.info(
-                "Inserted or referenced data acquisition device(s): "
-                + f"{ndx_devices.keys()}"
-            )
-        else:
-            logger.warning(
-                "No conforming data acquisition device metadata found."
-            )
 
     @classmethod
     def get_all_device_names(cls, nwbf, config) -> tuple:

--- a/src/spyglass/common/common_device.py
+++ b/src/spyglass/common/common_device.py
@@ -98,9 +98,13 @@ class DataAcquisitionDevice(SpyglassIngestion, dj.Manual):
             replace in the NWB file.
         """
         config = config or dict()
-        entries = super().insert_from_nwbfile(
-            nwb_file_name=nwb_file_name, config=config, dry_run=dry_run
-        )[self]
+        entries = (
+            super()
+            .insert_from_nwbfile(
+                nwb_file_name=nwb_file_name, config=config, dry_run=dry_run
+            )
+            .get(self, [])
+        )
         return entries
 
     @classmethod
@@ -386,6 +390,13 @@ class Probe(SpyglassIngestion, dj.Manual):
         @staticmethod
         def shank_name_to_int(shank_nwb_obj: ndx_franklab_novela.Shank):
             return int(shank_nwb_obj.name)
+
+        def _adjust_key_for_entry(self, key):
+            """Adjust key to ensure correct types/formats."""
+            # Avoids triggering 'accept_divergence' on reinsert
+            ret = key.copy()
+            ret["probe_shank"] = int(key.get("probe_shank", -1))
+            return ret
 
     class Electrode(SpyglassIngestion, dj.Part):
         definition = """

--- a/src/spyglass/common/common_device.py
+++ b/src/spyglass/common/common_device.py
@@ -79,7 +79,10 @@ class DataAcquisitionDevice(SpyglassIngestion, dj.Manual):
         }
 
     def insert_from_nwbfile(
-        self, nwb_file_name, config=dict(), execute_inserts=True
+        self,
+        nwb_file_name: str,
+        config=None,
+        dry_run=False,
     ):
         """Insert data acquisition devices from an NWB file.
 
@@ -94,13 +97,14 @@ class DataAcquisitionDevice(SpyglassIngestion, dj.Manual):
             Dictionary read from a user-defined YAML file containing values to
             replace in the NWB file.
         """
+        config = config or dict()
         entries = super().insert_from_nwbfile(
-            nwb_file_name, config, execute_inserts
+            nwb_file_name=nwb_file_name, config=config, dry_run=dry_run
         )
         if entries:
+            vals = [e["data_acquisition_device_name"] for e in entries]
             logger.info(
-                "Inserted or referenced data acquisition device(s): "
-                + f"{[entry['data_acquisition_device_name'] for entry in entries]}"
+                f"Inserted or referenced data acquisition device(s): {vals}"
             )
         else:
             logger.warning(

--- a/src/spyglass/common/common_device.py
+++ b/src/spyglass/common/common_device.py
@@ -391,12 +391,14 @@ class Probe(SpyglassIngestion, dj.Manual):
         def shank_name_to_int(shank_nwb_obj: ndx_franklab_novela.Shank):
             return int(shank_nwb_obj.name)
 
-        def _adjust_key_for_entry(self, key):
+        def _adjust_keys_for_entry(self, keys):
             """Adjust key to ensure correct types/formats."""
             # Avoids triggering 'accept_divergence' on reinsert
-            ret = key.copy()
-            ret["probe_shank"] = int(key.get("probe_shank", -1))
-            return ret
+            adjusted = []
+            for key in keys.copy():
+                key["probe_shank"] = int(key.get("probe_shank", -1))
+                adjusted.append(key)
+            return adjusted
 
     class Electrode(SpyglassIngestion, dj.Part):
         definition = """

--- a/src/spyglass/common/common_dio.py
+++ b/src/spyglass/common/common_dio.py
@@ -27,16 +27,12 @@ class DIOEvents(SpyglassIngestion, dj.Imported):
     """
 
     _nwb_table = Nwbfile
+    _source_nwb_object_name = "behavioral_events"
 
     @property
     def _source_nwb_object_type(self):
         """The _source_nwb_object_type property."""
         return pynwb.behavior.BehavioralEvents
-
-    @property
-    def _source_nwb_object_name(self):
-        """Restrict event objects to those with this name"""
-        return "behavioral_events"
 
     def generate_entries_from_nwb_object(
         self, nwb_obj, base_key=None
@@ -108,7 +104,7 @@ class DIOEvents(SpyglassIngestion, dj.Imported):
         """Make function to populate the table. For backward compatibility"""
         from spyglass.common.common_usage import ActivityLog
 
-        ActivityLog.deprecate_log(
+        ActivityLog().deprecate_log(
             self, "DIOEvents.make", alt="insert_from_nwbfile"
         )
 

--- a/src/spyglass/common/common_dio.py
+++ b/src/spyglass/common/common_dio.py
@@ -77,7 +77,6 @@ class DIOEvents(SpyglassIngestion, dj.Imported):
                     f"No timestamps found for DIO event {event_series.name}"
                 )
                 continue
-            print(f"aa {event_series.name}")
             dio_inserts.append(
                 dict(
                     base_key,

--- a/src/spyglass/common/common_dio.py
+++ b/src/spyglass/common/common_dio.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+
 import datajoint as dj
 import matplotlib.pyplot as plt
 import numpy as np
@@ -8,14 +10,14 @@ from spyglass.common.common_ephys import Raw
 from spyglass.common.common_interval import IntervalList
 from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session  # noqa: F401
-from spyglass.utils import SpyglassMixin, logger
+from spyglass.utils import SpyglassIngestion, SpyglassMixin, logger
 from spyglass.utils.nwb_helper_fn import get_data_interface, get_nwb_file
 
 schema = dj.schema("common_dio")
 
 
 @schema
-class DIOEvents(SpyglassMixin, dj.Imported):
+class DIOEvents(SpyglassIngestion, dj.Imported):
     definition = """
     -> Session
     dio_event_name: varchar(80)   # the name assigned to this DIO event
@@ -26,63 +28,93 @@ class DIOEvents(SpyglassMixin, dj.Imported):
 
     _nwb_table = Nwbfile
 
-    def make(self, key):
-        """Make without transaction
+    @property
+    def _source_nwb_object_type(self):
+        """The _source_nwb_object_type property."""
+        return pynwb.behavior.BehavioralEvents
 
-        Allows populate_all_common to work within a single transaction."""
-        nwb_file_name = key["nwb_file_name"]
-        nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
-        nwbf = get_nwb_file(nwb_file_abspath)
+    @property
+    def _source_nwb_object_name(self):
+        """Restrict event objects to those with this name"""
+        return "behavioral_events"
 
-        behav_events = get_data_interface(
-            nwbf, "behavioral_events", pynwb.behavior.BehavioralEvents
-        )
-        if behav_events is None:
-            logger.warning(
-                "No conforming behavioral events data interface found in "
-                + f"{nwb_file_name}\n"
-            )
-            return  # See #849
+    def generate_entries_from_nwb_object(
+        self, nwb_obj, base_key=None
+    ) -> Dict["SpyglassIngestion", List[dict]]:
+        """Generate entries from nwb object.
+
+        Parameters
+        ----------
+        nwb_obj : pynwb.NWBFile
+            The NWB file object.
+        base_key : dict, optional
+            The base key to use for the entries, by default None
+
+        Returns
+        -------
+        Dict[SpyglassIngestion, List[dict]]
+            A dictionary with the table class as the key and a list of entries
+            as the value.
+        """
+        base_key = base_key or dict()
+        nwb_file_name = base_key.get("nwb_file_name", None)
+        if not nwb_file_name:
+            raise ValueError("nwb_file_name must be provided in base_key")
 
         # Times for these events correspond to the valid times for the raw data
         # If no raw data found, create a default interval list named
         # "dio data valid times"
+        interval_list_name = "dio data valid times"
         if raw_query := (Raw() & {"nwb_file_name": nwb_file_name}):
-            key["interval_list_name"] = (raw_query).fetch1("interval_list_name")
-        else:
-            key["interval_list_name"] = "dio data valid times"
+            interval_list_name = (raw_query).fetch1("interval_list_name")
 
         dio_inserts = []
         time_range_list = []
-        for event_series in behav_events.time_series.values():
+        for event_series in nwb_obj.time_series.values():
             timestamps = event_series.get_timestamps()
             if len(timestamps) == 0:  # Can be either np array or HDMF5 dataset
                 logger.warning(
-                    f"No timestamps found for DIO event {event_series.name} "
-                    + f"in {nwb_file_name}. Skipping."
+                    f"No timestamps found for DIO event {event_series.name}"
                 )
                 continue
-            key["dio_event_name"] = event_series.name
-            key["dio_object_id"] = event_series.object_id
-            dio_inserts.append(key.copy())
+            print(f"aa {event_series.name}")
+            dio_inserts.append(
+                dict(
+                    base_key,
+                    interval_list_name=interval_list_name,
+                    dio_event_name=event_series.name,
+                    dio_object_id=event_series.object_id,
+                )
+            )
             time_range_list.extend([timestamps[0], timestamps[-1]])
 
-        if key["interval_list_name"] == "dio data valid times":
-            # insert a default interval list for DIO events if no raw data
-            interval_key = {
-                "nwb_file_name": nwb_file_name,
-                "interval_list_name": key["interval_list_name"],
-                "valid_times": np.array(
-                    [[np.min(time_range_list), np.max(time_range_list)]]
-                ),
-            }
-            IntervalList.insert1(interval_key)
+        interval_key = []
+        if not raw_query:
+            interval_key.append(
+                dict(
+                    nwb_file_name=nwb_file_name,
+                    interval_list_name=interval_list_name,
+                    valid_times=np.array(
+                        [[np.min(time_range_list), np.max(time_range_list)]]
+                    ),
+                )
+            )
 
-        self.insert(
-            dio_inserts,
-            skip_duplicates=True,
-            allow_direct_insert=True,
+        return {
+            IntervalList: interval_key,
+            DIOEvents: dio_inserts,
+        }
+
+    def make(self, key):
+        """Make function to populate the table. For backward compatibility"""
+        from spyglass.common.common_usage import ActivityLog
+
+        ActivityLog.deprecate_log(
+            self, "DIOEvents.make", alt="insert_from_nwbfile"
         )
+
+        # Call the new SpyglassIngestion method
+        self.insert_from_nwbfile(key["nwb_file_name"])
 
     def plot_all_dio_events(self, return_fig=False):
         """Plot all DIO events in the session.

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -271,8 +271,7 @@ class Electrode(SpyglassMixin, dj.Imported):
 
 @schema
 class Raw(SpyglassMixin, dj.Imported):
-    definition = """
-    # Raw voltage timeseries data, ElectricalSeries in NWB.
+    definition = """ # Raw voltage timeseries data, ElectricalSeries in NWB.
     -> Session
     ---
     -> IntervalList
@@ -315,7 +314,6 @@ class Raw(SpyglassMixin, dj.Imported):
         if rawdata.rate is not None:
             key["sampling_rate"] = rawdata.rate
         else:
-            logger.info("Estimating sampling rate...")
             # NOTE: Only use first 1e6 timepoints to save time
             key["sampling_rate"] = estimate_sampling_rate(
                 np.asarray(rawdata.timestamps[: int(1e6)]), 1.5, verbose=True
@@ -345,8 +343,7 @@ class Raw(SpyglassMixin, dj.Imported):
         # same nwb_object_id
 
         logger.info(
-            f'Importing raw data: Sampling rate:\t{key["sampling_rate"]} Hz\n\t'
-            + f'Number of valid intervals:\t{len(interval_dict["valid_times"])}'
+            f'Importing raw data: {len(interval_dict["valid_times"])} intervals at {key["sampling_rate"]} Hz'
         )
 
         key.update(

--- a/src/spyglass/common/common_ephys.py
+++ b/src/spyglass/common/common_ephys.py
@@ -14,7 +14,7 @@ from spyglass.common.common_nwbfile import AnalysisNwbfile, Nwbfile
 from spyglass.common.common_region import BrainRegion  # noqa: F401
 from spyglass.common.common_session import Session  # noqa: F401
 from spyglass.settings import test_mode
-from spyglass.utils import SpyglassMixin, logger
+from spyglass.utils import SpyglassIngestion, SpyglassMixin, logger
 from spyglass.utils.nwb_helper_fn import (
     estimate_sampling_rate,
     get_config,
@@ -226,51 +226,56 @@ class Electrode(SpyglassMixin, dj.Imported):
             for electrode_dict in config["Electrode"]
         }
 
+        defaults = dict(
+            x_warped=0,
+            y_warped=0,
+            z_warped=0,
+            contacts="",
+        )
+
+        inserts = []
+        updates = []
         electrodes = nwbf.electrodes.to_dataframe()
         for nwbfile_elect_id, elect_data in electrodes.iterrows():
-            if nwbfile_elect_id in electrode_dicts:
-                # use the information in the electrodes table to start and then
-                # add (or overwrite) values from the config YAML
-
-                key = dict()
-                key["nwb_file_name"] = nwb_file_name
-                key["name"] = str(nwbfile_elect_id)
-                key["electrode_group_name"] = elect_data.group_name
-                key["region_id"] = BrainRegion.fetch_add(
-                    region_name=elect_data.group.location
-                )
-                key["x"] = elect_data.x
-                key["y"] = elect_data.y
-                key["z"] = elect_data.z
-                key["x_warped"] = 0
-                key["y_warped"] = 0
-                key["z_warped"] = 0
-                key["contacts"] = ""
-                key["filtering"] = elect_data.filtering
-                key["impedance"] = elect_data.get("imp")
-                key.update(electrode_dicts[nwbfile_elect_id])
-                query = Electrode & {"electrode_id": nwbfile_elect_id}
-                if len(query):
-                    cls.update1(key)
-                    logger.info(
-                        f"Updated Electrode with ID {nwbfile_elect_id}."
-                    )
-                else:
-                    cls.insert1(
-                        key, skip_duplicates=True, allow_direct_insert=True
-                    )
-                    logger.info(
-                        f"Inserted Electrode with ID {nwbfile_elect_id}."
-                    )
-            else:
+            if nwbfile_elect_id not in electrode_dicts:
                 warnings.warn(
                     f"Electrode ID {nwbfile_elect_id} exists in the NWB file "
                     + "but has no corresponding config YAML entry."
                 )
+                continue
+
+            # use the information in the electrodes table to start and then
+            # add (or overwrite) values from the config YAML
+
+            key = dict(
+                nwb_file_name=nwb_file_name,
+                electrode_id=str(nwbfile_elect_id),
+                electrode_group_name=elect_data.group_name,
+                region_id=BrainRegion.fetch_add(
+                    region_name=elect_data.group.location
+                ),
+                **defaults,
+                filtering=elect_data.filtering,
+                impedance=elect_data.get("imp"),
+                **electrode_dicts[nwbfile_elect_id],
+            )
+
+            query = Electrode & {"electrode_id": nwbfile_elect_id}
+
+            if len(query):
+                updates.append(key)
+                logger.info(f"Updated Electrode with ID {nwbfile_elect_id}.")
+            else:
+                inserts.append(key)
+                logger.info(f"Inserted Electrode with ID {nwbfile_elect_id}.")
+
+        cls.insert(inserts, skip_duplicates=True, allow_direct_insert=True)
+        for update in updates:
+            cls.update1(update)
 
 
 @schema
-class Raw(SpyglassMixin, dj.Imported):
+class Raw(SpyglassIngestion, dj.Imported):
     definition = """ # Raw voltage timeseries data, ElectricalSeries in NWB.
     -> Session
     ---
@@ -282,23 +287,22 @@ class Raw(SpyglassMixin, dj.Imported):
     """
 
     _nwb_table = Nwbfile
+    _only_ingest_first = True
+    _source_nwb_object_name = "e-series"
 
     @property
     def _source_nwb_object_type(self):
-        # how to specify 'ony first'?
         return pynwb.ecephys.ElectricalSeries
 
     @property
     def table_key_to_obj_attr(self):
         return {
             "self": {
-                "interval_list_name": self._raw_data_valid_times,
+                "interval_list_name": lambda *args: "raw data valid times",
                 "raw_object_id": "object_id",
                 "sampling_rate": self._rate_fallback,
                 "comments": "comments",
                 "description": "description",
-            },
-            IntervalList: {  # this process undoes `cautious_insert` protections
                 "valid_times": self._valid_times_from_raw,
             },
         }
@@ -315,94 +319,46 @@ class Raw(SpyglassMixin, dj.Imported):
             np.asarray(timestamps[: int(1e6)]), 1.5, verbose=True
         )
 
-    def _raw_data_valid_times(self, *args, **kwargs):
-        """Return the name of the interval list for the raw data."""
-        # Callable present for SpyglassIngestion insertion
-        return "raw data valid times"
+    def _valid_times_from_raw(self, nwb_object):
+        """Return valid times from the raw data."""
+        rate = getattr(nwb_object, "rate", None)
+        if rate is not None:
+            return np.array([[0, len(nwb_object.data) / rate]])
 
-    # def generate_entries_from_nwb_object(
-    #     self, nwb_object: pynwb.NWBFile, base_key=None
-    # ):
-    #     pass
+        timestamps = getattr(nwb_object, "timestamps", None)
+        if timestamps is None:
+            raise ValueError("Neither rate nor timestamps are available.")
+
+        return get_valid_intervals(
+            timestamps=np.asarray(timestamps),
+            sampling_rate=self._rate_fallback(nwb_object),
+            gap_proportion=1.75,
+            min_valid_len=0,
+        )
+
+    def generate_entries_from_nwb_object(self, nwb_obj, base_key=None):
+        """Add IntervalList entry to the generated entries."""
+        super_ins = super().generate_entries_from_nwb_object(nwb_obj, base_key)
+        self_key = super_ins[self][0]
+        valid_times = self_key.pop("valid_times")  # remove from self key
+        interval_insert = {
+            k: v for k, v in self_key.items() if k in IntervalList.heading.names
+        }
+        return {
+            IntervalList: [dict(interval_insert, valid_times=valid_times)],
+            **super_ins,
+        }
 
     def make(self, key):
         """Make without transaction
 
         Allows populate_all_common to work within a single transaction."""
-        nwb_file_name = key["nwb_file_name"]
-        nwb_file_abspath = Nwbfile.get_abs_path(nwb_file_name)
-        nwbf = get_nwb_file(nwb_file_abspath)
-        raw_interval_name = "raw data valid times"
+        from spyglass.common.common_usage import ActivityLog
 
-        # get the ElectricalSeries acquisition object
-        eseries_aquisitions = []
-        for obj_name, obj in nwbf.acquisition.items():
-            if isinstance(obj, pynwb.ecephys.ElectricalSeries):
-                eseries_aquisitions.append(obj)
+        ActivityLog.deprecate_log(self, "Raw.make", alt="insert_from_nwbfile")
 
-        if len(eseries_aquisitions) == 0:
-            warnings.warn(
-                f"Unable to get acquisition object in: {nwb_file_abspath}\n\t"
-                + f"Skipping entry in {self.full_table_name}"
-            )
-            return
-        elif len(eseries_aquisitions) > 1:
-            warnings.warn(
-                f"Multiple ElectricalSeries objects found in: {nwb_file_abspath}\n\t"
-                + f"Inserting only first entry in {self.full_table_name}\n\t"
-                + "See issue #396 for more details."
-            )
-        rawdata = eseries_aquisitions[0]
-
-        if rawdata.rate is not None:
-            key["sampling_rate"] = rawdata.rate
-        else:
-            # NOTE: Only use first 1e6 timepoints to save time
-            key["sampling_rate"] = estimate_sampling_rate(
-                np.asarray(rawdata.timestamps[: int(1e6)]), 1.5, verbose=True
-            )
-
-        interval_dict = {
-            "nwb_file_name": key["nwb_file_name"],
-            "interval_list_name": raw_interval_name,
-        }
-
-        if rawdata.rate is not None:
-            interval_dict["valid_times"] = np.array(
-                [[0, len(rawdata.data) / rawdata.rate]]
-            )
-        else:
-            # get the list of valid times given the specified sampling rate.
-            interval_dict["valid_times"] = get_valid_intervals(
-                timestamps=np.asarray(rawdata.timestamps),
-                sampling_rate=key["sampling_rate"],
-                gap_proportion=1.75,
-                min_valid_len=0,
-            )
-
-        IntervalList().cautious_insert(interval_dict, update=True)
-
-        # now insert each of the electrodes as an individual row, but with the
-        # same nwb_object_id
-
-        logger.info(
-            f'Importing raw data: {len(interval_dict["valid_times"])} intervals at {key["sampling_rate"]} Hz'
-        )
-
-        key.update(
-            {
-                "raw_object_id": rawdata.object_id,
-                "interval_list_name": raw_interval_name,
-                "comments": rawdata.comments,
-                "description": rawdata.description,
-            }
-        )
-
-        self.insert1(
-            key,
-            skip_duplicates=True,
-            allow_direct_insert=True,
-        )
+        # Call the new SpyglassIngestion method
+        self.insert_from_nwbfile(key["nwb_file_name"])
 
     def nwb_object(self, key):
         """Return the NWB object in the raw NWB file."""

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -207,6 +207,10 @@ class IntervalList(SpyglassIngestion, dj.Manual):
         if return_fig:
             return fig
 
+    # TODO: override insert with cautious_insert?
+    # would allow SpyglassIngestion Raw to use cautious_insert
+    # Can add 'super_insert' to bypass when needed
+
     def cautious_insert(self, inserts, update=False, **kwargs):
         """On existing primary key, check secondary key and update if needed.
 

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -235,10 +235,9 @@ class IntervalList(SpyglassIngestion, dj.Manual):
             return match.fetch(as_dict=True)[0] if match else None
 
         def sk_match(new, old):
-            return (
-                np.array_equal(new["valid_times"], old["valid_times"])
-                and new["pipeline"] == old["pipeline"]
-            )
+            return np.array_equal(
+                new["valid_times"], old["valid_times"]
+            ) and new.get("pipeline", "") == old.get("pipeline", "")
 
         basic_inserts, need_update = [], []
         for row in inserts:

--- a/src/spyglass/common/common_lab.py
+++ b/src/spyglass/common/common_lab.py
@@ -295,12 +295,10 @@ class Institution(SpyglassIngestion, dj.Manual):
     def _source_nwb_object_type(self):
         return pynwb.NWBFile
 
-    def _adjust_key_for_entry(self, key):
+    def _adjust_keys_for_entry(self, keys):
         """Ensure that institution_name is not None."""
         # Prevents attempted insert when nwbfile.institution is None
-        if not key.get("institution_name", None):
-            return None
-        return key
+        return [k for k in keys if key.get("institution_name", None)]
 
 
 @schema

--- a/src/spyglass/common/common_lab.py
+++ b/src/spyglass/common/common_lab.py
@@ -298,7 +298,7 @@ class Institution(SpyglassIngestion, dj.Manual):
     def _adjust_keys_for_entry(self, keys):
         """Ensure that institution_name is not None."""
         # Prevents attempted insert when nwbfile.institution is None
-        return [k for k in keys if key.get("institution_name", None)]
+        return [k for k in keys if k.get("institution_name", None)]
 
 
 @schema

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -69,14 +69,15 @@ class Nwbfile(SpyglassMixin, dj.Manual):
         """
         nwb_file_abs_path = Nwbfile.get_abs_path(nwb_file_name, new_file=True)
 
-        assert os.path.exists(
-            nwb_file_abs_path
-        ), f"File does not exist: {nwb_file_abs_path}"
+        if not Path(nwb_file_abs_path).exists():
+            raise FileNotFoundError(f"File not found: {nwb_file_abs_path}")
 
-        key = dict()
-        key["nwb_file_name"] = nwb_file_name
-        key["nwb_file_abs_path"] = nwb_file_abs_path
-        cls.insert1(key, skip_duplicates=True)
+        cls.insert1(
+            dict(
+                nwb_file_name=nwb_file_name, nwb_file_abs_path=nwb_file_abs_path
+            ),
+            skip_duplicates=True,
+        )
 
     def fetch_nwb(self):
         return [

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -102,4 +102,4 @@ class Session(SpyglassIngestion, dj.Imported):
                         **base_key,
                     }
                 )
-            return entries
+            return {self: entries}

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -91,8 +91,8 @@ class Session(SpyglassIngestion, dj.Imported):
             base_key = base_key or dict()
             experimenter_list = nwb_obj.experimenter
             if not experimenter_list:
-                logger.info("No experimenter metadata found.\n")
-                return list()
+                logger.info("No experimenter metadata found for Session.\n")
+                return dict()
 
             entries = []
             for experimenter in experimenter_list:
@@ -104,3 +104,6 @@ class Session(SpyglassIngestion, dj.Imported):
                     }
                 )
             return {self: entries}
+
+    def make(self, key):
+        self.insert_from_nwbfile(**key)

--- a/src/spyglass/common/common_session.py
+++ b/src/spyglass/common/common_session.py
@@ -85,9 +85,10 @@ class Session(SpyglassIngestion, dj.Imported):
             return pynwb.NWBFile
 
         def generate_entries_from_nwb_object(
-            self, nwb_obj: pynwb.NWBFile, base_key=dict()
+            self, nwb_obj: pynwb.NWBFile, base_key=None
         ):
             """Override to handle multiple experimenters."""
+            base_key = base_key or dict()
             experimenter_list = nwb_obj.experimenter
             if not experimenter_list:
                 logger.info("No experimenter metadata found.\n")

--- a/src/spyglass/common/common_subject.py
+++ b/src/spyglass/common/common_subject.py
@@ -52,6 +52,6 @@ class Subject(SpyglassIngestion, dj.Manual):
         # Avoids triggering 'accept_divergence' on reinsert
         adjusted = []
         for key in keys.copy():
-            key["sex"] = self.standardized(key, warn=False)
+            key["sex"] = self.standardized_sex_string(key, warn=False)
             adjusted.append(key)
         return super()._adjust_keys_for_entry(adjusted)

--- a/src/spyglass/common/common_subject.py
+++ b/src/spyglass/common/common_subject.py
@@ -36,13 +36,20 @@ class Subject(SpyglassIngestion, dj.Manual):
         return pynwb.file.Subject
 
     @staticmethod
-    def standardized_sex_string(subject):
+    def standardized_sex_string(subject, warn=True):
         """Takes subject.sex and returns 'M', 'F', or 'U'."""
-        sex_field = getattr(subject, "sex", "U")
+        sex_field = getattr(subject, "sex", "U") or "U"
         if (sex := sex_field[0].upper()) in ("M", "F", "U"):
             return sex
-        else:
+        elif warn:
             logger.info(
                 f"Unrecognized sex identifier {sex_field}, setting to 'U'"
             )
         return "U"
+
+    def _adjust_key_for_entry(self, key):
+        """Fill in any NULL values in the key with defaults."""
+        # Avoids triggering 'accept_divergence' on reinsert
+        ret = key.copy()
+        ret["sex"] = self.standardized_sex_string(key, warn=False)
+        return super()._adjust_key_for_entry(ret)

--- a/src/spyglass/common/common_subject.py
+++ b/src/spyglass/common/common_subject.py
@@ -47,9 +47,11 @@ class Subject(SpyglassIngestion, dj.Manual):
             )
         return "U"
 
-    def _adjust_key_for_entry(self, key):
+    def _adjust_keys_for_entry(self, keys):
         """Fill in any NULL values in the key with defaults."""
         # Avoids triggering 'accept_divergence' on reinsert
-        ret = key.copy()
-        ret["sex"] = self.standardized_sex_string(key, warn=False)
-        return super()._adjust_key_for_entry(ret)
+        adjusted = []
+        for key in keys.copy():
+            key["sex"] = self.standardized(key, warn=False)
+            adjusted.append(key)
+        return super()._adjust_keys_for_entry(adjusted)

--- a/src/spyglass/common/common_user.py
+++ b/src/spyglass/common/common_user.py
@@ -116,14 +116,28 @@ class UserEnvironment(dj.Manual):
     def _basic_dep_format(self):
         """Regex patterns for dependency formats.
 
-        Allowable formats with suffixes: a1, b2, rc3, .post4, dev5, etc."""
+        Allowable formats with suffixes: a1, b2, rc3, .post4, dev5, etc.
+        Examples:
+        - package==1.2.3
+        - package==1.2.3a1 (alpha)
+        - package==1.2.3b2 (beta)
+        - package==1.2.3rc3 (release candidate)
+        - package==1.2.3.post4 (post-release)
+        - package==1.2.3.dev5 (developmental release)
+        - package==1.2.3+dfsg (Debian Free Software Guidelines)
+        - package==1.2.3+ds (Debian Source)
+        - package==1.2.3+ubuntu1.2 (Ubuntu-specific)
+        """
         return re.compile(  # allows suffixes like a1, dev, post1, etc.
             r"""^
                 (?P<pkg>[\w\d.-]+)                  # Package
                 ==                                  # `==` separator
                 (?P<ver>                            # Version
                     \d+(?:\.\d+)*                   # Major.Minor.Patch
-                    (?:(?:a|b|rc|\.post)\d+|dev\d*) # Suffixes
+                    (?:                             # Suffixes
+                        (?:a|b|rc|\.post)\d+|
+                        dev\d*|\+dfsg|\+ds|\+ubuntu\d+(?:\.\d+)*
+                    )
                 ?)
             $""",
             re.VERBOSE,

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -103,7 +103,6 @@ def single_transaction_make(
             table_config = config.get(config_name, dict())
 
             if isinstance(table(), SpyglassIngestion):
-                print(f"ING {config_name}")
                 try:
                     table().insert_from_nwbfile(
                         nwb_file_name, config=table_config
@@ -204,10 +203,10 @@ def populate_all_common(
             Raw,  # Depends on Session
             SampleCount,  # Depends on Session
             DIOEvents,  # Depends on Session
-            TaskEpoch,  # Depends on Session, Task, CamearaDevice, IntervalList
             ImportedSpikeSorting,  # Depends on Session
             SensorData,  # Depends on Session
             IntervalList,  # Depends on Session
+            TaskEpoch,  # Depends on Session, Task, CamearaDevice, IntervalList
             # NwbfileKachery, # Not used by default
         ],
         [  # Tables that depend on above transaction

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -84,7 +84,7 @@ def single_transaction_make(
     file_restr = {"nwb_file_name": nwb_file_name}
     with Nwbfile.connection.transaction:
         for table in tables:
-            logger.info(f"Populating {table.__name__}...")
+
             # TODO 1377:Temporary during migration
             if isinstance(table(), SpyglassIngestion):
                 try:
@@ -100,6 +100,7 @@ def single_transaction_make(
                 continue
 
             # If imported/computed table, get key from key_source
+            logger.info(f"Populating {table.__name__}...")
             key_source = getattr(table, "key_source", None)
             if key_source is None:  # Generate key from parents
                 parents = table.parents(as_objects=True)

--- a/src/spyglass/data_import/insert_sessions.py
+++ b/src/spyglass/data_import/insert_sessions.py
@@ -91,7 +91,9 @@ def insert_sessions(
         )
 
 
-def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
+def copy_nwb_link_raw_ephys(
+    nwb_file_name, out_nwb_file_name, keep_existing=False
+):
     """Copies an NWB file with a link to raw ephys data.
 
     Parameters
@@ -100,6 +102,8 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
         The name of the NWB file to be copied.
     out_nwb_file_name : str
         The name of the new NWB file with the link to raw ephys data.
+    keep_existing : bool, optional
+        If True, will not overwrite an existing file. Default is False.
 
     Returns
     -------
@@ -121,7 +125,7 @@ def copy_nwb_link_raw_ephys(nwb_file_name, out_nwb_file_name):
     )
 
     if os.path.exists(out_nwb_file_abs_path):
-        if debug_mode:
+        if debug_mode or keep_existing:
             return out_nwb_file_abs_path
         logger.warning(
             f"Output file exists, will be overwritten: {out_nwb_file_abs_path}"

--- a/src/spyglass/data_import/insert_sessions.py
+++ b/src/spyglass/data_import/insert_sessions.py
@@ -7,6 +7,7 @@ from typing import List, Union
 import pynwb
 
 from spyglass.common import Nwbfile, get_raw_eseries, populate_all_common
+from spyglass.common.common_nwbfile import schema as nwbfile_schema
 from spyglass.settings import debug_mode, raw_dir
 from spyglass.utils import logger
 from spyglass.utils.nwb_helper_fn import get_nwb_copy_filename
@@ -40,6 +41,8 @@ def insert_sessions(
         nwb_file_names = [nwb_file_names]
 
     for nwb_file_name in nwb_file_names:
+        nwb_file_name = str(nwb_file_name)  # in case it's a Path object
+
         if "/" in nwb_file_name:
             nwb_file_name = nwb_file_name.split("/")[-1]
 
@@ -65,7 +68,7 @@ def insert_sessions(
         out_nwb_file_name = get_nwb_copy_filename(nwb_file_abs_path.name)
 
         # Check whether the file already exists in the Nwbfile table
-        query = Nwbfile() & {"nwb_file_name": nwb_file_name}
+        query = Nwbfile() & {"nwb_file_name": out_nwb_file_name}
         file_exists = bool(query)
         if file_exists and not reinsert:
             warnings.warn(
@@ -77,7 +80,7 @@ def insert_sessions(
             logger.info(
                 f"Reinserting data from {nwb_file_name}: {out_nwb_file_name}"
             )
-            query.delete()
+            query.delete(safemode=False)
 
         # Make a copy of the NWB file that ends with '_'.
         # This has everything except the raw data but has a link to

--- a/src/spyglass/spikesorting/imported.py
+++ b/src/spyglass/spikesorting/imported.py
@@ -85,7 +85,7 @@ class ImportedSpikeSorting(SpyglassIngestion, dj.Imported):
         # Call the new SpyglassIngestion method
         from spyglass.common.common_usage import ActivityLog
 
-        ActivityLog.deprecate_log(
+        ActivityLog().deprecate_log(
             self, "ImportedSpikesorting.make", alt="insert_from_nwbfile"
         )
 

--- a/src/spyglass/spikesorting/imported.py
+++ b/src/spyglass/spikesorting/imported.py
@@ -6,13 +6,13 @@ import pynwb
 
 from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session  # noqa: F401
-from spyglass.utils import SpyglassMixin, logger
+from spyglass.utils import SpyglassIngestion, SpyglassMixin, logger
 
 schema = dj.schema("spikesorting_imported")
 
 
 @schema
-class ImportedSpikeSorting(SpyglassMixin, dj.Imported):
+class ImportedSpikeSorting(SpyglassIngestion, dj.Imported):
     definition = """
     -> Session
     ---
@@ -30,35 +30,68 @@ class ImportedSpikeSorting(SpyglassMixin, dj.Imported):
         annotations: longblob # dict of other annotations (e.g. metrics)
         """
 
-    def make(self, key):
-        """Make without transaction
+    # SpyglassIngestion properties
+    @property
+    def table_key_to_obj_attr(self):
+        return {
+            "self": {
+                "object_id": "object_id",
+            }
+        }
 
-        Allows populate_all_common to work within a single transaction."""
-        orig_key = copy.deepcopy(key)
+    @property
+    def _source_nwb_object_type(self):
+        return pynwb.misc.Units
 
-        nwb_file_abs_path = Nwbfile.get_abs_path(key["nwb_file_name"])
+    def get_nwb_objects(self, nwb_file, nwb_file_name=None):
+        """Override to get units from nwb_file.units."""
+        if not getattr(nwb_file, "units", None):
+            logger.warn("No units found in NWB file")
+            return []
+        return [nwb_file.units]
 
-        with pynwb.NWBHDF5IO(
-            nwb_file_abs_path, "r", load_namespaces=True
-        ) as io:
-            nwbfile = io.read()
-            if not nwbfile.units:
-                logger.warn("No units found in NWB file")
-                return
+    def insert_from_nwbfile(
+        self,
+        nwb_file_name: str,
+        config: dict = None,
+        dry_run: bool = False,
+    ):
+        """Override base method to add merge table integration."""
+        # Call the base implementation first
+        result = super().insert_from_nwbfile(nwb_file_name, config, dry_run)
+
+        if dry_run or not result or self not in result:
+            return result
+
+        # Add merge table integration
+        orig_key = {"nwb_file_name": nwb_file_name}
 
         from spyglass.spikesorting.spikesorting_merge import (
             SpikeSortingOutput,
         )  # noqa: F401
-
-        key["object_id"] = nwbfile.units.object_id
-
-        self.insert1(key, skip_duplicates=True, allow_direct_insert=True)
 
         part_name = SpikeSortingOutput._part_name(self.table_name)
         SpikeSortingOutput._merge_insert(
             [orig_key], part_name=part_name, skip_duplicates=True
         )
 
+        return result
+
+    def make(self, key):
+        """Legacy make method - replaced by insert_from_nwbfile.
+
+        Kept for backward compatibility during migration.
+        """
+        # Call the new SpyglassIngestion method
+        from spyglass.common.common_usage import ActivityLog
+
+        ActivityLog.deprecate_log(
+            self, "ImportedSpikesorting.make", alt="insert_from_nwbfile"
+        )
+
+        return self.insert_from_nwbfile(key["nwb_file_name"])
+
+    # ------------ Placeholder methods for merge table integration ------------
     @classmethod
     def get_recording(cls, key):
         """Placeholder for merge table to call on all sources."""
@@ -73,6 +106,7 @@ class ImportedSpikeSorting(SpyglassMixin, dj.Imported):
             "Imported spike sorting does not have a `get_sorting` method"
         )
 
+    # --------------------------- Annotation methods ---------------------------
     def add_annotation(
         self, key, id, label=[], annotations={}, merge_annotations=False
     ):
@@ -134,7 +168,7 @@ class ImportedSpikeSorting(SpyglassMixin, dj.Imported):
         return df
 
     def fetch_nwb(self, *attrs, **kwargs):
-        """class method to fetch the nwb and add annotations to the spike dfs returned"""
+        """Fetch the nwb and add annotations to the spike dfs returned"""
         # get the original nwbs
         nwbs = super().fetch_nwb(*attrs, **kwargs)
         # for each nwb, get the annotations and add them to the spikes dataframe

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -1081,7 +1081,6 @@ class SpyglassIngestion(SpyglassMixin):
         ret = self._config_entries(self, base_key, self_entries)
 
         for part in self.parts(as_objects=True):
-            # TODO: verify that returning the FreeTable works
             camel_part = to_camel_case(part.full_table_name.split("__")[-1])
             part_entries = config.get(camel_part, [])
             if len(part_entries) == 0:
@@ -1211,15 +1210,10 @@ class SpyglassIngestion(SpyglassMixin):
         if self._expected_duplicates:
             if isinstance(entries, list):
                 raise RuntimeError("TODO: this is no longer the case, right?")
-            #     for entry in entries:
-            #         self.validate_duplicates(entry)
-            # else:
             self.validate_duplicates(entries)
 
         # run insertions
         if not dry_run:
-            if not isinstance(entries, dict):
-                raise RuntimeError("TODO: this is no longer the case, right?")
             for table, table_entries in entries.items():
                 table.insert(
                     table_entries,

--- a/src/spyglass/utils/dj_mixin.py
+++ b/src/spyglass/utils/dj_mixin.py
@@ -860,7 +860,9 @@ class SpyglassMixin(ExportMixin):
 
     def exec_sql_fetchall(self, query):
         """
-        Execute the given query and fetch the results.    Parameters
+        Execute the given query and fetch the results.
+
+        Parameters
         ----------
         query : str
             The SQL query to execute.    Returns
@@ -1129,7 +1131,7 @@ class SpyglassIngestion(SpyglassMixin, ABC):
         self,
         nwb_file_name: str,
         config: dict = None,
-        execute_inserts: bool = True,
+        dry_run: bool = False,
     ):
         """Insert entries into the table from an NWB file.
 
@@ -1139,9 +1141,9 @@ class SpyglassIngestion(SpyglassMixin, ABC):
             The name of the NWB file to import from.
         config : dict, optional
             A configuration dictionary to supplement NWB data. Default None.
-        execute_inserts : bool, optional
-            If False, do not execute the insert, just return the entries that
-            would be inserted. Default True.
+        dry_run : bool, optional
+            If True, do not insert into the database, just return the entries
+            that would be inserted. Default False.
         """
         from spyglass.common.common_nwbfile import Nwbfile
 
@@ -1189,7 +1191,7 @@ class SpyglassIngestion(SpyglassMixin, ABC):
                         table().validate_duplicates(entry)
 
         # run insertions
-        if execute_inserts:
+        if not dry_run:
             if isinstance(entries, dict):
                 for table, table_entries in entries.items():
                     table().insert(

--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -395,7 +395,9 @@ def get_valid_intervals(
 
     if total_time < min_valid_len:
         half_total_time = total_time / 2
-        logger.warning(f"Setting minimum valid interval to {half_total_time}")
+        logger.warning(
+            f"Setting minimum valid interval to {half_total_time:.4f}"
+        )
         min_valid_len = half_total_time
 
     # get rid of NaN elements

--- a/tests/common/test_device.py
+++ b/tests/common/test_device.py
@@ -22,29 +22,31 @@ def test_spike_gadgets_system_alias(mini_insert, common):
     ), "SpikeGadgets MCU alias not found"
 
 
-def test_invalid_probe(common, populate_exception):
-    probe_dict = common.ProbeType.fetch(as_dict=True)[0]
-    probe_dict["other"] = "invalid"
-    with pytest.raises(populate_exception):
-        common.Probe._add_probe_type(probe_dict)
+# REMOVING TEST FOR REMOVED FUNC
+# def test_invalid_probe(common, populate_exception):
+#     probe_dict = common.ProbeType.fetch(as_dict=True)[0]
+#     probe_dict["other"] = "invalid"
+#     with pytest.raises(populate_exception):
+#         common.Probe._add_probe_type(probe_dict)
 
 
-def test_create_probe(common, mini_devices, mini_path, mini_copy_name):
-    probe_id = common.Probe.fetch("KEY", as_dict=True)[0]
-    probe_type = common.ProbeType.fetch("KEY", as_dict=True)[0]
-    before = common.Probe.fetch()
-    common.Probe.create_from_nwbfile(
-        nwb_file_name=mini_copy_name,
-        nwb_device_name="probe 0",
-        contact_side_numbering=False,
-        **probe_id,
-        **probe_type,
-    )
-    after = common.Probe.fetch()
-    # Because already inserted, expect no change
-    assert array_equal(
-        before, after
-    ), "Probe create_from_nwbfile had unexpected effect"
+# REMOVING TEST FOR REMOVED FUNC
+# def test_create_probe(common, mini_devices, mini_path, mini_copy_name):
+#     probe_id = common.Probe.fetch("KEY", as_dict=True)[0]
+#     probe_type = common.ProbeType.fetch("KEY", as_dict=True)[0]
+#     before = common.Probe.fetch()
+#     common.Probe.create_from_nwbfile(
+#         nwb_file_name=mini_copy_name,
+#         nwb_device_name="probe 0",
+#         contact_side_numbering=False,
+#         **probe_id,
+#         **probe_type,
+#     )
+#     after = common.Probe.fetch()
+#     # Because already inserted, expect no change
+#     assert array_equal(
+#         before, after
+#     ), "Probe create_from_nwbfile had unexpected effect"
 
 
 def test_replace_nan_with_default(utils):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,13 +286,13 @@ def load_config(dj_conn, base_dir):
 
 @pytest.fixture(autouse=True, scope="session")
 def mini_insert(
-    dj_conn, mini_path, mini_content, teardown, server, load_config
+    dj_conn, mini_path, mini_content, teardown, server, load_config, mini_dict
 ):
     from spyglass.common import LabMember, Nwbfile, Session  # noqa: E402
     from spyglass.data_import import insert_sessions  # noqa: E402
-    from spyglass.spikesorting.spikesorting_merge import (  # noqa: E402
+    from spyglass.spikesorting.spikesorting_merge import (
         SpikeSortingOutput,
-    )
+    )  # noqa: E402
     from spyglass.utils.nwb_helper_fn import close_nwb_files  # noqa: E402
 
     _ = SpikeSortingOutput()
@@ -307,7 +307,7 @@ def mini_insert(
     if not server.connected:
         raise ConnectionError("No server connection.")
 
-    if len(Nwbfile()) != 0:
+    if len(Nwbfile & mini_dict) != 0:
         dj_logger.warning("Skipping insert, use existing data.")
     else:
         try:

--- a/tests/position/v1/test_import.py
+++ b/tests/position/v1/test_import.py
@@ -19,6 +19,7 @@ def imported_pose_tbl():
 @pytest.fixture(scope="module")
 def import_pose_nwb(verbose_context, imported_pose_tbl):
     from spyglass.common import Nwbfile, Session
+    from spyglass.data_import import insert_sessions
     from spyglass.settings import raw_dir
 
     # --- Create fake data
@@ -81,7 +82,9 @@ def import_pose_nwb(verbose_context, imported_pose_tbl):
     behavior_mod.add(pose)
 
     # --- Write to file
-    pose_file = Path(raw_dir) / "test_imported_pose.nwb"
+    raw_file_name = "test_imported_pose.nwb"
+    copy_file_name = "test_imported_pose_.nwb"
+    pose_file = Path(raw_dir) / raw_file_name
     nwb_dict = dict(nwb_file_name=pose_file.name)
     if (Nwbfile() & nwb_dict) or pose_file.exists():
         Nwbfile().delete(safemode=False)
@@ -91,10 +94,11 @@ def import_pose_nwb(verbose_context, imported_pose_tbl):
         io.write(nwbfile)
 
     # --- Insert pose data into ImportedPose
-    Nwbfile().insert_from_relative_file_name(pose_file.name)
-    Session().populate(dict(nwb_file_name=pose_file.name))
+    insert_sessions([str(pose_file)], raise_err=True)
+    # Nwbfile().insert_from_relative_file_name(pose_file.name)
+    # Session().populate(dict(nwb_file_name=pose_file.name))
 
-    imported_pose_tbl.insert_from_nwbfile(pose_file.name, skip_duplicates=True)
+    imported_pose_tbl.insert_from_nwbfile(copy_file_name, skip_duplicates=True)
 
     yield pose_file
 


### PR DESCRIPTION
# Description

This PR makes updates to existing work on NWB ingestion by...
- Addressing failing tests
- Building the mapping doc on mkdocs build
- Handling inserts as dicts, to allow multi-table inserts (i.e., TableA triggers inserts for TableA and TableB)
- Quieting false-positive 'accept divergence' issues (i.e., normalize defaults before entry, skip empty nullable inserts)
- Standardizing the output format: `{nwbfile} inserts {count} into {table}`

Adds `SpyglassIngestion` to ...
- `Raw`
- `DIOEvents`

To do:
- Makes user-facing changes to logging - does that require edits to docs?
- New approach changes an `IntervalList` insert from `cautious_insert` -> vanilla `insert`
  - Should this motivate an override of `insert`?
  - Does `SpyglassIngestion` need to check for a `cautious_insert` method?

# Checklist:

- [X] NA. If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [X] NA. If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [X] Yes. If this PR makes changes to position, I ran the relevant tests locally.
- [?] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [X] I have updated the `CHANGELOG.md` with PR number and description.
