### PR TITLE
Normalize poses by body length for Moseq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ for label, interval_data in results.groupby("interval_labels"):
 
     - Add methods for calling moseq visualization functions #1374
     - Ensure latent moseq dimension is compatible with dataset #1511
+    - Add option to normalize keypoint spacing by body length #1569
 
 - Common
 

--- a/notebooks/60_MoSeq.ipynb
+++ b/notebooks/60_MoSeq.ipynb
@@ -638,13 +638,18 @@
    "source": [
     "## Defining the Moseq Model\n",
     "\n",
-    "Next, we make an entry intpo the `MoseqModelParams` table.  The information in this\n",
+    "Next, we make an entry into the `MoseqModelParams` table.  The information in this\n",
     "is used to initialize the moseq model and includes hyperparameters for model training\n",
     "as well as allows you to begin training from an existing model in the database \n",
     "(discussed more below). Relevant parameters can be found in the [Moseq documentation](\n",
     "https://keypoint-moseq.readthedocs.io/en/latest/modeling.html#model-fitting)\n",
     "\n",
-    "** Note: All bodyparts in the `PoseGroup` entry will be used in the model"
+    "** Note: All bodyparts in the `PoseGroup` entry will be used in the model\n",
+    "\n",
+    "** Note: When training on multiple animals of different sizes (e.g. male and female rats),\n",
+    "The [Moseq documentation](https://keypoint-moseq.readthedocs.io/en/latest/FAQs.html) \n",
+    "suggests scaling keypoint distances by each animal's size. This can be done here using\n",
+    "the optional parameter `normalize=True`."
    ]
   },
   {
@@ -760,11 +765,13 @@
     "params[\"num_ar_iters\"] = 50\n",
     "# num_epochs is the number of epochs to train the model\n",
     "params[\"num_epochs\"] = 50\n",
-    "# anteror and posterior bodyparts are used to define the orientation of the animal\n",
+    "# anterior and posterior bodyparts are used to define the orientation of the animal\n",
     "params[\"anterior_bodyparts\"] = [\"nose\"]\n",
     "params[\"posterior_bodyparts\"] = [\"tailBase\"]\n",
     "# Optional: set number of PCs to use; based on number needed to explain target_variance in data\n",
     "params[\"target_variance\"] = 0.9\n",
+    "# Optional: scale the keypoint distances by animal size\n",
+    "params[\"normalize\"] = False\n",
     "\n",
     "MoseqModelParams().insert1(\n",
     "    {\"model_params_name\": model_params_name, \"model_params\": params},\n",

--- a/notebooks/py_scripts/60_MoSeq.py
+++ b/notebooks/py_scripts/60_MoSeq.py
@@ -102,13 +102,18 @@ PoseGroup() & group_key
 
 # ## Defining the Moseq Model
 #
-# Next, we make an entry intpo the `MoseqModelParams` table.  The information in this
+# Next, we make an entry into the `MoseqModelParams` table.  The information in this
 # is used to initialize the moseq model and includes hyperparameters for model training
 # as well as allows you to begin training from an existing model in the database
 # (discussed more below). Relevant parameters can be found in the [Moseq documentation](
 # https://keypoint-moseq.readthedocs.io/en/latest/modeling.html#model-fitting)
 #
 # ** Note: All bodyparts in the `PoseGroup` entry will be used in the model
+#
+# ** Note: When training on multiple animals of different sizes (e.g. male and female rats),
+# The [Moseq documentation](https://keypoint-moseq.readthedocs.io/en/latest/FAQs.html)
+# suggests scaling keypoint distances by each animal's size. This can be done here using
+# the optional parameter `normalize=True`.
 
 # +
 from spyglass.behavior.v1.moseq import (
@@ -134,11 +139,13 @@ params["kappa"] = 1e4
 params["num_ar_iters"] = 50
 # num_epochs is the number of epochs to train the model
 params["num_epochs"] = 50
-# anteror and posterior bodyparts are used to define the orientation of the animal
+# anterior and posterior bodyparts are used to define the orientation of the animal
 params["anterior_bodyparts"] = ["nose"]
 params["posterior_bodyparts"] = ["tailBase"]
 # Optional: set number of PCs to use; based on number needed to explain target_variance in data
 params["target_variance"] = 0.9
+# Optional: scale the keypoint distances by animal size
+params["normalize"] = False
 
 MoseqModelParams().insert1(
     {"model_params_name": model_params_name, "model_params": params},

--- a/src/spyglass/behavior/v1/core.py
+++ b/src/spyglass/behavior/v1/core.py
@@ -66,7 +66,12 @@ class PoseGroup(SpyglassMixin, dj.Manual):
             )
 
     def fetch_pose_datasets(
-        self, key: dict = None, format_for_moseq: bool = False
+        self,
+        key: dict = None,
+        format_for_moseq: bool = False,
+        normalize: bool = False,
+        anterior_bodyparts: List[str] = None,
+        posterior_bodyparts: List[str] = None,
     ):
         """fetch pose information for a group of videos
 
@@ -76,6 +81,14 @@ class PoseGroup(SpyglassMixin, dj.Manual):
             group key
         format_for_moseq : bool, optional
             format for MoSeq, by default False
+        normalize : bool, optional
+            whether to normalize the pose datasets by animal length, by default False
+        anterior_bodyparts : List[str], optional
+            list of anterior body parts to use for normalization, required if
+            normalize is True
+        posterior_bodyparts : List[str], optional
+            list of posterior body parts to use for normalization, required if
+            normalize is True
 
         Returns
         -------
@@ -98,6 +111,15 @@ class PoseGroup(SpyglassMixin, dj.Manual):
                 )
             bodyparts_df = bodyparts_df[bodyparts]
             datasets[video_name] = bodyparts_df
+        if normalize:
+            if anterior_bodyparts is None or posterior_bodyparts is None:
+                raise ValueError(
+                    "anterior_bodyparts and posterior_bodyparts must be "
+                    + "provided for normalization"
+                )
+            datasets = normalize_pose_dataset(
+                datasets, anterior_bodyparts, posterior_bodyparts
+            )
         if format_for_moseq:
             datasets = format_dataset_for_moseq(datasets, bodyparts)
         return datasets
@@ -122,6 +144,82 @@ class PoseGroup(SpyglassMixin, dj.Manual):
             Path((PositionOutput & merge_key).fetch_video_path())
             for merge_key in (self.Pose & key).proj(merge_id="pose_merge_id")
         ]
+
+
+def _normalize_1_pose_dataset(
+    dataset: pd.DataFrame,
+    anterior_bodyparts: List[str],
+    posterior_bodyparts: List[str],
+) -> pd.DataFrame:
+    """
+    Normalize a pose dataset by centering and scaling based on the mean position and length
+    of the anterior and posterior body parts
+
+    Parameters
+    ----------
+    dataset : pd.DataFrame
+        pose dataset to normalize
+    anterior_bodyparts : List[str]
+        list of anterior body parts to use for normalization
+    posterior_bodyparts : List[str]
+        list of posterior body parts to use for normalization
+    """
+    anterior_x = np.array(
+        [dataset[bp, "x"].values for bp in anterior_bodyparts]
+    ).mean(axis=0)
+    anterior_y = np.array(
+        [dataset[bp, "y"].values for bp in anterior_bodyparts]
+    ).mean(axis=0)
+    posterior_x = np.array(
+        [dataset[bp, "x"].values for bp in posterior_bodyparts]
+    ).mean(axis=0)
+    posterior_y = np.array(
+        [dataset[bp, "y"].values for bp in posterior_bodyparts]
+    ).mean(axis=0)
+
+    mean_x_t = (anterior_x + posterior_x) / 2
+    mean_y_t = (anterior_y + posterior_y) / 2
+
+    length_t = np.sqrt(
+        (anterior_x - posterior_x) ** 2 + (anterior_y - posterior_y) ** 2
+    )
+    mean_length = length_t.mean()
+
+    for key in dataset.keys():
+        if key[1] == "x":
+            dataset[key] = ((dataset[key] - mean_x_t) / mean_length) + mean_x_t
+        elif key[1] == "y":
+            dataset[key] = ((dataset[key] - mean_y_t) / mean_length) + mean_y_t
+    return dataset
+
+
+def normalize_pose_dataset(
+    datasets, anterior_bodyparts, posterior_bodyparts
+) -> dict[str, pd.DataFrame]:
+    """
+    Normalize pose datasets by centering and scaling based on the mean position and length
+    of the anterior and posterior body parts
+
+    Parameters
+    ----------
+    datasets : dict[str, pd.DataFrame]
+        dictionary of video name to pose dataset (as returned by fetch_pose_datasets)
+    anterior_bodyparts : List[str]
+        list of anterior body parts to use for normalization
+    posterior_bodyparts : List[str]
+        list of posterior body parts to use for normalization
+
+    Returns
+    -------
+    dict[str, pd.DataFrame]
+        normalized pose datasets
+    """
+
+    for video, dataset in datasets.items():
+        datasets[video] = _normalize_1_pose_dataset(
+            dataset, anterior_bodyparts, posterior_bodyparts
+        )
+    return datasets
 
 
 def format_dataset_for_moseq(

--- a/src/spyglass/behavior/v1/core.py
+++ b/src/spyglass/behavior/v1/core.py
@@ -126,9 +126,9 @@ class PoseGroup(SpyglassMixin, dj.Manual):
                     bodyparts_df.keys().get_level_values(0).unique().values
                 )
                 missing_bodyparts = sorted(
-                    set(anterior_bodyparts).union(
-                        posterior_bodyparts
-                    ).difference(available_bodyparts)
+                    set(anterior_bodyparts)
+                    .union(posterior_bodyparts)
+                    .difference(available_bodyparts)
                 )
                 if missing_bodyparts:
                     raise ValueError(

--- a/src/spyglass/behavior/v1/core.py
+++ b/src/spyglass/behavior/v1/core.py
@@ -100,6 +100,17 @@ class PoseGroup(SpyglassMixin, dj.Manual):
         query = self & key
         bodyparts = query.fetch1("bodyparts")
         datasets = {}
+        if normalize:
+            if (
+                anterior_bodyparts is None
+                or posterior_bodyparts is None
+                or len(anterior_bodyparts) == 0
+                or len(posterior_bodyparts) == 0
+            ):
+                raise ValueError(
+                    "anterior_bodyparts and posterior_bodyparts must be "
+                    + "provided as non-empty lists for normalization"
+                )
         for merge_key in (self.Pose & query).proj(merge_id="pose_merge_id"):
             video_name = Path(
                 (PositionOutput & merge_key).fetch_video_path()
@@ -110,13 +121,22 @@ class PoseGroup(SpyglassMixin, dj.Manual):
                     bodyparts_df.keys().get_level_values(0).unique().values
                 )
             bodyparts_df = bodyparts_df[bodyparts]
+            if normalize:
+                available_bodyparts = set(
+                    bodyparts_df.keys().get_level_values(0).unique().values
+                )
+                missing_bodyparts = sorted(
+                    set(anterior_bodyparts).union(
+                        posterior_bodyparts
+                    ).difference(available_bodyparts)
+                )
+                if missing_bodyparts:
+                    raise ValueError(
+                        "Requested normalization bodyparts are missing from "
+                        f"dataset '{video_name}': {missing_bodyparts}"
+                    )
             datasets[video_name] = bodyparts_df
         if normalize:
-            if anterior_bodyparts is None or posterior_bodyparts is None:
-                raise ValueError(
-                    "anterior_bodyparts and posterior_bodyparts must be "
-                    + "provided for normalization"
-                )
             datasets = normalize_pose_dataset(
                 datasets, anterior_bodyparts, posterior_bodyparts
             )
@@ -164,6 +184,8 @@ def _normalize_1_pose_dataset(
     posterior_bodyparts : List[str]
         list of posterior body parts to use for normalization
     """
+    dataset = dataset.copy()
+
     anterior_x = np.array(
         [dataset[bp, "x"].values for bp in anterior_bodyparts]
     ).mean(axis=0)
@@ -183,7 +205,12 @@ def _normalize_1_pose_dataset(
     length_t = np.sqrt(
         (anterior_x - posterior_x) ** 2 + (anterior_y - posterior_y) ** 2
     )
-    mean_length = length_t.mean()
+    mean_length = np.nanmean(length_t)
+    if not np.isfinite(mean_length) or mean_length <= 0:
+        raise ValueError(
+            "Cannot normalize pose dataset: mean anterior/posterior length "
+            "must be finite and greater than zero."
+        )
 
     for key in dataset.keys():
         if key[1] == "x":

--- a/src/spyglass/behavior/v1/core.py
+++ b/src/spyglass/behavior/v1/core.py
@@ -218,7 +218,9 @@ def _normalize_1_pose_dataset(
 
 
 def normalize_pose_dataset(
-    datasets, anterior_bodyparts, posterior_bodyparts
+    datasets: dict[str, pd.DataFrame],
+    anterior_bodyparts: List[str],
+    posterior_bodyparts: List[str],
 ) -> dict[str, pd.DataFrame]:
     """
     Normalize pose datasets by centering and scaling based on the mean position and length

--- a/src/spyglass/behavior/v1/core.py
+++ b/src/spyglass/behavior/v1/core.py
@@ -187,7 +187,7 @@ def _normalize_1_pose_dataset(
     """
     dataset = dataset.copy()
 
-   def parse_dataset(bps: list, dim: str) -> np.ndarray:
+    def parse_dataset(bps: list, dim: str) -> np.ndarray:
         """Parse the dataset for the given bodyparts and dimension."""
         return np.array([dataset[bp, dim].values for bp in bps]).mean(axis=0)
 

--- a/src/spyglass/behavior/v1/core.py
+++ b/src/spyglass/behavior/v1/core.py
@@ -100,17 +100,18 @@ class PoseGroup(SpyglassMixin, dj.Manual):
         query = self & key
         bodyparts = query.fetch1("bodyparts")
         datasets = {}
-        if normalize:
-            if (
-                anterior_bodyparts is None
-                or posterior_bodyparts is None
-                or len(anterior_bodyparts) == 0
-                or len(posterior_bodyparts) == 0
-            ):
-                raise ValueError(
-                    "anterior_bodyparts and posterior_bodyparts must be "
-                    + "provided as non-empty lists for normalization"
-                )
+
+        empty_parts = []
+        if anterior_bodyparts is None or len(anterior_bodyparts) == 0:
+            empty_parts.append("anterior")
+        if posterior_bodyparts is None or len(posterior_bodyparts) == 0:
+            empty_parts.append("posterior")
+        if normalize and empty_parts:
+            raise ValueError(
+                f"Both anterior_bodyparts and posterior_bodyparts must be provided "
+                f"as non-empty lists for normalization. Missing: {', '.join(empty_parts)}"
+            )
+
         for merge_key in (self.Pose & query).proj(merge_id="pose_merge_id"):
             video_name = Path(
                 (PositionOutput & merge_key).fetch_video_path()

--- a/src/spyglass/behavior/v1/core.py
+++ b/src/spyglass/behavior/v1/core.py
@@ -186,18 +186,14 @@ def _normalize_1_pose_dataset(
     """
     dataset = dataset.copy()
 
-    anterior_x = np.array(
-        [dataset[bp, "x"].values for bp in anterior_bodyparts]
-    ).mean(axis=0)
-    anterior_y = np.array(
-        [dataset[bp, "y"].values for bp in anterior_bodyparts]
-    ).mean(axis=0)
-    posterior_x = np.array(
-        [dataset[bp, "x"].values for bp in posterior_bodyparts]
-    ).mean(axis=0)
-    posterior_y = np.array(
-        [dataset[bp, "y"].values for bp in posterior_bodyparts]
-    ).mean(axis=0)
+   def parse_dataset(bps: list, dim: str) -> np.ndarray:
+        """Parse the dataset for the given bodyparts and dimension."""
+        return np.array([dataset[bp, dim].values for bp in bps]).mean(axis=0)
+
+    anterior_x = parse_dataset(anterior_bodyparts, "x")
+    anterior_y = parse_dataset(anterior_bodyparts, "y")
+    posterior_x = parse_dataset(posterior_bodyparts, "x")
+    posterior_y = parse_dataset(posterior_bodyparts, "y")
 
     mean_x_t = (anterior_x + posterior_x) / 2
     mean_y_t = (anterior_y + posterior_y) / 2

--- a/src/spyglass/behavior/v1/moseq.py
+++ b/src/spyglass/behavior/v1/moseq.py
@@ -9,10 +9,21 @@ from spyglass.utils import logger
 try:
     import keypoint_moseq as kpms
 except ImportError:
+    kpms = None
     logger.warning(
         "keypoint_moseq not found. This package is necessary to "
         + "populate the MoseqModel table"
     )
+
+
+def _require_keypoint_moseq():
+    if kpms is None:
+        raise ImportError(
+            "keypoint_moseq is required for MoSeq operations but is not "
+            "installed. Install the `keypoint_moseq` package to use "
+            "MoseqModel-related functionality."
+        )
+
 
 from spyglass.common import AnalysisNwbfile
 from spyglass.position.position_merge import PositionOutput

--- a/src/spyglass/behavior/v1/moseq.py
+++ b/src/spyglass/behavior/v1/moseq.py
@@ -3,15 +3,28 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import datajoint as dj
-import keypoint_moseq as kpms
 import numpy as np
+from spyglass.utils import logger
+
+try:
+    import keypoint_moseq as kpms
+except ImportError:
+    logger.warning(
+        "keypoint_moseq not found. This package is necessary to "
+        + "populate the MoseqModel table"
+    )
 
 from spyglass.common import AnalysisNwbfile
 from spyglass.position.position_merge import PositionOutput
 from spyglass.settings import moseq_project_dir, moseq_video_dir
 from spyglass.utils import SpyglassMixin
 
-from .core import PoseGroup, format_dataset_for_moseq, results_to_df
+from .core import (
+    PoseGroup,
+    format_dataset_for_moseq,
+    results_to_df,
+    _normalize_1_pose_dataset,
+)
 
 schema = dj.schema("behavior_v1_moseq")
 
@@ -129,7 +142,11 @@ class MoseqModel(SpyglassMixin, dj.Computed):
         video_paths = (PoseGroup & key).fetch_video_paths()  # FETCH
         bodyparts = (PoseGroup & key).fetch1("bodyparts")  # FETCH
         coordinates, confidences = PoseGroup().fetch_pose_datasets(
-            key, format_for_moseq=True
+            key,
+            format_for_moseq=True,
+            normalize=model_params.get("normalize", False),
+            anterior_bodyparts=model_params.get("anterior_bodyparts", None),
+            posterior_bodyparts=model_params.get("posterior_bodyparts", None),
         )
 
         model, epochs_trained = None, None
@@ -520,7 +537,14 @@ class MoseqSyllable(SpyglassMixin, dj.Computed):
         merge_query = PositionOutput & merge_key
         video_path = merge_query.fetch_video_path()
         video_name = Path(video_path).name
+        model_params = (MoseqModelParams & key).fetch1("model_params")
         bodyparts_df = merge_query.fetch_pose_dataframe()
+        if model_params.get("normalize", False):
+            bodyparts_df = _normalize_1_pose_dataset(
+                bodyparts_df,
+                model_params.get("anterior_bodyparts", None),
+                model_params.get("posterior_bodyparts", None),
+            )
 
         if bodyparts is None:
             bodyparts = self.get_bodyparts_from_dataframe(bodyparts_df)

--- a/src/spyglass/behavior/v1/moseq.py
+++ b/src/spyglass/behavior/v1/moseq.py
@@ -197,6 +197,8 @@ class MoseqModel(SpyglassMixin, dj.Computed):
         model: Optional[dict] = None,
         epochs_trained: Optional[int] = None,
     ):
+        _require_keypoint_moseq()
+
         # set up the project and config
         project_dir, video_dir = moseq_project_dir, moseq_video_dir
         project_dir = os.path.join(project_dir, model_name)
@@ -328,6 +330,8 @@ class MoseqModel(SpyglassMixin, dj.Computed):
         tuple
             model, model_name
         """
+        _require_keypoint_moseq()
+
         # fit pca of data
         pca = kpms.fit_pca(**data, **config)
         kpms.save_pca(pca, project_dir)
@@ -368,6 +372,7 @@ class MoseqModel(SpyglassMixin, dj.Computed):
         explained_variance : float, optional
             minimum explained variance to print, by default 0.9
         """
+        _require_keypoint_moseq()
         project_dir = (self & key).fetch1("project_dir")
         pca = kpms.load_pca(project_dir)
         config = kpms.load_config(project_dir)
@@ -388,6 +393,7 @@ class MoseqModel(SpyglassMixin, dj.Computed):
         dict
             model dictionary
         """
+        _require_keypoint_moseq()
         if key is None:
             key = {}
         return kpms.load_checkpoint(
@@ -430,6 +436,7 @@ class MoseqModel(SpyglassMixin, dj.Computed):
         -------
         None
         """
+        _require_keypoint_moseq()
         self.ensure_single_entry(key)
         query = self & key
         project_dir, model_name = (query).fetch1("project_dir", "model_name")
@@ -471,6 +478,7 @@ class MoseqModel(SpyglassMixin, dj.Computed):
         None
         """
 
+        _require_keypoint_moseq()
         self.ensure_single_entry(key)
         query = self & key
         project_dir, model_name = (query).fetch1("project_dir", "model_name")
@@ -534,6 +542,7 @@ class MoseqSyllable(SpyglassMixin, dj.Computed):
     """
 
     def make(self, key):
+        _require_keypoint_moseq()
         model = MoseqModel().fetch_model(key)
         project_dir, model_name = (MoseqModel & key).fetch1(
             "project_dir", "model_name"


### PR DESCRIPTION
Resolves #1568

This pull request adds pose normalization functionality to the behavior analysis pipeline, allowing pose datasets to be normalized by animal length using specified anterior and posterior body parts. The changes introduce new normalization functions, update the `fetch_pose_datasets` method to support normalization, and ensure normalization is applied in relevant downstream analyses.

**Pose normalization support:**

* Added `normalize`, `anterior_bodyparts`, and `posterior_bodyparts` parameters to `PoseGroup.fetch_pose_datasets` to enable pose normalization by animal length. The method now normalizes datasets when requested, raising an error if required body parts are not provided. [[1]](diffhunk://#diff-a6d5f037f45ddeea63b1de268960bfb7a57639d1a8d7191d43be001f337e71c8L69-R74) [[2]](diffhunk://#diff-a6d5f037f45ddeea63b1de268960bfb7a57639d1a8d7191d43be001f337e71c8R84-R91) [[3]](diffhunk://#diff-a6d5f037f45ddeea63b1de268960bfb7a57639d1a8d7191d43be001f337e71c8R114-R122)
* Implemented `_normalize_1_pose_dataset` and `normalize_pose_dataset` functions to perform centering and scaling of pose data based on the mean positions and length between specified body parts.
* Exposed `_normalize_1_pose_dataset` for use in other modules and updated imports accordingly.

**Integration with MoSeq processing:**

* Updated calls to `fetch_pose_datasets` in `moseq.py` to pass normalization parameters from `model_params`, ensuring pose normalization is applied during MoSeq model training and inference.
* Applied normalization to pose data in the `make` method of the MoSeq pipeline if requested in `model_params`.# Description


# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] NA If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] NA If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] Y If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
