### PR TITLE
Fixed multi-session unit annotations bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,9 @@ for label, interval_data in results.groupby("interval_labels"):
         seconds-to-samples conversion #1564
     - Trigger recording recompute in `SpikeSortingRecording.populate` when
         necessary #1588
+    - Restrict `ImportedSpikeSorting.Annotations` to the current session in
+        `make_df_from_annotations` so `fetch_nwb` works across multiple sessions
+        with overlapping unit ids #1581
 
 ## [0.5.5] (Aug 6, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,7 @@ for label, interval_data in results.groupby("interval_labels"):
         necessary #1588
     - Restrict `ImportedSpikeSorting.Annotations` to the current session in
         `make_df_from_annotations` so `fetch_nwb` works across multiple sessions
-        with overlapping unit ids #1581
+        with overlapping unit ids #1581, #1592
 
 ## [0.5.5] (Aug 6, 2025)
 

--- a/src/spyglass/spikesorting/imported.py
+++ b/src/spyglass/spikesorting/imported.py
@@ -151,9 +151,10 @@ class ImportedSpikeSorting(SpyglassIngestion, dj.Imported):
     def make_df_from_annotations(self):
         """Convert the annotations part table into a dataframe that can be
         concatenated to the spikes dataframe in the nwb file."""
+        annotation_query = self.Annotations & self.fetch("KEY")
         df = []
         for id, label, annotations in zip(
-            *self.Annotations.fetch("id", "label", "annotations")
+            *annotation_query.fetch("id", "label", "annotations")
         ):
             df.append(
                 dict(

--- a/tests/data_import/test_imported_spike_sorting.py
+++ b/tests/data_import/test_imported_spike_sorting.py
@@ -1,5 +1,9 @@
-from pynwb.testing.mock.file import mock_NWBFile, mock_Subject
+from pathlib import Path
+
 import numpy as np
+import pytest
+from pynwb import NWBHDF5IO
+from pynwb.testing.mock.file import mock_NWBFile, mock_Subject
 
 
 def test_imported_spike_sorting_ingestion(imported_spike):
@@ -29,3 +33,89 @@ def test_imported_spike_sorting_ingestion(imported_spike):
     assert (
         insert_keys[0]["object_id"] == nwbfile.units.object_id
     ), f"Inserted object_id {insert_keys[0]['object_id']} does not match original {nwbfile.units.object_id}"
+
+
+@pytest.fixture(scope="module")
+def two_sessions_with_annotations(imported_spike, verbose_context):
+    """Insert two NWB sessions with overlapping unit ids and add per-unit
+    annotations to both. Reproduces the data setup in issue #1581."""
+    from spyglass.common import Nwbfile
+    from spyglass.data_import import insert_sessions
+    from spyglass.settings import raw_dir
+    from spyglass.utils.nwb_helper_fn import get_nwb_copy_filename
+
+    raw_dir_path = Path(raw_dir)
+    raw_file_names = ["issue_1581_a.nwb", "issue_1581_b.nwb"]
+    session_info = []
+
+    for raw_file_name in raw_file_names:
+        nwbfile = mock_NWBFile(
+            identifier=raw_file_name,
+            session_description=f"Issue #1581 regression session for {raw_file_name}",
+        )
+        mock_Subject(nwbfile=nwbfile)
+        for unit_id in range(3):
+            nwbfile.add_unit(id=unit_id, spike_times=np.array([0.1, 0.2, 0.3]))
+
+        file_path = raw_dir_path / raw_file_name
+        file_path.unlink(missing_ok=True)
+        with NWBHDF5IO(file_path, mode="w") as io:
+            io.write(nwbfile)
+        insert_sessions([str(file_path)], raise_err=True)
+        session_info.append(
+            {
+                "nwb_file_name": get_nwb_copy_filename(raw_file_name),
+                "raw_path": file_path,
+            }
+        )
+
+    sorting_table = imported_spike.ImportedSpikeSorting()
+    for info in session_info:
+        for unit_id in range(3):
+            sorting_table.add_annotation(
+                key={"nwb_file_name": info["nwb_file_name"]},
+                id=unit_id,
+                annotations={"score": float(unit_id)},
+            )
+
+    yield session_info
+
+    with verbose_context:
+        for info in session_info:
+            (Nwbfile & {"nwb_file_name": info["nwb_file_name"]}).delete(
+                safemode=False
+            )
+            info["raw_path"].unlink(missing_ok=True)
+
+
+def test_make_df_from_annotations_restricted_to_session(
+    imported_spike, two_sessions_with_annotations
+):
+    """Regression test for issue #1581: `make_df_from_annotations` must
+    restrict the Annotations part-table to the parent's restriction. Without
+    the restriction, overlapping unit ids across sessions produce a
+    non-unique index in the returned dataframe."""
+    session_a, _ = two_sessions_with_annotations
+    table = imported_spike.ImportedSpikeSorting & {
+        "nwb_file_name": session_a["nwb_file_name"]
+    }
+    annotation_df = table.make_df_from_annotations()
+    assert list(annotation_df.index) == [0, 1, 2]
+    assert annotation_df["score"].tolist() == [0.0, 1.0, 2.0]
+
+
+def test_fetch_nwb_with_annotations_multiple_sessions(
+    imported_spike, two_sessions_with_annotations
+):
+    """Regression test for issue #1581: `fetch_nwb` on `ImportedSpikeSorting`
+    must not raise `pandas.errors.InvalidIndexError` when multiple sessions
+    have annotations with overlapping unit ids."""
+    _, session_b = two_sessions_with_annotations
+    result = (
+        imported_spike.ImportedSpikeSorting
+        & {"nwb_file_name": session_b["nwb_file_name"]}
+    ).fetch_nwb()
+    assert len(result) == 1
+    spikes_df = result[0]["object_id"]
+    assert list(spikes_df.index) == [0, 1, 2]
+    assert spikes_df["score"].tolist() == [0.0, 1.0, 2.0]


### PR DESCRIPTION
# Description

- Fixes #1581: by constructing the unit_annotations DataFrame with only annotations from one session at a time.

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- N/A If this PR edits table definitions, I have included an `alter` snippet for release notes.
- N/A If this PR makes changes to position, I ran the relevant tests locally.
- N/A If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
