### PR TITLE
Add deprecation migration guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ for label, interval_data in results.groupby("interval_labels"):
 - Revise table field docstring heading and `mermaid` diagram generation #1402
 - Add pages for custom analysis tables and class inheritance structure #1435
 - Add support for bandstop filter type #1464
+- Add Interval and Populate migration guides #1615
 
 ### Infrastructure
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -84,6 +84,8 @@ nav:
     - Centralized Code: Features/Mixin.md
     - Recompute: Features/Recompute.md
     - Ingestion: Features/Ingestion.md
+    - Interval: Features/Intervals.md
+    - Populate: Features/Populate.md
   - For Developers:
     - Overview: ForDevelopers/index.md
     - How to Contribute: ForDevelopers/Contribute.md

--- a/docs/src/Features/Intervals.md
+++ b/docs/src/Features/Intervals.md
@@ -219,8 +219,8 @@ ______________________________________________________________________
 
 Older Spyglass code used standalone functions like `interval_list_intersect`,
 `interval_list_contains`, and `interval_list_complement`. These are now
-deprecated wrappers around `Interval` and emit a warning on every call. They
-continue to work but will be removed in a future release.
+deprecated wrappers around `Interval` and emit a warning once per Python
+process. They continue to work but will be removed in a future release.
 
 All replacements produce identical output. The only change is that intermediate
 results are `Interval` objects rather than raw arrays — call `.times` at the end

