### PR TITLE
Analysis write efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ for label, interval_data in results.groupby("interval_labels"):
     `HDF5_USE_FILE_LOCKING` so the HDF5 library actually sees the intended
     `FALSE` default #1575
 - Warn on no-operation restrictions #1586
+- Improved efficiency for writing multiple object to analysis file #1594
 
 ### Pipelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,7 @@ for label, interval_data in results.groupby("interval_labels"):
     `HDF5_USE_FILE_LOCKING` so the HDF5 library actually sees the intended
     `FALSE` default #1575
 - Warn on no-operation restrictions #1586
-- Improved efficiency for writing multiple object to analysis file #1594
+- Improved efficiency for writing multiple objects to analysis file #1594
 
 ### Pipelines
 

--- a/docs/src/Features/AnalysisTables.md
+++ b/docs/src/Features/AnalysisTables.md
@@ -119,10 +119,9 @@ with AnalysisNwbfile().build("session.nwb") as builder:
 
 ```python
 with AnalysisNwbfile().build("session.nwb") as builder:
-    with builder.open_for_write() as io:
-        nwbf = io.read()
-        nwbf.add_unit(spike_times=[0.1, 0.5, 1.2], id=1)
-        io.write(nwbf)
+    io, nwbf = builder.open_nwb
+    nwbf.add_unit(spike_times=[0.1, 0.5, 1.2], id=1)
+    # io closing and file write handled at exit
 ```
 
 **What happens on exception**:
@@ -458,9 +457,10 @@ Even with direct I/O, you can still use the builder:
 
 ```python
 with AnalysisNwbfile().build("session.nwb") as builder:
-    with builder.open_for_write() as io:
-        # Direct PyNWB operations here
-        pass
+    io, nwbf = builder.open_nwb
+    # Direct PyNWB operations here
+    ...
+    # io close and file write handled at exit
 ```
 
 ______________________________________________________________________

--- a/src/spyglass/utils/mixins/analysis.py
+++ b/src/spyglass/utils/mixins/analysis.py
@@ -510,7 +510,7 @@ class AnalysisMixin(BaseMixin):
 
         Direct I/O for complex cases:
         >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
-        ...     io, nwbf =builder.open_nwb
+        ...     io, nwbf = builder.open_nwb
         ...     nwbf.add_unit(spike_times=times, id=unit_id)
 
         See Also

--- a/src/spyglass/utils/mixins/analysis.py
+++ b/src/spyglass/utils/mixins/analysis.py
@@ -653,7 +653,7 @@ class AnalysisMixin(BaseMixin):
         self,
         analysis_file_name: str,
         nwb_object: pynwb.core.NWBDataInterface,
