### PR TITLE
Updated _get_pos_dict to handle timestamps = None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,8 @@ for label, interval_data in results.groupby("interval_labels"):
 - Fix update bug in `_resolve_external_tables` #1536
 - Fix `_get_epoch_groups` raising `TypeError` for `SpatialSeries` with
     `starting_time + rate` (no timestamps) #1567
+- Fix `_get_pos_dict` raising `TypeError` for `SpatialSeries` with
+    `starting_time + rate` (no timestamps) #1571
 - Parallelize `AnalysisFileIssues` checks #1557
 
 ### Pipelines
@@ -226,9 +228,8 @@ for label, interval_data in results.groupby("interval_labels"):
     - Trigger recompute in `CurationV1.get_recording` when necessary #1561
     - Drop spike sample indices that exceed the recording length in
         `CurationV1.get_sorting` and `SpikeSorting.get_sorting`, fixing a
-        SpikeInterface `ValueError` caused by floating-point round-trip
-        in the seconds-to-samples conversion #1564
-
+        SpikeInterface `ValueError` caused by floating-point round-trip in the
+        seconds-to-samples conversion #1564
 
 ## [0.5.5] (Aug 6, 2025)
 

--- a/src/spyglass/utils/nwb_helper_fn.py
+++ b/src/spyglass/utils/nwb_helper_fn.py
@@ -569,7 +569,17 @@ def _get_pos_dict(
             spatial_series = all_spatial_series[index]
             valid_times = None
             if incl_times:  # get the valid intervals for the position data
-                timestamps = np.asarray(spatial_series.timestamps)
+                if spatial_series.timestamps is None:
+                    starting_time = spatial_series.starting_time
+                    rate = spatial_series.rate
+                    num_samples = spatial_series.data.shape[0]
+                    timestamps = np.linspace(
+                        starting_time,
+                        starting_time + (num_samples - 1) / rate,
+                        num_samples,
+                    )
+                else:
+                    timestamps = np.asarray(spatial_series.timestamps)
                 sampling_rate = estimate_sampling_rate(
                     timestamps, verbose=verbose, filename=session_id
                 )

--- a/tests/utils/test_nwb_helper_fn.py
+++ b/tests/utils/test_nwb_helper_fn.py
@@ -121,3 +121,61 @@ def test_get_pos_dict_with_rate():
         np.array([[-1e-7, 3.3 + 1e-7]]),
         atol=1e-9,
     )
+
+
+def test_get_pos_dict_with_timestamps():
+    """_get_pos_dict handles SpatialSeries that provide explicit timestamps."""
+    spatial_series = pynwb.behavior.SpatialSeries(
+        name="series_0",
+        data=np.zeros((100, 2)),
+        timestamps=np.linspace(0.0, 99.0 / 30.0, 100),
+        reference_frame="unknown",
+    )
+    position = pynwb.behavior.Position(spatial_series=spatial_series)
+    epoch_groups = _get_epoch_groups(position)
+
+    pos_dict = _get_pos_dict(position.spatial_series, epoch_groups)
+
+    assert list(pos_dict.keys()) == [0]
+    assert len(pos_dict[0]) == 1
+    assert pos_dict[0][0]["raw_position_object_id"] == spatial_series.object_id
+    assert pos_dict[0][0]["name"] == "series_0"
+    np.testing.assert_allclose(
+        pos_dict[0][0]["valid_times"],
+        np.array([[-1e-7, 3.3 + 1e-7]]),
+        atol=1e-9,
+    )
+
+
+def test_get_pos_dict_with_missing_starting_time_raises_value_error():
+    """_get_pos_dict raises a clear error when starting_time is missing."""
+    spatial_series = pynwb.behavior.SpatialSeries(
+        name="series_0",
+        data=np.zeros((100, 2)),
+        timestamps=None,
+        starting_time=0.0,
+        rate=30.0,
+        reference_frame="unknown",
+    )
+    spatial_series.starting_time = None
+    position = pynwb.behavior.Position(spatial_series=spatial_series)
+    epoch_groups = {0.0: [0]}
+
+    with pytest.raises(ValueError, match="missing starting_time"):
+        _get_pos_dict(position.spatial_series, epoch_groups)
+
+
+def test_get_pos_dict_with_invalid_rate_raises_value_error():
+    """_get_pos_dict raises a clear error when rate is invalid."""
+    spatial_series = pynwb.behavior.SpatialSeries(
+        name="series_0",
+        data=np.zeros((100, 2)),
+        starting_time=0.0,
+        rate=0.0,
+        reference_frame="unknown",
+    )
+    position = pynwb.behavior.Position(spatial_series=spatial_series)
+    epoch_groups = _get_epoch_groups(position)
+
+    with pytest.raises(ValueError, match="invalid rate"):
+        _get_pos_dict(position.spatial_series, epoch_groups)