--- a/docs/src/Features/Intervals.md
+++ b/docs/src/Features/Intervals.md
@@ -1,0 +1,341 @@
+# Interval
+
+Neuroscience recordings are rarely clean from start to finish. A session may
+include periods where the animal was running, resting, or off-task; the hardware
+may have introduced noise artifacts; or only certain epochs have been annotated
+for analysis. Working with neural data means constantly answering the question:
+_which samples actually belong to this analysis?_
+
+Spyglass answers that question with **time intervals** — `[start, stop]` pairs
+in seconds that mark regions of interest. The `Interval` class is the primary
+tool for creating, combining, and querying these regions.
+
+```python
+from spyglass.common.common_interval import Interval
+```
+
+______________________________________________________________________
+
+## What is an Interval?
+
+An `Interval` is a thin wrapper around a NumPy array of shape `(N, 2)`, where
+each row is one `[start, stop]` time range in seconds. It represents a set of
+non-overlapping time windows — e.g., the valid portions of a recording, the
+trials in an epoch, or the periods free of movement artifacts.
+
+```python
+import numpy as np
+
+# Two valid windows: 0–5 s and 8–12 s
+valid = Interval(np.array([[0.0, 5.0], [8.0, 12.0]]))
+```
+
+The underlying array is always available as `.times`:
+
+```python
+valid.times  # np.array([[0.0, 5.0], [8.0, 12.0]])
+```
+
+______________________________________________________________________
+
+## Why use `Interval` instead of a raw array?
+
+A plain NumPy array of shape `(N, 2)` can represent the same data, but
+`Interval` adds three things that matter in practice:
+
+**1. Input validation.** `Interval` checks that every row has `start <= stop`
+and that the array is shaped `(N, 2)`. Passing a 1-D array, a transposed array,
+or an interval where the stop comes before the start raises a `ValueError`
+immediately rather than producing silent garbage downstream.
+
+**2. Consistent input handling.** Methods accept any `IntervalLike` — a raw
+array, a list, another `Interval`, or an `IntervalList` table key — so you never
+need to think about conversion.
+
+**3. Chainable operations.** Every method that produces a new interval set
+returns a new `Interval`. Multi-step filtering pipelines can be written as a
+single expression without intermediate variables.
+
+______________________________________________________________________
+
+## Creating an Interval
+
+`Interval` accepts several input formats at construction time:
+
+```python
+# From a numpy array or list of [start, stop] pairs
+iv = Interval([[0.0, 1.0], [2.0, 3.0]])
+
+# From an IntervalList table key — fetches valid_times automatically
+iv = Interval({"nwb_file_name": "my_file_.nwb", "interval_list_name": "01_r1"})
+
+# From a list of frame indices — contiguous runs become intervals
+# e.g. [2, 3, 4, 6, 7] -> [[2, 4], [6, 7]]
+iv = Interval([2, 3, 4, 6, 7], from_inds=True)
+
+# From an existing Interval
+iv2 = Interval(iv)
+```
+
+### Overlap and duplicate handling
+
+By default, `Interval` warns if the input contains duplicate rows or overlapping
+windows. Two optional flags control this behavior:
+
+| Flag            | Default | Effect                                              |
+| --------------- | ------- | --------------------------------------------------- |
+| `no_duplicates` | `True`  | Silently remove duplicate intervals                 |
+| `no_overlap`    | `False` | Merge overlapping intervals into one                |
+| `warn`          | `True`  | Log a warning when duplicates or overlaps are found |
+
+```python
+# Overlapping input — merged automatically
+iv = Interval([[0.0, 3.0], [2.0, 5.0]], no_overlap=True)
+iv.times  # [[0.0, 5.0]]
+```
+
+______________________________________________________________________
+
+## Working with Intervals
+
+### Combining interval sets
+
+The most common operation is combining two sets of intervals — keeping only the
+time that falls within both (intersection), within either (union), or within one
+but not the other (subtraction).
+
+```python
+recording = Interval([[0.0, 100.0]])  # full recording
+epoch = Interval([[10.0, 40.0], [60.0, 90.0]])  # annotated epochs
+artifacts = Interval([[25.0, 27.0], [65.0, 66.0]])  # noise windows
+
+# Keep only times that are both in the recording and in an epoch
+recording.intersect(epoch).times
+# [[10.0, 40.0], [60.0, 90.0]]
+
+# Remove artifact windows from the epoch times
+epoch.subtract(artifacts).times
+# [[10.0, 25.0], [27.0, 40.0], [60.0, 65.0], [66.0, 90.0]]
+
+# All times covered by either set
+epoch.union(artifacts).times
+# [[10.0, 40.0], [60.0, 90.0]]  (artifacts are subsumed)
+```
+
+`intersect` and `subtract` accept a `min_length` keyword to drop resulting
+windows that are too short to be useful. `union` also accepts `max_length`.
+
+### Querying timestamps
+
+Given a dense array of timestamps (e.g., LFP samples, spike times), `Interval`
+can filter them to only those falling within the valid windows:
+
+```python
+timestamps = np.linspace(0, 100, 10_000)
+valid = Interval([[10.0, 40.0], [60.0, 90.0]])
+
+# Return only the timestamps inside the intervals
+valid.contains(timestamps)
+
+# Return the *indices* of those timestamps instead
+valid.contains(timestamps, as_indices=True)
+
+# Return timestamps that fall *outside* the intervals
+valid.excludes(timestamps)
+```
+
+`censor` trims the interval boundaries to the span of the timestamps — useful
+when you want to ensure no interval extends beyond the available data:
+
+```python
+valid.censor(timestamps)
+```
+
+### Filtering by duration
+
+To keep only windows long enough to be worth analyzing:
+
+```python
+iv = Interval([[0.0, 0.1], [1.0, 5.0], [6.0, 6.05]])
+iv.by_length(min_length=0.5).times  # [[1.0, 5.0]]
+```
+
+### Merging overlapping windows
+
+If you have built up a set of intervals that may overlap, `consolidate` merges
+them:
+
+```python
+iv = Interval([[0.0, 3.0], [2.0, 5.0], [7.0, 9.0]])
+iv.consolidate().times  # [[0.0, 5.0], [7.0, 9.0]]
+```
+
+### Chaining
+
+Because every operation returns an `Interval`, a multi-step pipeline can be
+written as a single expression. Call `.times` only at the final step when you
+need the raw array:
+
+```python
+from spyglass.common.common_interval import Interval
+
+clean = (
+    Interval(raw_valid_times)
+    .intersect(epoch_times)
+    .subtract(artifact_times)
+    .by_length(min_length=0.5)
+)
+
+# Pass `clean` to the next step, or extract the array
+clean.times
+```
+
+______________________________________________________________________
+
+## Table integration
+
+`IntervalList` is the DataJoint table that stores valid time windows for each
+session. `fetch_interval()` returns an `Interval` directly:
+
+```python
+from spyglass.common import IntervalList
+
+iv = (
+    IntervalList & {"nwb_file_name": "my_file_.nwb", "interval_list_name": "01_r1"}
+).fetch_interval()
+
+trimmed = iv.by_length(min_length=1.0)
+```
+
+To store a derived interval back in the table, use `.as_dict`:
+
+```python
+IntervalList.insert1({**my_key, **trimmed.as_dict})
+```
+
+______________________________________________________________________
+
+## Migration from `interval_list_*` functions
+
+Older Spyglass code used standalone functions like `interval_list_intersect`,
+`interval_list_contains`, and `interval_list_complement`. These are now
+deprecated wrappers around `Interval` and emit a warning on every call. They
+continue to work but will be removed in a future release.
+
+All replacements produce identical output. The only change is that intermediate
+results are `Interval` objects rather than raw arrays — call `.times` at the end
+if a NumPy array is required.
+
+| Deprecated function                  | Replacement                                  |
+| ------------------------------------ | -------------------------------------------- |
+| `interval_list_intersect(a, b)`      | `Interval(a).intersect(b).times`             |
+| `interval_list_union(a, b)`          | `Interval(a).union(b).times`                 |
+| `interval_list_complement(a, b)`     | `Interval(a).subtract(b).times`              |
+| `interval_set_difference_inds(a, b)` | `Interval(a).subtract(b).times`              |
+| `interval_list_contains(il, ts)`     | `Interval(il).contains(ts)`                  |
+| `interval_list_contains_ind(il, ts)` | `Interval(il).contains(ts, as_indices=True)` |
+| `interval_list_excludes(il, ts)`     | `Interval(il).excludes(ts)`                  |
+| `interval_list_excludes_ind(il, ts)` | `Interval(il).excludes(ts, as_indices=True)` |
+| `interval_list_censor(il, ts)`       | `Interval(il).censor(ts).times`              |
+| `interval_from_inds(frames)`         | `Interval(frames, from_inds=True).times`     |
+| `intervals_by_length(il, min, max)`  | `Interval(il).by_length(min, max).times`     |
+| `consolidate_intervals(il)`          | `Interval(il).consolidate().times`           |
+| `union_adjacent_index(a, b)`         | `Interval(a).union_adjacent_index(b).times`  |
+
+### Before and after
+
+#### `interval_list_contains_ind` — get indices of timestamps inside intervals
+
+```python
+# Before
+from spyglass.common.common_interval import interval_list_contains_ind
+
+ind = interval_list_contains_ind(valid_times, timestamps)
+
+# After
+ind = Interval(valid_times).contains(timestamps, as_indices=True)
+```
+
+#### `interval_list_contains` — filter timestamps to those inside intervals
+
+```python
+# Before
+from spyglass.common.common_interval import interval_list_contains
+
+ts = interval_list_contains(valid_times, timestamps)
+
+# After
+ts = Interval(valid_times).contains(timestamps)
+```
+
+#### `intervals_by_length` — keep only intervals within a length range
+
+```python
+# Before
+from spyglass.common.common_interval import intervals_by_length
+
+result = intervals_by_length(valid_times, min_length=0.5, max_length=10.0)
+
+# After
+result = Interval(valid_times).by_length(min_length=0.5, max_length=10.0).times
+```
+
+#### `interval_from_inds` — convert frame indices to interval arrays
+
+```python
+# Before
+from spyglass.common.common_interval import interval_from_inds
+
+result = interval_from_inds([2, 3, 4, 6, 7, 8])  # → [[2, 4], [6, 8]]
+
+# After
+result = Interval([2, 3, 4, 6, 7, 8], from_inds=True).times
+```
+
+#### Multi-step pipeline
+
+```python
+# Before
+from spyglass.common.common_interval import (
+    interval_list_intersect,
+    intervals_by_length,
+    interval_list_complement,
+)
+
+step1 = interval_list_intersect(raw_times, epoch_times)
+step2 = intervals_by_length(step1, min_length=0.5)
+result = interval_list_complement(step2, artifact_times)
+
+# After
+result = (
+    Interval(raw_times)
+    .intersect(epoch_times)
+    .by_length(min_length=0.5)
+    .subtract(artifact_times)
+    .times
+)
+```
+
+#### Single operation
+
+```python
+# Before
+from spyglass.common.common_interval import interval_list_intersect
+
+result = interval_list_intersect(epoch_times, valid_times, min_length=0.5)
+
+# After
+result = Interval(epoch_times).intersect(valid_times, min_length=0.5).times
+```
+
+______________________________________________________________________
+
+## Related migration guides
+
+- **Fetching NWB data** — if your pipeline loads NWB files alongside interval
+    filtering, see
+    [Centralized Code (Mixin)](./Mixin.md#migration-from-standalone-fetch_nwb--get_nwb_table-helpers)
+    for migration from `fetch_nwb` and `get_nwb_table`.
+- **Long-running computations** — if your table sets `_use_transaction = False`,
+    see [Populate and Long-Running Computations](./Populate.md) for the tri-part
+    make migration guide.

--- a/docs/src/Features/Merge.md
+++ b/docs/src/Features/Merge.md
@@ -10,6 +10,28 @@ and related discussions
 [here](https://github.com/datajoint/datajoint-python/issues/151) and
 [here](https://github.com/LorenFrankLab/spyglass/issues/469).
 
+## Version Support Policy
+
+Pipelines are periodically rewritten as new major versions — for example,
+`SpikeSortingV0` and `SpikeSortingV1` today, with `PositionV2` and
+`SpikeSortingV2` anticipated. Merge Tables (e.g., `PositionOutput`,
+`SpikeSortingOutput`) are what let the old and new versions coexist and be
+queried interchangeably while users migrate.
+
+When a new version `VX` is released, the previous version `VX-1` is supported as
+follows:
+
+- **Installation**: `VX-1` is no longer supported for installation once `VX` is
+    released.
+- **Data access**: Data generated with `VX-1` will always remain accessible. Use
+    it with caution after 12 months, as it will no longer reflect ongoing
+    improvements to the pipeline.
+- **Bug fixes**: After 12 months, the Spyglass team no longer issues bug fixes
+    for `VX-1`. Affected users are welcome to submit a pull request.
+- **Insert tools**: After 12 months, the tools used to insert new `VX-1` entries
+    are removed. Fetch methods are retained so that existing data remains
+    accessible.
+
 ## What
 
 A Merge Table is fundamentally a master table with one part for each divergent

--- a/docs/src/Features/Mixin.md
+++ b/docs/src/Features/Mixin.md
@@ -57,6 +57,55 @@ and fetches from the appropriate location. See
 [Custom Analysis Tables](../ForDevelopers/Management.md#custom-analysis-tables)
 for details on using custom analysis file tables.
 
+### Migration from standalone `fetch_nwb` / `get_nwb_table` helpers
+
+Older Spyglass code used two standalone functions from
+`spyglass.utils.dj_helper_fn` that required passing the NWB table and attribute
+explicitly. Both are deprecated and emit a warning on every call.
+
+#### `fetch_nwb` (helper function)
+
+```python
+# Before
+from spyglass.utils.dj_helper_fn import fetch_nwb
+from spyglass.common import Nwbfile
+
+results = fetch_nwb(
+    MyTable & my_key,
+    (Nwbfile, "nwb_file_abs_path"),
+)
+
+# After
+results = (MyTable & my_key).fetch_nwb()
+```
+
+#### `get_nwb_table`
+
+```python
+# Before
+from spyglass.utils.dj_helper_fn import get_nwb_table
+from spyglass.common import Nwbfile
+
+nwb_files, path_fn = get_nwb_table(
+    MyTable & my_key,
+    Nwbfile,
+    "nwb_file_abs_path",
+)
+file_path = path_fn(nwb_files[0])
+
+# After — fetch_nwb handles file resolution internally
+results = (MyTable & my_key).fetch_nwb()
+```
+
+The method inspects the table's foreign-key references to determine whether to
+resolve paths from `Nwbfile` or `AnalysisNwbfile` automatically, so the
+`nwb_master` tuple is no longer needed. The return value is a list of dicts,
+each containing the fetched row fields plus the loaded NWB object.
+
+**NOTE:** Both functions are always called together in practice —
+`get_nwb_table` provides the file list and path resolver that `fetch_nwb` then
+uses. The `fetch_nwb()` method replaces both in a single call.
+
 ## Long-Distance Restrictions
 
 In complicated pipelines like Spyglass, there are often tables that 'bury' their
@@ -287,8 +336,8 @@ declare/modify a table while the transaction is open (see
 [issue #1030](https://github.com/LorenFrankLab/spyglass/issues/1030) and
 [DataJoint issue #1170](https://github.com/datajoint/datajoint-python/issues/1170)).
 
-Tables with `_use_transaction` set to `False` will not be wrapped in a
-transaction when calling `populate`. Transaction protection is replaced by a
-hash of upstream data to ensure no changes are made to the table during the
-unprotected populate. The additional time required to hash the data is a
-trade-off for already time-consuming populates, but avoids blocking other users.
+**NOTE:** Setting `_use_transaction = False` on a table class is deprecated. The
+recommended replacement is the tri-part make pattern (`make_fetch`,
+`make_compute`, `make_insert`), which keeps the database insert inside a
+transaction while allowing long computations to run without holding a lock. See
+[Populate and Long-Running Computations](./Populate.md) for a migration guide.

--- a/docs/src/Features/Mixin.md
+++ b/docs/src/Features/Mixin.md
@@ -61,7 +61,7 @@ for details on using custom analysis file tables.
 
 Older Spyglass code used two standalone functions from
 `spyglass.utils.dj_helper_fn` that required passing the NWB table and attribute
-explicitly. Both are deprecated and emit a warning on every call.
+explicitly. Both are deprecated and emit a warning once per Python process.
 
 #### `fetch_nwb` (helper function)
 

--- a/docs/src/Features/Populate.md
+++ b/docs/src/Features/Populate.md
@@ -79,7 +79,7 @@ For a detailed walkthrough with a real Spyglass table, see
 ## Migration from `_use_transaction = False`
 
 If your table currently sets `_use_transaction = False`, Spyglass emits a
-deprecation warning on every `populate` call and falls back to the old
+deprecation warning once per table per Python process and falls back to the old
 no-transaction behavior. Migrate by removing the attribute and splitting your
 `make` into three methods.
 
@@ -134,7 +134,9 @@ class MyHeavyTable(SpyglassMixin, dj.Computed):
         self.insert1(dict(key, **insert_dict))
 ```
 
-**NOTE:** The `no_transaction_make` deprecation warning is triggered by the
-`_use_transaction = False` class attribute — not by calling `populate` with
-`use_transaction=False` as a keyword argument. The keyword argument is still a
-supported way to override transaction behavior at call time.
+**NOTE:** The deprecation warning is triggered by the `_use_transaction = False`
+class attribute — not by calling `populate` with `use_transaction=False` as a
+keyword argument. The keyword argument is still a supported way to override
+transaction behavior at call time. The warning is logged once per table per
+Python process; the logged identifier in `ActivityLog` takes the form
+`no_transact:<full_table_name>` (truncated to 64 characters).

--- a/docs/src/Features/Populate.md
+++ b/docs/src/Features/Populate.md
@@ -1,0 +1,140 @@
+# Populate and Long-Running Computations
+
+## Why
+
+DataJoint wraps each `populate` call in a database transaction. This protects
+data integrity, but it also holds a table lock for the entire duration of the
+computation. For analyses that take seconds, this is fine. For analyses that
+take minutes or hours (spike sorting, LFP filtering, decoding), the open
+transaction blocks other users from modifying related tables — even for
+unrelated sessions.
+
+The old workaround was to set `_use_transaction = False` on the table class.
+This bypassed the transaction wrapper entirely, which removed the lock but also
+removed the data-integrity guarantees. It is now deprecated.
+
+## What: tri-part make
+
+The replacement is the **tri-part make** pattern: split the monolithic `make`
+method into three methods with explicit responsibilities.
+
+| Method                   | Responsibility                   | DB access  |
+| ------------------------ | -------------------------------- | ---------- |
+| `make_fetch(key)`        | Read inputs from upstream tables | Read only  |
+| `make_compute(key, ...)` | Run the computation              | None       |
+| `make_insert(key, ...)`  | Write results to the database    | Write only |
+
+Spyglass's `populate` calls these three methods in sequence. `make_fetch` and
+`make_compute` run outside the transaction; `make_insert` runs inside one. The
+long computation no longer holds a lock, but the database write is still atomic.
+
+## How
+
+```python
+import datajoint as dj
+from spyglass.utils import SpyglassMixin
+
+schema = dj.schema("my_schema")
+
+
+@schema
+class MyHeavyTable(SpyglassMixin, dj.Computed):
+    definition = """
+    -> UpstreamTable
+    ---
+    result: float
+    """
+
+    _parallel_make = True  # enables tri-part populate
+
+    def make_fetch(self, key):
+        """Read inputs. No database writes allowed here."""
+        data = (UpstreamTable & key).fetch1("raw_data")
+        params = (ParameterTable & key).fetch1("params")
+        return [data, params]
+
+    def make_compute(self, key, data, params):
+        """Run the computation. No database access allowed here."""
+        result = heavy_analysis(data, params)  # can take minutes
+        return [{"result": result}]
+
+    def make_insert(self, key, insert_dict):
+        """Write results. Runs inside a transaction."""
+        self.insert1(dict(key, **insert_dict))
+```
+
+**Rules:**
+
+1. `make_fetch` must only read — no inserts, updates, or deletes.
+2. `make_fetch` must be deterministic: the same key always returns the same
+    data.
+3. `make_compute` must not access the database at all.
+4. `make_insert` is the only method that writes to the database.
+5. Each method returns a list; the next method receives those values as
+    positional arguments after `key`.
+
+For a detailed walkthrough with a real Spyglass table, see
+[Custom Pipelines — Make Method](../ForDevelopers/CustomPipelines.md#make-method).
+
+## Migration from `_use_transaction = False`
+
+If your table currently sets `_use_transaction = False`, Spyglass emits a
+deprecation warning on every `populate` call and falls back to the old
+no-transaction behavior. Migrate by removing the attribute and splitting your
+`make` into three methods.
+
+#### Before
+
+```python
+@schema
+class MyHeavyTable(SpyglassMixin, dj.Computed):
+    definition = """
+    -> UpstreamTable
+    ---
+    result: float
+    """
+
+    _use_transaction = False  # deprecated — remove this
+
+    def make(self, key):
+        # step 1: fetch
+        data = (UpstreamTable & key).fetch1("raw_data")
+        params = (ParameterTable & key).fetch1("params")
+
+        # step 2: compute (long-running, holds no lock under old pattern)
+        result = heavy_analysis(data, params)
+
+        # step 3: insert
+        self.insert1(dict(key, result=result))
+```
+
+#### After
+
+```python
+@schema
+class MyHeavyTable(SpyglassMixin, dj.Computed):
+    definition = """
+    -> UpstreamTable
+    ---
+    result: float
+    """
+
+    _parallel_make = True  # replaces _use_transaction = False
+
+    def make_fetch(self, key):
+        data = (UpstreamTable & key).fetch1("raw_data")
+        params = (ParameterTable & key).fetch1("params")
+        return [data, params]
+
+    def make_compute(self, key, data, params):
+        result = heavy_analysis(data, params)
+        return [{"result": result}]
+
+    def make_insert(self, key, insert_dict):
+        self.insert1(dict(key, **insert_dict))
+```
+
+**NOTE:** The `no_transaction_make` deprecation warning is triggered by the
+`_use_transaction = False` class attribute — not by calling `populate` with
+`use_transaction=False` as a keyword argument. The keyword argument is still a
+supported way to override transaction behavior at call time.

--- a/docs/src/Features/index.md
+++ b/docs/src/Features/index.md
@@ -11,3 +11,8 @@ Spyglass.
 - [Mixin](./Mixin.md) - Spyglass-specific functionalities to DataJoint tables,
     including fetching NWB files, long-distance restrictions, and permission
     checks on delete operations.
+- [Interval](./Intervals.md) - The `Interval` class for creating, combining, and
+    querying time windows. Includes migration from deprecated `interval_list_*`
+    functions.
+- [Populate](./Populate.md) - Tri-part make pattern for long-running
+    computations. Includes migration from deprecated `_use_transaction = False`.

--- a/docs/src/ForDevelopers/CustomPipelines.md
+++ b/docs/src/ForDevelopers/CustomPipelines.md
@@ -182,7 +182,7 @@ class MyAnalysis(SpyglassMixin, dj.Computed):
         interval = (IntervalList & key).fetch_interval()
         interval = interval.intersect(params["valid_times"])
         interval.name = my_new_name
-        test_data = [[1,2,3],[4,5,6]]
+        test_data = [[1, 2, 3], [4, 5, 6]]
         with self.analysis_table.build(nwb_file_name) as builder:
             # store results in file
             data_id = builder.add_nwb_object(test_data, "test")
@@ -194,7 +194,7 @@ class MyAnalysis(SpyglassMixin, dj.Computed):
                 **key,
                 **interval.primary_key,
                 "analysis_file_name": builder.analysis_file_name,
-                "data_object_id": data_id
+                "data_object_id": data_id,
             }
         )
         self.MyAnalysisPart.insert1({**key, "result": 1})
@@ -202,46 +202,13 @@ class MyAnalysis(SpyglassMixin, dj.Computed):
 
 ### Make Method
 
-In general, `make` methods have three steps:
-
-1. Collect inputs: fetch the relevant parameters and data.
-2. Run analysis: run the analysis on the inputs.
-3. Insert results: insert the results into the relevant tables.
-
-DataJoint has protections in place to ensure that `populate` calls are treated
-as a single transaction, but transaction times can slow down table interactions
-for collaborators. Instead, consider an explicit separation with a
-[generator approach](https://github.com/datajoint/datajoint-python/blob/63ebc380ecdd1ba1b0cff02f9927fe2666a59e24/datajoint/autopopulate.py#L108-L112).
-
-```python
-@schema
-class MyAnalysis(SpyglassMixin, dj.Computed):
-    ...
-
-    def make_fetch(self, key):
-        one = SomeUpstreamTable.fetch1(...)  # (1)
-        two = AnotherUpstreamTable.fetch1(...)  # (2)
-
-        return [one, two]
-
-    def make_compute(self, key, one, two):
-        result = some_analysis_function(one, two)  # (3)
-        self_insert = {"result_field": result}  # (4)
-
-        return self_insert
-
-    def make_insert(self, key, self_insert):
-        self.insert1(dict(key, **self_insert))  # (5)
-```
-
-1. `make_fetch` may not modify the key or the database, and only fetches data.
-2. `make_fetch` must be deterministic and idempotent.
-    - Deterministic: given the same key, it always returns the same data.
-    - Idempotent: calling it multiple times has the same effect as calling it
-        once.
-3. `make_compute` runs time-consuming computations.
-4. `make_compute` should not modify the key or the database.
-5. `make_insert` modifies the database.
+In general, `make` methods have three steps: collect inputs, run analysis, and
+insert results. For long-running computations, holding a DataJoint transaction
+open for the full duration can block collaborators. Spyglass supports an
+explicit three-method split (`make_fetch`, `make_compute`, `make_insert`) that
+keeps only the database write inside a transaction. See
+[Populate and Long-Running Computations](../Features/Populate.md) for the full
+pattern, rules, and a migration guide.
 
 ### Time Intervals
 
@@ -426,15 +393,15 @@ unsure about relevant methods, please open a GitHub discussion.
 
 [^1]: For example, `externalpackage.analysis_func` renames `param_name` to
     `param_rename` in version 2.0, and adjusts the functionality to handle new
-    cases. You can either (a) run an `if/then` against the package version, and
-    rename the parameters in the relevant case(s), or (b) alter the table
+    cases. You can either (a) run an `if/then` against the package version,
+    and rename the parameters in the relevant case(s), or (b) alter the table
     definition to add a new nullable secondary field `param_rename=NULL` and
     declare new paramsets for new versions of the package.
 
 [^2]: `blob`s are MySQL-native data types, and come in
-    [various sizes](https://dev.mysql.com/doc/refman/8.0/en/blob.html). For best
-    results, select the smallest size that will fit your data. `tinyblob` is 255
-    bytes, `blob` is 64KB, `mediumblob` is 16MB, and `longblob` is 4GB.
+    [various sizes](https://dev.mysql.com/doc/refman/8.0/en/blob.html). For
+    best results, select the smallest size that will fit your data. `tinyblob`
+    is 255 bytes, `blob` is 64KB, `mediumblob` is 16MB, and `longblob` is 4GB.
 
 [^3]: See `spyglass.lfp.lfp_electrode.LFPElectrodeGroup` for an example of
     grouping electrodes into a collection.

--- a/src/spyglass/common/common_interval.py
+++ b/src/spyglass/common/common_interval.py
@@ -17,6 +17,10 @@ from spyglass.utils.dj_helper_fn import get_child_tables
 
 schema = dj.schema("common_interval")
 
+_INTERVAL_DOC = (
+    "https://lorenfranklab.github.io/spyglass/latest/Features/Intervals/"
+)
+
 # TODO: ADD export to NWB function to save relevant intervals in an NWB file
 
 
@@ -1017,7 +1021,11 @@ def intervals_by_length(interval_list, min_length=0.0, max_length=1e10):
     """
     from spyglass.common.common_usage import ActivityLog
 
-    ActivityLog().deprecate_log("intervals_by_length", alt="Interval.by_length")
+    ActivityLog().deprecate_log(
+        "intervals_by_length",
+        alt="Interval(interval_list).by_length(min_length, max_length).times",
+        doc=_INTERVAL_DOC,
+    )
 
     return Interval(interval_list).by_length(min_length, max_length).times
 
@@ -1034,7 +1042,9 @@ def interval_list_contains_ind(interval_list, timestamps):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "interval_list_contains_ind", alt="Interval.contains"
+        "interval_list_contains_ind",
+        alt="Interval(interval_list).contains(timestamps, as_indices=True)",
+        doc=_INTERVAL_DOC,
     )
 
     return Interval(interval_list).contains(timestamps, as_indices=True)
@@ -1052,7 +1062,9 @@ def interval_list_contains(interval_list, timestamps):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "interval_list_contains", alt="Interval.contains"
+        "interval_list_contains",
+        alt="Interval(interval_list).contains(timestamps)",
+        doc=_INTERVAL_DOC,
     )
     return Interval(interval_list).contains(timestamps)
 
@@ -1070,7 +1082,8 @@ def interval_list_excludes_ind(interval_list, timestamps):
 
     ActivityLog().deprecate_log(
         "interval_list_excludes_ind",
-        alt="Interval.excludes(timestamps, as_indices=True)",
+        alt="Interval(interval_list).excludes(timestamps, as_indices=True)",
+        doc=_INTERVAL_DOC,
     )
     return Interval(interval_list).excludes(timestamps, as_indices=True)
 
@@ -1087,7 +1100,9 @@ def interval_list_excludes(interval_list, timestamps):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "interval_list_excludes", alt="Interval.excludes"
+        "interval_list_excludes",
+        alt="Interval(interval_list).excludes(timestamps)",
+        doc=_INTERVAL_DOC,
     )
     return Interval(interval_list).excludes(timestamps)
 
@@ -1097,7 +1112,9 @@ def consolidate_intervals(interval_list):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "consolidate_intervals", alt="Interval.consolidate"
+        "consolidate_intervals",
+        alt="Interval(interval_list).consolidate().times",
+        doc=_INTERVAL_DOC,
     )
     return Interval(interval_list).consolidate().times
 
@@ -1121,7 +1138,9 @@ def interval_list_intersect(interval_list1, interval_list2, min_length=0):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "interval_list_intersect", alt="Interval.intersect"
+        "interval_list_intersect",
+        alt="Interval(interval_list1).intersect(interval_list2, min_length).times",
+        doc=_INTERVAL_DOC,
     )
     return Interval(interval_list1).intersect(interval_list2, min_length).times
 
@@ -1139,7 +1158,9 @@ def union_adjacent_index(interval1, interval2):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "union_adjacent_index", alt="Interval.union_adjacent_index"
+        "union_adjacent_index",
+        alt="Interval(interval1).union_adjacent_index(interval2).times",
+        doc=_INTERVAL_DOC,
     )
     return Interval(interval1).union_adjacent_index(interval2).times
 
@@ -1170,7 +1191,14 @@ def interval_list_union(
     """
     from spyglass.common.common_usage import ActivityLog
 
-    ActivityLog().deprecate_log("interval_list_union", alt="Interval.union")
+    ActivityLog().deprecate_log(
+        "interval_list_union",
+        alt=(
+            "Interval(interval_list1)"
+            ".union(interval_list2, min_length, max_length).times"
+        ),
+        doc=_INTERVAL_DOC,
+    )
 
     return (
         Interval(interval_list1)
@@ -1194,7 +1222,11 @@ def interval_list_censor(interval_list, timestamps):
     """
     from spyglass.common.common_usage import ActivityLog
 
-    ActivityLog().deprecate_log("interval_list_censor", alt="Interval.censor")
+    ActivityLog().deprecate_log(
+        "interval_list_censor",
+        alt="Interval(interval_list).censor(timestamps).times",
+        doc=_INTERVAL_DOC,
+    )
     return Interval(interval_list).censor(timestamps).times
 
 
@@ -1210,7 +1242,9 @@ def interval_from_inds(list_frames):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "interval_from_inds", alt="Interval(list_frames, from_inds=True)"
+        "interval_from_inds",
+        alt="Interval(list_frames, from_inds=True).times",
+        doc=_INTERVAL_DOC,
     )
     return Interval(list_frames, from_inds=True).times
 
@@ -1235,7 +1269,9 @@ def interval_set_difference_inds(intervals1, intervals2):
     from spyglass.common.common_usage import ActivityLog
 
     ActivityLog().deprecate_log(
-        "interval_set_difference_inds", alt="Interval.subtract"
+        "interval_set_difference_inds",
+        alt="Interval(intervals1).subtract(intervals2).times",
+        doc=_INTERVAL_DOC,
     )
     return Interval(intervals1).subtract(intervals2).times
 
@@ -1253,7 +1289,8 @@ def interval_list_complement(intervals1, intervals2, min_length=0.0):
 
     ActivityLog().deprecate_log(
         "interval_list_complement",
-        alt="Interval(one).subtract(two, min_length=min_length)",
+        alt="Interval(intervals1).subtract(intervals2, min_length=min_length).times",
+        doc=_INTERVAL_DOC,
     )
     return (
         Interval(intervals1).subtract(intervals2, min_length=min_length).times

--- a/src/spyglass/common/common_usage.py
+++ b/src/spyglass/common/common_usage.py
@@ -25,6 +25,8 @@ from spyglass.utils.sql_helper_fn import SQLDumpHelper
 
 schema = dj.schema("common_usage")
 
+_warned_functions: set = set()
+
 
 @schema
 class CautiousDelete(dj.Manual):
@@ -67,7 +69,7 @@ class ActivityLog(dj.Manual):
     """
 
     @classmethod
-    def deprecate_log(cls, name, alt=None, warning=True) -> None:
+    def deprecate_log(cls, name, alt=None, doc=None, warning=True) -> None:
         """Log a deprecation warning for a feature.
 
         Parameters
@@ -75,15 +77,20 @@ class ActivityLog(dj.Manual):
         name : str
             The name of the feature to deprecate.
         alt : str, optional
-            What to use instead. Default no such message.
+            Exact replacement call to display. Default no such message.
+        doc : str, optional
+            URL of the migration guide. Default no such message.
         warning : bool, optional
             Whether to log a warning. Default is True.
         """
-        if warning:
-            msg = f"\n\tUse {alt} instead" if alt else ""
-            logger.warning(
-                f"DEPRECATION scheduled for Spyglass 0.6.0: {name}{msg}"
-            )
+        if warning and name not in _warned_functions:
+            _warned_functions.add(name)
+            msg = f"DEPRECATION scheduled for Spyglass 0.6.0: {name}"
+            if alt:
+                msg += f"\n\tUse instead: {alt}"
+            if doc:
+                msg += f"\n\tMigration guide: {doc}"
+            logger.warning(msg)
         cls.insert1(
             dict(dj_user=dj.config["database.user"], function=name[:64])
         )

--- a/src/spyglass/common/common_usage.py
+++ b/src/spyglass/common/common_usage.py
@@ -69,7 +69,7 @@ class ActivityLog(dj.Manual):
     """
 
     @classmethod
-    def deprecate_log(cls, name, alt=None, doc=None, warning=True) -> None:
+    def deprecate_log(cls, name, alt=None, warning=True, doc=None) -> None:
         """Log a deprecation warning for a feature.
 
         Parameters
@@ -78,10 +78,10 @@ class ActivityLog(dj.Manual):
             The name of the feature to deprecate.
         alt : str, optional
             Exact replacement call to display. Default no such message.
-        doc : str, optional
-            URL of the migration guide. Default no such message.
         warning : bool, optional
             Whether to log a warning. Default is True.
+        doc : str, optional
+            URL of the migration guide. Default no such message.
         """
         if warning and name not in _warned_functions:
             _warned_functions.add(name)

--- a/src/spyglass/utils/dj_helper_fn.py
+++ b/src/spyglass/utils/dj_helper_fn.py
@@ -246,8 +246,8 @@ def get_nwb_table(query_expression, tbl, attr_name, *attrs, **kwargs):
     """Get the NWB file name and path from the given DataJoint query.
 
     .. deprecated:: 0.6.0
-        This function has been integrated into FetchMixin.
-        Use table.fetch_nwb() instead, which now includes all this logic.
+        Use ``(table & key).fetch_nwb()`` instead. Migration guide:
+        https://lorenfranklab.github.io/spyglass/latest/Features/Mixin/
 
     Parameters
     ----------
@@ -337,8 +337,8 @@ def fetch_nwb(query_expression, nwb_master, *attrs, **kwargs):
     """Get an NWB object from the given DataJoint query.
 
     .. deprecated:: 0.6.0
-        This function has been integrated into FetchMixin.
-        Use table.fetch_nwb() instead, which now includes all this logic.
+        Use ``(table & key).fetch_nwb()`` instead. Migration guide:
+        https://lorenfranklab.github.io/spyglass/latest/Features/Mixin/
 
     Parameters
     ----------

--- a/src/spyglass/utils/mixins/populate.py
+++ b/src/spyglass/utils/mixins/populate.py
@@ -68,7 +68,9 @@ class PopulateMixin(BaseMixin):
                 from spyglass.common.common_usage import ActivityLog
 
                 ActivityLog().deprecate_log(
-                    "no_transaction_make", alt="tri-part make"
+                    f"no_transact:{self.full_table_name}"[:64],
+                    alt="tri-part make",
+                    doc="https://lorenfranklab.github.io/spyglass/latest/Features/Populate/",
                 )
 
         if use_transact is False and processes > 1:


### PR DESCRIPTION
# Description

This PR improves the deprecation process by ...
1. Signaling only once, so users don't tune out the warning
2. Adding docs with specific migration guides

# Checklist:

- [X] N/a. If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [X] N/a. If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [X] N/a. If this PR makes changes to position, I ran the relevant tests locally.
- [X] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