-        table_name: Optional[str] = "pandas_table",
+        table_name: Optional[str] = None,
     ):
         """Add an NWB object to the analysis file and return the NWB object ID
 

--- a/src/spyglass/utils/mixins/analysis.py
+++ b/src/spyglass/utils/mixins/analysis.py
@@ -510,10 +510,8 @@ class AnalysisMixin(BaseMixin):
 
         Direct I/O for complex cases:
         >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
-        ...     with builder.open_for_write() as io:
-        ...         nwbf = io.read()
-        ...         nwbf.add_unit(spike_times=times, id=unit_id)
-        ...         io.write(nwbf)
+        ...     io, nwbf =builder.open_nwb
+        ...     nwbf.add_unit(spike_times=times, id=unit_id)
 
         See Also
         --------

--- a/src/spyglass/utils/mixins/analysis.py
+++ b/src/spyglass/utils/mixins/analysis.py
@@ -4,7 +4,7 @@ import string
 import subprocess
 from functools import cached_property
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, Tuple
 from uuid import uuid4
 
 import datajoint as dj
@@ -683,26 +683,57 @@ class AnalysisMixin(BaseMixin):
             load_namespaces=True,
         ) as io:
             nwbf = io.read()
-            # convert to pynwb object if it is a dataframe or array
-            if isinstance(nwb_object, pd.DataFrame):
-                nwb_object = DynamicTable.from_dataframe(
-                    name=table_name or "pandas_table", df=nwb_object
-                )
-            elif isinstance(nwb_object, np.ndarray):
-                nwb_object = ScratchData(
-                    name=table_name or "numpy_array",
-                    data=nwb_object,
-                    description="Numpy array stored in scratch space",
-                )
-            if nwb_object.name in nwbf.scratch:
-                raise ValueError(
-                    f"Object with name '{nwb_object.name}' already exists in "
-                    + f"{analysis_file_name}. Please pass a different name "
-                    + "argument to AnalysisNwbfile.add_nwb_object()."
-                )
-            nwbf.add_scratch(nwb_object)
+            object_id = self._add_nwb_object_to_open_nwb(
+                nwbf, nwb_object, table_name
+            )
             io.write(nwbf)
-            return nwb_object.object_id
+            return object_id
+
+    def _add_nwb_object_to_open_nwb(
+        self,
+        nwbf: pynwb.NWBFile,
+        nwb_object: pynwb.core.NWBDataInterface,
+        table_name: Optional[str] = "pandas_table",
+    ) -> str:
+        """Add an NWB object to an open NWB file and return the NWB object ID
+
+        Adds object to the scratch space of the NWB file.
+
+        Parameters
+        ----------
+        nwbf : pynwb.NWBFile
+            An open NWB file.
+        nwb_object : pynwb.core.NWBDataInterface
+            The NWB object created by PyNWB.
+        table_name : str, optional
+            The name of the pynwb object made from a passed dataframe or array.
+            Defaults to "pandas_table" or "numpy_array" for dataframes and arrays
+            respectively.
+        Returns
+        -------
+        nwb_object_id : str
+            The NWB object ID of the added object.
+        """
+
+        # convert to pynwb object if it is a dataframe or array
+        if isinstance(nwb_object, pd.DataFrame):
+            nwb_object = DynamicTable.from_dataframe(
+                name=table_name or "pandas_table", df=nwb_object
+            )
+        elif isinstance(nwb_object, np.ndarray):
+            nwb_object = ScratchData(
+                name=table_name or "numpy_array",
+                data=nwb_object,
+                description="Numpy array stored in scratch space",
+            )
+        if nwb_object.name in nwbf.scratch:
+            raise ValueError(
+                f"Object with name '{nwb_object.name}' already exists in "
+                + f"{Path(nwbf.container_source).name}. Please pass a different name "
+                + "argument to AnalysisNwbfile.add_nwb_object()."
+            )
+        nwbf.add_scratch(nwb_object)
+        return nwb_object.object_id
 
     # -------------------------------- Hashing --------------------------------
 
@@ -828,77 +859,121 @@ class AnalysisMixin(BaseMixin):
             load_namespaces=True,
         ) as io:
             nwbf = io.read()
-            sort_intervals = list()
-
-            if not len(units.keys()):
-                return ""
-
-            # Add spike times and valid time range for the sort
-            for id in units.keys():
-                nwbf.add_unit(
-                    spike_times=units[id],
-                    id=id,
-                    # waveform_mean = units_templates[id],
-                    obs_intervals=units_valid_times[id],
-                )
-                sort_intervals.append(units_sort_interval[id])
-
-            # Add a column for the sort interval (subset of valid time)
-            nwbf.add_unit_column(
-                name="sort_interval",
-                description="the interval used for spike sorting",
-                data=sort_intervals,
+            units_object_id, waveforms_object_id = self._add_units_to_open_nwb(
+                nwbf,
+                units,
+                units_valid_times,
+                units_sort_interval,
+                metrics=metrics,
+                units_waveforms=units_waveforms,
+                labels=labels,
             )
-
-            # If metrics were specified, add one column per metric
-            metrics = metrics or []  # do nothing if metrics is None
-            for metric in metrics:
-                if not metrics.get(metric):
-                    continue
-
-                unit_ids = np.array(list(metrics[metric].keys()))
-                metric_values = np.array(list(metrics[metric].values()))
-
-                # sort by unit_ids and apply that sorting to values
-                # to ensure that things go in the right order
-
-                metric_values = metric_values[np.argsort(unit_ids)]
-                self._info_msg(f"Adding metric {metric} : {metric_values}")
-                nwbf.add_unit_column(
-                    name=metric,
-                    description=f"{metric} metric",
-                    data=metric_values,
-                )
-
-            if labels is not None:
-                unit_ids = np.array(list(units.keys()))
-                labels.update(
-                    {unit: "" for unit in unit_ids if unit not in labels}
-                )
-                label_values = np.array(list(labels.values()))
-                label_values = label_values[np.argsort(unit_ids)].tolist()
-                nwbf.add_unit_column(
-                    name="label",
-                    description="label given during curation",
-                    data=label_values,
-                )
-
-            # If the waveforms were specified, add them as a df to scratch
-            waveforms_object_id = ""
-            if units_waveforms is not None:
-                waveforms_df = pd.DataFrame.from_dict(
-                    units_waveforms, orient="index"
-                )
-                waveforms_df.columns = ["waveforms"]
-                nwbf.add_scratch(
-                    waveforms_df,
-                    name="units_waveforms",
-                    notes="spike waveforms for each unit",
-                )
-                waveforms_object_id = nwbf.scratch["units_waveforms"].object_id
-
             io.write(nwbf)
             return nwbf.units.object_id, waveforms_object_id
+
+    def _add_units_to_open_nwb(
+        self,
+        nwbf: pynwb.NWBFile,
+        units: dict,
+        units_valid_times: dict,
+        units_sort_interval: dict,
+        metrics: Optional[dict] = None,
+        units_waveforms: Optional[dict] = None,
+        labels: Optional[dict] = None,
+    ) -> Tuple[str, str]:
+        """Add units to an open NWB file
+
+        Parameters
+        ----------
+        nwbf : pynwb.NWBFile
+            An open NWB file.
+        units : dict
+            keys are unit ids, values are spike times
+        units_valid_times : dict
+            Dictionary of units and valid times with unit ids as keys.
+        units_sort_interval : dict
+            Dictionary of units and sort_interval with unit ids as keys.
+        units_waveforms : dict, optional
+            Dictionary of unit waveforms with unit ids as keys.
+        metrics : dict, optional
+            Cluster metrics.
+        labels : dict, optional
+            Curation labels for clusters
+        Returns
+        -------
+        units_object_id, waveforms_object_id : str, str
+            The NWB object id of the Units object and the object id of the
+            waveforms object ('' if None)
+        """
+
+        sort_intervals = list()
+
+        if not len(units.keys()):
+            return "", ""
+
+        # Add spike times and valid time range for the sort
+        for id in units.keys():
+            nwbf.add_unit(
+                spike_times=units[id],
+                id=id,
+                # waveform_mean = units_templates[id],
+                obs_intervals=units_valid_times[id],
+            )
+            sort_intervals.append(units_sort_interval[id])
+
+        # Add a column for the sort interval (subset of valid time)
+        nwbf.add_unit_column(
+            name="sort_interval",
+            description="the interval used for spike sorting",
+            data=sort_intervals,
+        )
+
+        # If metrics were specified, add one column per metric
+        metrics = metrics or []  # do nothing if metrics is None
+        for metric in metrics:
+            if not metrics.get(metric):
+                continue
+
+            unit_ids = np.array(list(metrics[metric].keys()))
+            metric_values = np.array(list(metrics[metric].values()))
+
+            # sort by unit_ids and apply that sorting to values
+            # to ensure that things go in the right order
+
+            metric_values = metric_values[np.argsort(unit_ids)]
+            self._info_msg(f"Adding metric {metric} : {metric_values}")
+            nwbf.add_unit_column(
+                name=metric,
+                description=f"{metric} metric",
+                data=metric_values,
+            )
+
+        if labels is not None:
+            unit_ids = np.array(list(units.keys()))
+            labels.update({unit: "" for unit in unit_ids if unit not in labels})
+            label_values = np.array(list(labels.values()))
+            label_values = label_values[np.argsort(unit_ids)].tolist()
+            nwbf.add_unit_column(
+                name="label",
+                description="label given during curation",
+                data=label_values,
+            )
+
+        # If the waveforms were specified, add them as a df to scratch
+        waveforms_object_id = ""
+        if units_waveforms is not None:
+            waveforms_df = pd.DataFrame.from_dict(
+                units_waveforms, orient="index"
+            )
+            waveforms_df.columns = ["waveforms"]
+            nwbf.add_scratch(
+                waveforms_df,
+                name="units_waveforms",
+                notes="spike waveforms for each unit",
+            )
+            waveforms_object_id = nwbf.scratch["units_waveforms"].object_id
+
+        return nwbf.units.object_id, waveforms_object_id
 
     def add_units_waveforms(
         self,
@@ -931,41 +1006,69 @@ class AnalysisMixin(BaseMixin):
             load_namespaces=True,
         ) as io:
             nwbf = io.read()
-            for id in waveform_extractor.sorting.get_unit_ids():
-                # (spikes, samples, channels)
-                waveforms = waveform_extractor.get_waveforms(unit_id=id)
-                # (channels, spikes, samples)
-                waveforms = np.moveaxis(waveforms, source=2, destination=0)
-                nwbf.add_unit(
-                    spike_times=waveform_extractor.sorting.get_unit_spike_train(
-                        unit_id=id
-                    ),
-                    id=id,
-                    electrodes=waveform_extractor.recording.get_channel_ids(),
-                    waveforms=waveforms,
-                )
-
-            # If metrics were specified, add one column per metric
-            if metrics is not None:
-                for metric_name, metric_dict in metrics.items():
-                    self._info_msg(
-                        f"Adding metric {metric_name} : {metric_dict}"
-                    )
-                    metric_data = metric_dict.values().to_list()
-                    nwbf.add_unit_column(
-                        name=metric_name,
-                        description=metric_name,
-                        data=metric_data,
-                    )
-            if labels is not None:
-                nwbf.add_unit_column(
-                    name="label",
-                    description="label given during curation",
-                    data=labels,
-                )
-
+            units_object_id = self._add_units_waveforms_to_open_nwb(
+                nwbf, waveform_extractor, metrics=metrics, labels=labels
+            )
             io.write(nwbf)
-            return nwbf.units.object_id
+            return units_object_id
+
+    def _add_units_waveforms_to_open_nwb(
+        self,
+        nwbf: pynwb.NWBFile,
+        waveform_extractor: si.WaveformExtractor,
+        metrics: Optional[dict] = None,
+        labels: Optional[dict] = None,
+    ) -> str:
+        """Add units to an open NWB file along with the waveforms
+
+        Parameters
+        ----------
+        nwbf : pynwb.NWBFile
+            An open NWB file.
+        waveform_extractor : si.WaveformExtractor object
+        metrics : dict, optional
+            Cluster metrics.
+        labels : dict, optional
+            Curation labels for clusters
+
+        Returns
+        -------
+        units_object_id : str
+            The NWB object id of the Units object
+        """
+
+        for id in waveform_extractor.sorting.get_unit_ids():
+            # (spikes, samples, channels)
+            waveforms = waveform_extractor.get_waveforms(unit_id=id)
+            # (channels, spikes, samples)
+            waveforms = np.moveaxis(waveforms, source=2, destination=0)
+            nwbf.add_unit(
+                spike_times=waveform_extractor.sorting.get_unit_spike_train(
+                    unit_id=id
+                ),
+                id=id,
+                electrodes=waveform_extractor.recording.get_channel_ids(),
+                waveforms=waveforms,
+            )
+
+        # If metrics were specified, add one column per metric
+        if metrics is not None:
+            for metric_name, metric_dict in metrics.items():
+                self._info_msg(f"Adding metric {metric_name} : {metric_dict}")
+                metric_data = metric_dict.values().to_list()
+                nwbf.add_unit_column(
+                    name=metric_name,
+                    description=metric_name,
+                    data=metric_data,
+                )
+        if labels is not None:
+            nwbf.add_unit_column(
+                name="label",
+                description="label given during curation",
+                data=labels,
+            )
+
+        return nwbf.units.object_id
 
     def add_units_metrics(self, analysis_file_name: str, metrics: dict):
         """Add units to analysis NWB file along with the waveforms
