### PR TITLE
Recompute call fixes from get_recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,7 +237,7 @@ for label, interval_data in results.groupby("interval_labels"):
         SpikeInterface `ValueError` caused by floating-point round-trip in the
         seconds-to-samples conversion #1564
     - Trigger recording recompute in `SpikeSortingRecording.populate` when
-        necessary #1588
+        necessary #1588, #1599
     - Restrict `ImportedSpikeSorting.Annotations` to the current session in
         `make_df_from_annotations` so `fetch_nwb` works across multiple sessions
         with overlapping unit ids #1581, #1592

--- a/src/spyglass/spikesorting/v1/recording.py
+++ b/src/spyglass/spikesorting/v1/recording.py
@@ -338,6 +338,10 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             parent = SpikeSortingRecordingSelection & key
             parent_file_name = parent.fetch1("nwb_file_name")
 
+        cls._check_recompute_args(
+            recompute_file_name, recompute_object_id, recompute_electrodes_id
+        )
+
         recording_nwb_file_name, recording_object_id, electrodes_id = (
             _write_recording_to_nwb(
                 **cls()._get_preprocessed_recording(key),
@@ -418,7 +422,7 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
         )
 
         if not Path(analysis_file_abs_path).exists():
-            cls._make_file(key, recompute_file_name=analysis_file_name)
+            cls._make_file(key=None, recompute_file_name=analysis_file_name)
 
         recording = se.read_nwb_recording(
             analysis_file_abs_path, load_time_vector=True
@@ -711,6 +715,24 @@ class SpikeSortingRecording(SpyglassMixin, dj.Computed):
             channel_names = electrodes_table["channel_name"]
             return [channel_names[ch] for ch in channel_ids]
 
+    @staticmethod
+    def _check_recompute_args(
+        recompute_file_name: str = None,
+        recompute_object_id: str = None,
+        recompute_electrodes_id: str = None,
+    ):
+        """Check that if any recompute args are specified, all are specified."""
+        recompute_args = (
+            recompute_file_name,
+            recompute_object_id,
+            recompute_electrodes_id,
+        )
+        if any(recompute_args) and not all(recompute_args):
+            raise ValueError(
+                "If recomputing, must specify all of recompute_file_name, "
+                "recompute_object_id, and recompute_electrodes_id."
+            )
+
 
 def _consolidate_intervals(intervals, timestamps):
     """Convert a list of intervals (start_time, stop_time)
@@ -806,11 +828,7 @@ def _write_recording_to_nwb(
         recompute_electrodes_id,
     )
     recompute = any(recompute_args)
-    if recompute and not all(recompute_args):
-        raise ValueError(
-            "If recomputing, must specify all of recompute_file_name, "
-            "recompute_object_id, and recompute_electrodes_id."
-        )
+    SpikeSortingRecording._check_recompute_args(*recompute_args)
 
     series_name = "ProcessedElectricalSeries"
     series_attr = "acquisition/" + series_name


### PR DESCRIPTION
# Description

Fixes #1596 
- passes `None` for key to match `_make_file` expectations for recompute

- Earlier check for recompute arg consistency to avoid erroring after computing the recording

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
