### PR TITLE
Trigger recording recompute in v1.SpikeSorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,8 @@ for label, interval_data in results.groupby("interval_labels"):
         `CurationV1.get_sorting` and `SpikeSorting.get_sorting`, fixing a
         SpikeInterface `ValueError` caused by floating-point round-trip in the
         seconds-to-samples conversion #1564
+    - Trigger recording recompute in `SpikeSortingRecording.populate` when
+        necessary #1588
 
 ## [0.5.5] (Aug 6, 2025)
 

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -9,7 +9,6 @@ import numpy as np
 import pynwb
 import spikeinterface as si
 import spikeinterface.curation as sic
-import spikeinterface.extractors as se
 import spikeinterface.preprocessing as sip
 import spikeinterface.sorters as sis
 from spikeinterface.sortingcomponents.peak_detection import detect_peaks

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -269,20 +269,12 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
             SpikeSorterParameters * SpikeSortingSelection & key
         ).fetch1("sorter", "sorter_params")
 
-        recording_analysis_nwb_file_abs_path = AnalysisNwbfile.get_abs_path(
-            recording_key["analysis_file_name"]
-        )
-
-        # Check if recording file exists on disc. Trigger recompute if not.
-        if not os.path.exists(recording_analysis_nwb_file_abs_path):
-            _ = (AnalysisNwbfile() & recording_key).fetch_nwb()
-
         return [
             nwb_file_name,
             artifact_removed_intervals,
             sorter,
             sorter_params,
-            recording_analysis_nwb_file_abs_path,
+            recording_key,
         ]
 
     def make_compute(
@@ -292,10 +284,10 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
         artifact_removed_intervals: IntervalLike,
         sorter: str,
         sorter_params: dict,
-        recording_analysis_nwb_file_abs_path: str,
+        recording_key: dict,
     ):
         sorting, timestamps = self._run_spike_sorter(
-            recording_analysis_nwb_file_abs_path=recording_analysis_nwb_file_abs_path,
+            recording_key=recording_key,
             artifact_removed_intervals=artifact_removed_intervals,
             sorter=sorter,
             sorter_params=sorter_params,
@@ -332,7 +324,7 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
 
     def _run_spike_sorter(
         self,
-        recording_analysis_nwb_file_abs_path,
+        recording_key,
         artifact_removed_intervals,
         sorter,
         sorter_params,
@@ -344,8 +336,8 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
 
         Parameters
         ----------
-        recording_analysis_nwb_file_abs_path : str
-            Path to recording NWB file
+        recording_key : dict
+            Key for the recording
         artifact_removed_intervals : np.ndarray
             Artifact-free time intervals
         sorter : str
@@ -361,9 +353,7 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
             Recording timestamps
         """
         # Load recording (spikeinterface)
-        recording = se.read_nwb_recording(
-            recording_analysis_nwb_file_abs_path, load_time_vector=True
-        )
+        recording = SpikeSortingRecording().get_recording(recording_key)
 
         timestamps = recording.get_times()
 

--- a/src/spyglass/spikesorting/v1/sorting.py
+++ b/src/spyglass/spikesorting/v1/sorting.py
@@ -273,6 +273,10 @@ class SpikeSorting(SpyglassMixin, dj.Computed):
             recording_key["analysis_file_name"]
         )
 
+        # Check if recording file exists on disc. Trigger recompute if not.
+        if not os.path.exists(recording_analysis_nwb_file_abs_path):
+            _ = (AnalysisNwbfile() & recording_key).fetch_nwb()
+
         return [
             nwb_file_name,
             artifact_removed_intervals,

--- a/tests/spikesorting/v1/conftest.py
+++ b/tests/spikesorting/v1/conftest.py
@@ -166,7 +166,7 @@ def mock_spike_sorter():
 
     def _mock_run_sorter(
         self,
-        recording_analysis_nwb_file_abs_path,
+        recording_key,
         artifact_removed_intervals,
         sorter,
         sorter_params,


### PR DESCRIPTION
# Description

Similar to #1560

- `v1.Spikesorting` doesn't trigger the recompute of the recording file if unavailable.
- This modifies the dataload to use `v1.SpikeSortingRecording.get_recording` which will use the recompute

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