@@ -982,26 +1085,47 @@ class AnalysisMixin(BaseMixin):
         units_object_id : str
             The NWB object id of the Units object
         """
-        metric_names = list(metrics.keys())
-        unit_ids = list(metrics[metric_names[0]].keys())
         with pynwb.NWBHDF5IO(
             path=self.get_abs_path(analysis_file_name),
             mode="a",
             load_namespaces=True,
         ) as io:
             nwbf = io.read()
-            for id in unit_ids:
-                nwbf.add_unit(id=id)
-
-            for metric_name, metric_dict in metrics.items():
-                self._info_msg(f"Adding metric {metric_name} : {metric_dict}")
-                metric_data = list(metric_dict.values())
-                nwbf.add_unit_column(
-                    name=metric_name, description=metric_name, data=metric_data
-                )
+            units_object_id = self._add_units_metrics_to_open_nwb(nwbf, metrics)
 
             io.write(nwbf)
-            return nwbf.units.object_id
+            return units_object_id
+
+    def _add_units_metrics_to_open_nwb(
+        self, nwbf: pynwb.NWBFile, metrics: dict
+    ) -> str:
+        """Add units to an open NWB file along with the waveforms
+
+        Parameters
+        ----------
+        nwbf : pynwb.NWBFile
+            An open NWB file.
+        metrics : dict
+            Cluster metrics.
+
+        Returns
+        -------
+        units_object_id : str
+            The NWB object id of the Units object
+        """
+        metric_names = list(metrics.keys())
+        unit_ids = list(metrics[metric_names[0]].keys())
+        for id in unit_ids:
+            nwbf.add_unit(id=id)
+
+        for metric_name, metric_dict in metrics.items():
+            self._info_msg(f"Adding metric {metric_name} : {metric_dict}")
+            metric_data = list(metric_dict.values())
+            nwbf.add_unit_column(
+                name=metric_name, description=metric_name, data=metric_data
+            )
+
+        return nwbf.units.object_id
 
     @classmethod
     def get_electrode_indices(

--- a/src/spyglass/utils/mixins/analysis.py
+++ b/src/spyglass/utils/mixins/analysis.py
@@ -693,7 +693,7 @@ class AnalysisMixin(BaseMixin):
         self,
         nwbf: pynwb.NWBFile,
         nwb_object: pynwb.core.NWBDataInterface,
-        table_name: Optional[str] = "pandas_table",
+        table_name: Optional[str] = None,
     ) -> str:
         """Add an NWB object to an open NWB file and return the NWB object ID
 

