### PR TITLE
Fix typo: HD5_USE_FILE_LOCKING → HDF5_USE_FILE_LOCKING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@ for label, interval_data in results.groupby("interval_labels"):
     `starting_time + rate` (no timestamps) #1571
 - Parallelize `AnalysisFileIssues` checks #1557
 - Tests update config sooner to avoid false-negative `test_mode` errors #1572
+- Fix typo in `env_defaults` key: `HD5_USE_FILE_LOCKING` →
+    `HDF5_USE_FILE_LOCKING` so the HDF5 library actually sees the intended
+    `FALSE` default #1575
 
 ### Pipelines
 

--- a/src/spyglass/settings.py
+++ b/src/spyglass/settings.py
@@ -117,7 +117,7 @@ class SpyglassConfig:
             "FIGURL_CHANNEL": "franklab2",
             "DJ_SUPPORT_FILEPATH_MANAGEMENT": "TRUE",
             "KACHERY_CLOUD_EPHEMERAL": "TRUE",
-            "HD5_USE_FILE_LOCKING": "FALSE",
+            "HDF5_USE_FILE_LOCKING": "FALSE",
         }
 
     def load_config(


### PR DESCRIPTION
## Summary

- Fixes typo in `SpyglassConfig.env_defaults` at `src/spyglass/settings.py:120` — the HDF5 library reads `HDF5_USE_FILE_LOCKING` (with the "F"), so the current key has had no effect since it was introduced in #722 (Dec 20 2023).
- DLC notebooks (`21_DLC.ipynb`, `22_DLC_Loop.ipynb`) already document the env var with the correct name, confirming the intent.

Fixes #1575.

## Test plan

- [ ] Verify `os.environ["HDF5_USE_FILE_LOCKING"] == "FALSE"` after importing Spyglass on a fresh environment.
- [ ] Confirm users on networked/read-only filesystems no longer hit HDF5 file-lock errors that this default was meant to suppress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)