--- a/tests/utils/test_nwb_helper_fn.py
+++ b/tests/utils/test_nwb_helper_fn.py
@@ -145,37 +145,3 @@ def test_get_pos_dict_with_timestamps():
         np.array([[-1e-7, 3.3 + 1e-7]]),
         atol=1e-9,
     )
-
-
-def test_get_pos_dict_with_missing_starting_time_raises_value_error():
-    """_get_pos_dict raises a clear error when starting_time is missing."""
-    spatial_series = pynwb.behavior.SpatialSeries(
-        name="series_0",
-        data=np.zeros((100, 2)),
-        timestamps=None,
-        starting_time=0.0,
-        rate=30.0,
-        reference_frame="unknown",
-    )
-    spatial_series.starting_time = None
-    position = pynwb.behavior.Position(spatial_series=spatial_series)
-    epoch_groups = {0.0: [0]}
-
-    with pytest.raises(ValueError, match="missing starting_time"):
-        _get_pos_dict(position.spatial_series, epoch_groups)
-
-
-def test_get_pos_dict_with_invalid_rate_raises_value_error():
-    """_get_pos_dict raises a clear error when rate is invalid."""
-    spatial_series = pynwb.behavior.SpatialSeries(
-        name="series_0",
-        data=np.zeros((100, 2)),
-        starting_time=0.0,
-        rate=0.0,
-        reference_frame="unknown",
-    )
-    position = pynwb.behavior.Position(spatial_series=spatial_series)
-    epoch_groups = _get_epoch_groups(position)
-
-    with pytest.raises(ValueError, match="invalid rate"):
-        _get_pos_dict(position.spatial_series, epoch_groups)

--- a/tests/utils/test_nwb_helper_fn.py
+++ b/tests/utils/test_nwb_helper_fn.py
@@ -4,7 +4,7 @@ import numpy as np
 import pynwb
 import pytest
 
-from spyglass.utils.nwb_helper_fn import _get_epoch_groups
+from spyglass.utils.nwb_helper_fn import _get_epoch_groups, _get_pos_dict
 
 
 @pytest.fixture(scope="module")
@@ -96,3 +96,28 @@ def test_get_epoch_groups_with_rate():
     assert len(epoch_groups) == 1
     assert list(epoch_groups.keys())[0] == pytest.approx(5.0)
     assert 0 in epoch_groups[list(epoch_groups.keys())[0]]
+
+
+def test_get_pos_dict_with_rate():
+    """_get_pos_dict handles SpatialSeries that omit explicit timestamps."""
+    spatial_series = pynwb.behavior.SpatialSeries(
+        name="series_0",
+        data=np.zeros((100, 2)),
+        starting_time=0.0,
+        rate=30.0,
+        reference_frame="unknown",
+    )
+    position = pynwb.behavior.Position(spatial_series=spatial_series)
+    epoch_groups = _get_epoch_groups(position)
+
+    pos_dict = _get_pos_dict(position.spatial_series, epoch_groups)
+
+    assert list(pos_dict.keys()) == [0]
+    assert len(pos_dict[0]) == 1
+    assert pos_dict[0][0]["raw_position_object_id"] == spatial_series.object_id
+    assert pos_dict[0][0]["name"] == "series_0"
+    np.testing.assert_allclose(
+        pos_dict[0][0]["valid_times"],
+        np.array([[-1e-7, 3.3 + 1e-7]]),
+        atol=1e-9,
+    )


### PR DESCRIPTION
# Description

Follow-up from #1567

Similar problem crops up in _get_pose_dict, which this PR fixes.

- N/A If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- N/A If this PR edits table definitions, I have included an `alter` snippet for release notes.
- N/A If this PR makes changes to position, I ran the relevant tests locally.
- N/A If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