--- a/src/spyglass/utils/mixins/analysis.py
+++ b/src/spyglass/utils/mixins/analysis.py
@@ -869,7 +869,7 @@ class AnalysisMixin(BaseMixin):
                 labels=labels,
             )
             io.write(nwbf)
-            return nwbf.units.object_id, waveforms_object_id
+            return units_object_id, waveforms_object_id
 
     def _add_units_to_open_nwb(
         self,

--- a/src/spyglass/utils/mixins/analysis_builder.py
+++ b/src/spyglass/utils/mixins/analysis_builder.py
@@ -5,6 +5,7 @@ the CREATE → POPULATE → REGISTER lifecycle for analysis NWB files, preventin
 common user errors like forgetting registration or modifying registered files.
 """
 
+from functools import cached_property
 from typing import Optional, Tuple
 
 import pynwb
@@ -83,6 +84,8 @@ class AnalysisFileBuilder:
         self._state = "INIT"
         self._exception_occurred = False
         self._exception_log = dict()
+        self._open_io = None
+        self._open_nwb = None
 
     def __enter__(self):
         """Create analysis file (CREATE phase).
@@ -184,6 +187,17 @@ class AnalysisFileBuilder:
             )
         # CREATED state is valid, no error
 
+    @property
+    def open_nwb(self):
+        if self._open_nwb is None:
+            self._open_io = pynwb.NWBHDF5IO(
+                path=self.get_path(),
+                mode="a",
+                load_namespaces=True,
+            )
+            self._open_nwb = self._open_io.read()
+        return self._open_io, self._open_nwb
+
     def register(self):
         """Register the analysis file in the database.
 
@@ -204,12 +218,32 @@ class AnalysisFileBuilder:
                 f"File must be created first (use context manager)."
             )
 
+        self.close_and_write()
         self._table.add(self.nwb_file_name, self.analysis_file_name)
         self._state = "REGISTERED"
         logger.debug(
             f"Registered analysis file: {self.analysis_file_name} "
             f"(parent: {self.nwb_file_name})"
         )
+
+    def close_and_write(self):
+        """Close open NWB file and write changes to disk.
+
+        This is used internally to ensure that any open NWB file is properly
+        closed and written before registration. It can also be called manually
+        if needed (e.g. to finalize changes before registration).
+
+        Raises
+        ------
+        ValueError
+            If no NWB file is currently open
+        """
+        if self._open_io is None or self._open_nwb is None:
+            return
+        self._open_io.write(self._open_nwb)
+        self._open_io.close()
+        self._open_io = None
+        self._open_nwb = None
 
     def add_nwb_object(
         self, nwb_object, table_name: str = "pandas_table"
@@ -234,8 +268,9 @@ class AnalysisFileBuilder:
             If called before create or after registration
         """
         self._ensure_created("add_nwb_object")
