### PR TITLE
Make path return consistent type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ import all foreign key references.
 - Common
     - Add tables for storing optogenetic experiment information #1312
     - Remove wildcard matching in `Nwbfile().get_abs_path` #1382
+    - Ensure `AnalysisNwbfile.get_abs_path` always returns same type #1429
 - Decoding
     - Ensure results directory is created if it doesn't exist #1362
 - Position

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -393,7 +393,7 @@ class AnalysisNwbfile(SpyglassMixin, dj.Manual):
                 & f"filepath LIKE '%{analysis_nwb_file_name}'"
             )
             if len(query) == 1:  # Else try the standard way
-                return Path(analysis_dir) / query.fetch1("filepath")
+                return str(Path(analysis_dir) / query.fetch1("filepath"))
             logger.warning(
                 f"Found {len(query)} files for: {analysis_nwb_file_name}"
             )


### PR DESCRIPTION
# Description

Fixes #1428 
- Ensure `AnalysisNwbfile.get_abs_path` always returns same type (`str`)
# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
