### PR TITLE
Address FigURLCuration() populate issue #1504

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ these, please run the `LFPBandV1().fix_1481()` method after updating.
 - Spikesorting
 
     - Implement short-transaction `SpikeSortingRecording.make` for v0 #1338
+    - Fix `FigURLCuration.make`. Postpone fetch of unhashable items #1505
 
 ## [0.5.5] (Aug 6, 2025)
 

--- a/src/spyglass/spikesorting/v1/figurl_curation.py
+++ b/src/spyglass/spikesorting/v1/figurl_curation.py
@@ -166,7 +166,7 @@ class FigURLCuration(SpyglassMixin, dj.Computed):
         sorting = CurationV1.get_sorting(sel_key)
 
         # Some versions of sortingview expect `_file_path` attribute
-        # not present in all recording objects
+        # which may not be present in all recording objects
         if not hasattr(recording, "_file_path") and hasattr(
             recording, "file_path"
         ):


### PR DESCRIPTION
# Description

`FigURLCuration` tripart make split failed to delay fetch of unhashable items.

# Checklist:

- [X] N/a. If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [X] N/a. If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [X] N/a. If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [X] I have updated the `CHANGELOG.md` with PR number and description.