-        return self._table.add_nwb_object(
-            self.analysis_file_name, nwb_object, table_name
+        nwbf = self.open_nwb[1]
+        return self._table._add_nwb_object_to_open_nwb(
+            nwbf, nwb_object, table_name
         )
 
     def add_units(
@@ -271,8 +306,9 @@ class AnalysisFileBuilder:
             If called before create or after registration
         """
         self._ensure_created("add_units")
-        return self._table.add_units(
-            self.analysis_file_name,
+        nwbf = self.open_nwb[1]
+        return self._table._add_units_to_open_nwb(
+            nwbf,
             units,
             units_valid_times,
             units_sort_interval,
@@ -298,7 +334,8 @@ class AnalysisFileBuilder:
             If called before create or after registration
         """
         self._ensure_created("add_units_metrics")
-        return self._table.add_units_metrics(self.analysis_file_name, metrics)
+        nwbf = self.open_nwb[1]
+        return self._table._add_units_metrics_to_open_nwb(nwbf, metrics)
 
     def add_units_waveforms(self, waveform_extractor) -> str:
         """Add unit waveforms to analysis file (POPULATE phase).
@@ -319,8 +356,9 @@ class AnalysisFileBuilder:
             If called before create or after registration
         """
         self._ensure_created("add_units_waveforms")
-        return self._table.add_units_waveforms(
-            self.analysis_file_name, waveform_extractor
+        nwbf = self.open_nwb[1]
+        return self._table._add_units_waveforms_to_open_nwb(
+            nwbf, waveform_extractor
         )
 
     def open_for_write(self):

--- a/src/spyglass/utils/mixins/analysis_builder.py
+++ b/src/spyglass/utils/mixins/analysis_builder.py
@@ -16,55 +16,53 @@ from spyglass.utils.logging import logger
 class AnalysisFileBuilder:
     """Context manager for safe analysis file creation.
 
-    Enforces CREATE → POPULATE → REGISTER lifecycle with automatic state
-    tracking and fail-fast error messages.
+        Enforces CREATE → POPULATE → REGISTER lifecycle with automatic state
+        tracking and fail-fast error messages.
 
-    The builder prevents common errors:
-    - Forgetting to call add() (auto-registration on __exit__)
-    - Calling helpers after registration (state checks with clear errors)
-    - Opening files in write mode after registration (prevented)
-    - Losing track of file state (explicit state machine)
-    - Creating orphaned files on exception (logged for cleanup)
+        The builder prevents common errors:
+        - Forgetting to call add() (auto-registration on __exit__)
+        - Calling helpers after registration (state checks with clear errors)
+        - Opening files in write mode after registration (prevented)
+        - Losing track of file state (explicit state machine)
+        - Creating orphaned files on exception (logged for cleanup)
 
-    Parameters
-    ----------
-    analysis_table : AnalysisMixin instance
-        The table to create/register file in (master or custom)
-    nwb_file_name : str
-        Parent NWB file name
+        Parameters
+        ----------
+        analysis_table : AnalysisMixin instance
+            The table to create/register file in (master or custom)
+        nwb_file_name : str
+            Parent NWB file name
 
-    Attributes
-    ----------
-    analysis_file_name : str
-        Name of created analysis file (set after __enter__)
-    nwb_file_name : str
-        Parent NWB file name
+        Attributes
+        ----------
+        analysis_file_name : str
+            Name of created analysis file (set after __enter__)
+        nwb_file_name : str
+            Parent NWB file name
 
-    Examples
-    --------
-    Basic usage with helper methods:
-    >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
-    ...     builder.add_nwb_object(my_data, "results")
-    ...     file = builder.analysis_file_name
-    # File automatically registered on exit!
+        Examples
+        --------
+        Basic usage with helper methods:
+        >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
+        ...     builder.add_nwb_object(my_data, "results")
+        ...     file = builder.analysis_file_name
+        # File automatically registered on exit!
 
-    Multiple helper calls:
-    >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
-    ...     builder.add_nwb_object(position_data, "position")
-    ...     builder.add_nwb_object(velocity_data, "velocity")
-    ...     file = builder.analysis_file_name
+        Multiple helper calls:
+        >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
+        ...     builder.add_nwb_object(position_data, "position")
+        ...     builder.add_nwb_object(velocity_data, "velocity")
+        ...     file = builder.analysis_file_name
 
-    Direct NWB I/O for complex operations:
-    >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
-    ...     with builder.open_for_write() as io:
-    ...         nwbf = io.read()
+        Direct NWB I/O for complex operations:
+        >>> with AnalysisNwbfile().build(nwb_file_name) as builder:
+        ...     io, nwbf = builder.open_nwb
     ...         nwbf.add_unit(spike_times=times, id=unit_id)
-    ...         io.write(nwbf)
-    ...     file = builder.analysis_file_name
+        ...     file = builder.analysis_file_name
 
-    See Also
-    --------
-    AnalysisMixin.build : Factory method that creates this builder
+        See Also
+        --------
+        AnalysisMixin.build : Factory method that creates this builder
     """
 
     def __init__(self, analysis_table, nwb_file_name: str):
@@ -161,7 +159,7 @@ class AnalysisFileBuilder:
         """Ensure file is in CREATED state (not INIT or REGISTERED).
 
         This helper validates that population methods (add_nwb_object, add_units,
-        open_for_write) are called at the correct time in the lifecycle.
+        open_nwb) are called at the correct time in the lifecycle.
 
         Parameters
         ----------
@@ -192,6 +190,8 @@ class AnalysisFileBuilder:
 
     @property
     def open_nwb(self):
+        """Tuple of (io, nwb) for currently open NWB file, or opens it if not already open."""
+        self._ensure_created("open_nwb")
         if self._open_nwb is None:
             self._open_io = pynwb.NWBHDF5IO(
                 path=self.get_path(),
@@ -359,32 +359,6 @@ class AnalysisFileBuilder:
         return self._table._add_units_waveforms_to_open_nwb(
             nwbf, waveform_extractor
         )
-
-    def open_for_write(self):
-        """Open analysis file for direct NWB I/O (POPULATE phase).
-
-        Returns context manager for NWBHDF5IO in append mode.
-        Only works if file is CREATED but not yet REGISTERED.
-
-        Returns
-        -------
-        io : pynwb.NWBHDF5IO
-            Context manager for file I/O
-
-        Raises
-        ------
-        ValueError
-            If called before create or after registration
-
-        Examples
-        --------
-        >>> with builder.open_for_write() as io:
-        ...     nwbf = io.read()
-        ...     nwbf.add_unit(spike_times=times, id=unit_id)
-        ...     io.write(nwbf)
-        """
-        self._ensure_created("open_for_write")
-        return self.open_nwb[0]
 
     def get_path(self) -> str:
         """Get absolute filesystem path to analysis file.

--- a/src/spyglass/utils/mixins/analysis_builder.py
+++ b/src/spyglass/utils/mixins/analysis_builder.py
@@ -380,8 +380,7 @@ class AnalysisFileBuilder:
         ...     io.write(nwbf)
         """
         self._ensure_created("open_for_write")
-        path = self.get_path()
-        return pynwb.NWBHDF5IO(path=path, mode="a", load_namespaces=True)
+        return self.open_nwb[0]
 
     def get_path(self) -> str:
         """Get absolute filesystem path to analysis file.

--- a/src/spyglass/utils/mixins/analysis_builder.py
+++ b/src/spyglass/utils/mixins/analysis_builder.py
@@ -201,6 +201,12 @@ class AnalysisFileBuilder:
             self._open_nwb = self._open_io.read()
         return self._open_io, self._open_nwb
 
+    def open_for_write(self):
+        raise NotImplementedError(
+            "Please use the open_nwb property to get the NWB file for writing."
+            + " See updated AnalysisTables documentation for examples."
+        )
+
     def register(self):
         """Register the analysis file in the database.
 

--- a/src/spyglass/utils/mixins/analysis_builder.py
+++ b/src/spyglass/utils/mixins/analysis_builder.py
@@ -5,7 +5,6 @@ the CREATE → POPULATE → REGISTER lifecycle for analysis NWB files, preventin
 common user errors like forgetting registration or modifying registered files.
 """
 
-from functools import cached_property
 from typing import Optional, Tuple
 
 import pynwb
@@ -231,12 +230,8 @@ class AnalysisFileBuilder:
 
         This is used internally to ensure that any open NWB file is properly
         closed and written before registration. It can also be called manually
-        if needed (e.g. to finalize changes before registration).
-
-        Raises
-        ------
-        ValueError
-            If no NWB file is currently open
+        if needed (e.g. to finalize changes before registration). If no NWB
+        file is currently open, this method does nothing.
         """
         if self._open_io is None or self._open_nwb is None:
             return

--- a/src/spyglass/utils/mixins/analysis_builder.py
+++ b/src/spyglass/utils/mixins/analysis_builder.py
@@ -136,6 +136,8 @@ class AnalysisFileBuilder:
                     f"File will be detected and cleaned up by "
                     f"AnalysisNwbfile.cleanup()"
                 )
+            if self._open_io:
+                self._open_io.close()
             return False  # Don't suppress exception
 
         # Always auto-register on successful exit
@@ -149,6 +151,8 @@ class AnalysisFileBuilder:
                     f"Failed to register analysis file "
                     f"'{self.analysis_file_name}': {e}"
                 )
+            if self._open_io:
+                self._open_io.close()
             raise  # Re-raise registration error
 
         return False  # Never suppress exceptions

--- a/src/spyglass/utils/mixins/analysis_builder.py
+++ b/src/spyglass/utils/mixins/analysis_builder.py
@@ -250,17 +250,17 @@ class AnalysisFileBuilder:
         self._open_io = None
         self._open_nwb = None
 
-    def add_nwb_object(
-        self, nwb_object, table_name: str = "pandas_table"
-    ) -> str:
+    def add_nwb_object(self, nwb_object, table_name: str = None) -> str:
         """Add NWB object to analysis file (POPULATE phase).
 
         Parameters
         ----------
         nwb_object : pynwb object, DataFrame, or ndarray
             Object to add to file scratch space
-        table_name : str, default="pandas_table"
-            Name for object in scratch space
+        table_name : str, default=None
+            The name of the pynwb object made from a passed dataframe or array.
+            Defaults to "pandas_table" or "numpy_array" for dataframes and arrays
+            respectively.
 
         Returns
         -------
@@ -272,6 +272,7 @@ class AnalysisFileBuilder:
         ValueError
             If called before create or after registration
         """
+
         self._ensure_created("add_nwb_object")
         nwbf = self.open_nwb[1]
         return self._table._add_nwb_object_to_open_nwb(

--- a/tests/common/test_analysis_builder.py
+++ b/tests/common/test_analysis_builder.py
@@ -232,7 +232,7 @@ class TestHelperMethods:
             entry.delete_quick()
             Path(table.get_abs_path(analysis_file)).unlink(missing_ok=True)
 
-    def test_open_for_write_before_registration(
+    def test_open_nwb_before_registration(
         self,
         master_analysis_table,
         mini_copy_name,
@@ -240,17 +240,15 @@ class TestHelperMethods:
         load_config,
         teardown,
     ):
-        """Test open_for_write() works before registration."""
+        """Test open_nwb property works before registration."""
         table = master_analysis_table
 
         with table.build(mini_copy_name) as builder:
             analysis_file = builder.analysis_file_name
 
             # Open file for writing
-            with builder.open_for_write() as io:
-                nwbf = io.read()
-                # Should be able to read the NWB file
-                assert nwbf is not None
+            io, nwbf = builder.open_nwb
+            assert nwbf is not None
 
         # File should be registered after exit
         entry = table & {"analysis_file_name": analysis_file}
@@ -318,10 +316,10 @@ class TestStateEnforcement:
             (table & {"analysis_file_name": analysis_file}).delete_quick()
             Path(table.get_abs_path(analysis_file)).unlink(missing_ok=True)
 
-    def test_error_on_open_for_write_after_registration(
+    def test_error_on_open_nwb_after_registration(
         self, master_analysis_table, mini_copy_name, mock_create, teardown
     ):
-        """Test that open_for_write() fails after registration."""
+        """Test that open_nwb property fails after registration."""
         table = master_analysis_table
         mock_create(table)
 
@@ -333,8 +331,7 @@ class TestStateEnforcement:
 
             # Try to open file after registration
             with pytest.raises(ValueError, match="REGISTERED"):
-                with builder.open_for_write():
-                    pass
+                builder.open_nwb
 
         # Cleanup
         if teardown:


### PR DESCRIPTION
# Description

- Resolves #1593 
    - When using the builder, moves the file open and write management to the builder context
    - avoids reopening and writing file for each object added
    - No change to interface when using standard builder or analysis table methods 

- Adds `builder.open_nwb` property
   - property is a tuple (io, nwb) in writable mode
   - `write` and `io.close` are handled by the builder at `register` and/or context exit 
   - Deprecates `open_nwb_for_write` in favor of this managed property (edits docs and doc-strings accordingly)

- corrects intended default naming for numpy arrays stored in analysis nwb files with `add_nwb_object`

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] NA If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] NA If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] NA If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
