### PR TITLE
Restrict DLC version (<3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,7 @@ for label, interval_data in results.groupby("interval_labels"):
     - Fix ingestion nwb files with position objects but no spatial series #1405
     - Ignore `percent_frames` when using `limit` in `DLCPosVideo` #1418
     - Increase `DLCProject.config_path` length #1534
+    - Restrict `DLC<3.0` #1605
 
 - Spikesorting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 ]
 
 optional-dependencies.dlc = [
-  "deeplabcut[tf]", # removing dlc pin removes need to pin tf/numba
+  "deeplabcut[tf]<3.0", # pin to 2.0 until PositionV2 release
   "ffmpeg",
 ]
 optional-dependencies.docs = [


### PR DESCRIPTION
Fixes #1604
 
This pull request makes a minor update to the `pyproject.toml` file by pinning the `deeplabcut[tf]` dependency to a version below 3.0 in the `dlc` optional dependencies. This ensures compatibility until the PositionV2 release (#1317)

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [ ] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [ ] If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [ ] If this PR makes changes to position, I ran the relevant tests locally.
- [ ] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [ ] I have updated the `CHANGELOG.md` with PR number and description.
