### PR TITLE
Make DecodingParameters serialization robust to non_local_detector model changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,12 @@ for label, interval_data in results.groupby("interval_labels"):
         above.
     - Fix fetching position df in
         SortedSpikesDecodingV1.get_ahead_behind_distance() #1540
+    - Make `DecodingParameters` serialization robust to `non_local_detector`
+        model changes: serialize via `get_params()` instead of `vars()` (so
+        derived internals like `_frozen_discrete_transition_rows_mask_` are not
+        stored and re-passed to the constructor) and reconstruct via the stored
+        model class (so subclass-only parameters such as NonLocal's
+        `non_local_*_penalty` round-trip). Legacy rows remain readable.
 
 - LFP
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,11 +214,11 @@ for label, interval_data in results.groupby("interval_labels"):
     - Fix fetching position df in
         SortedSpikesDecodingV1.get_ahead_behind_distance() #1540
     - Make `DecodingParameters` serialization robust to `non_local_detector`
-        model changes: serialize via `get_params()` instead of `vars()` (so
-        derived internals like `_frozen_discrete_transition_rows_mask_` are not
-        stored and re-passed to the constructor) and reconstruct via the stored
-        model class (so subclass-only parameters such as NonLocal's
-        `non_local_*_penalty` round-trip). Legacy rows remain readable.
+        model changes: serialize via `get_params()` (the public constructor
+        parameters) instead of `vars()`, so version-specific derived internals
+        are not stored and re-passed to the constructor, and reconstruct via the
+        stored model class so subclass-only parameters such as NonLocal's
+        `non_local_*_penalty` round-trip. Legacy rows remain readable. #1618
 
 - LFP
 

--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -284,7 +284,13 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
         ValueError
             If all decoding intervals are empty (no valid time points)
         """
-        classifier = ClusterlessDetector(**decoding_params)
+        # ``decoding_params`` is a reconstructed detector instance for params
+        # stored in the current format, or a kwargs dict for legacy rows.
+        classifier = (
+            decoding_params
+            if isinstance(decoding_params, ClusterlessDetector)
+            else ClusterlessDetector(**decoding_params)
+        )
 
         if key["estimate_decoding_params"]:
             # When estimating parameters, treat times outside decoding intervals
@@ -504,7 +510,13 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
             position_info,
             position_variable_names,
         ) = ClusterlessDecodingV1.fetch_position_info(key)
-        classifier = ClusterlessDetector(**decoding_params)
+        # ``decoding_params`` is a reconstructed detector instance for params
+        # stored in the current format, or a kwargs dict for legacy rows.
+        classifier = (
+            decoding_params
+            if isinstance(decoding_params, ClusterlessDetector)
+            else ClusterlessDetector(**decoding_params)
+        )
 
         classifier.initialize_environments(
             position=position_info[position_variable_names].to_numpy(),

--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -116,7 +116,12 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
             & {"decoding_param_name": key["decoding_param_name"]}
         ).fetch1()
 
-        decoding_params = model_params.get("decoding_params") or dict()
+        # Guard on ``is None`` (not truthiness): a reconstructed detector
+        # instance must not be discarded if it were ever falsy. ``decoding_kwargs``
+        # may legitimately be empty, so ``or dict()`` is fine there.
+        decoding_params = model_params.get("decoding_params")
+        if decoding_params is None:
+            decoding_params = dict()
         decoding_kwargs = model_params.get("decoding_kwargs") or dict()
 
         # Get position data

--- a/src/spyglass/decoding/v1/clusterless.py
+++ b/src/spyglass/decoding/v1/clusterless.py
@@ -223,7 +223,7 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
     def _run_decoder(
         self,
         key: dict,
-        decoding_params: dict,
+        decoding_params: ClusterlessDetector | dict,
         decoding_kwargs: dict,
         position_info: pd.DataFrame,
         position_variable_names: list[str],
@@ -240,8 +240,9 @@ class ClusterlessDecodingV1(SpyglassMixin, dj.Computed):
         ----------
         key : dict
             The key for the current decode operation
-        decoding_params : dict
-            Parameters for ClusterlessDetector initialization
+        decoding_params : ClusterlessDetector | dict
+            A reconstructed ClusterlessDetector instance (current-format rows)
+            or kwargs for ClusterlessDetector initialization (legacy rows)
         decoding_kwargs : dict
             Additional kwargs for fit/predict
         position_info : pd.DataFrame

--- a/src/spyglass/decoding/v1/core.py
+++ b/src/spyglass/decoding/v1/core.py
@@ -73,12 +73,16 @@ class DecodingParameters(SpyglassMixin, dj.Lookup):
         """Override insert to convert classes to dict before inserting.
 
         A detector/classifier is serialized via ``get_params()`` (its public
-        constructor parameters) rather than ``vars()``, so derived internal
-        attributes -- e.g. ``_frozen_discrete_transition_rows_mask_`` -- are not
-        stored and then passed back into the constructor as unexpected keyword
-        arguments on fetch. The concrete class name is recorded so that
-        ``restore_classes`` can rebuild the exact subclass (preserving
-        subclass-only parameters such as NonLocal's ``non_local_*_penalty``).
+        constructor parameters) rather than ``vars()``. ``get_params()`` is the
+        stable serialization contract: it returns exactly the constructor
+        parameters and excludes version-specific derived internal attributes
+        that ``vars()`` may include (historically, e.g.,
+        ``_frozen_discrete_transition_rows_mask_``, since made a lazy property
+        upstream), which would otherwise be passed back into the constructor as
+        unexpected keyword arguments on fetch. The concrete class name is
+        recorded so that ``restore_classes`` can rebuild the exact subclass
+        (preserving subclass-only parameters such as NonLocal's
+        ``non_local_*_penalty``).
         """
         for row in rows:
             params = row["decoding_params"]

--- a/src/spyglass/decoding/v1/core.py
+++ b/src/spyglass/decoding/v1/core.py
@@ -70,10 +70,24 @@ class DecodingParameters(SpyglassMixin, dj.Lookup):
         cls.super().insert(cls.contents, skip_duplicates=True)
 
     def insert(self, rows, *args, **kwargs):
-        """Override insert to convert classes to dict before inserting"""
+        """Override insert to convert classes to dict before inserting.
+
+        A detector/classifier is serialized via ``get_params()`` (its public
+        constructor parameters) rather than ``vars()``, so derived internal
+        attributes -- e.g. ``_frozen_discrete_transition_rows_mask_`` -- are not
+        stored and then passed back into the constructor as unexpected keyword
+        arguments on fetch. The concrete class name is recorded so that
+        ``restore_classes`` can rebuild the exact subclass (preserving
+        subclass-only parameters such as NonLocal's ``non_local_*_penalty``).
+        """
         for row in rows:
             params = row["decoding_params"]
-            if hasattr(params, "__dict__"):
+            if hasattr(params, "get_params"):
+                # non_local_detector models are sklearn-style estimators.
+                class_name = type(params).__name__
+                params = params.get_params(deep=False)
+                params["class_name"] = class_name
+            elif hasattr(params, "__dict__"):
                 params = vars(params)
             row["decoding_params"] = convert_classes_to_dict(params)
         super().insert(rows, *args, **kwargs)

--- a/src/spyglass/decoding/v1/dj_decoder_conversion.py
+++ b/src/spyglass/decoding/v1/dj_decoder_conversion.py
@@ -4,14 +4,29 @@ so that datajoint can store them in tables."""
 import copy
 
 import datajoint as dj
+import non_local_detector
 from non_local_detector import continuous_state_transitions as cst
 from non_local_detector import discrete_state_transitions as dst
 from non_local_detector import initial_conditions as ic
 from non_local_detector.environment import Environment
+from non_local_detector.models import base as nld_base
 from non_local_detector.observation_models import ObservationModel
 from track_linearization import make_track_graph
 
 schema = dj.schema("decoding_clusterless_v1")
+
+
+def _model_class_registry() -> dict:
+    """Map model class name -> class for decoder reconstruction.
+
+    Covers the public detector/classifier classes (e.g.
+    ``NonLocalClusterlessDetector``, ``ContFragSortedSpikesClassifier``) plus
+    the base ``ClusterlessDetector`` / ``SortedSpikesDetector``.
+    """
+    return {
+        **_map_class_name_to_class(non_local_detector),
+        **_map_class_name_to_class(nld_base),
+    }
 
 
 def _convert_dict_to_class(d: dict, class_conversion: dict) -> object:
@@ -104,8 +119,11 @@ def restore_classes(params: dict) -> dict:
 
     Returns
     -------
-    converted_params : dict
-        The converted parameters
+    model : object or dict
+        A reconstructed detector/classifier instance when the stored params
+        carry a ``"class_name"`` (the current format). For legacy rows stored
+        without a class name, the converted parameter ``dict`` is returned
+        unchanged for backward compatibility.
     """
 
     params = copy.deepcopy(params)
@@ -139,7 +157,22 @@ def restore_classes(params: dict) -> dict:
             ObservationModel(**obs) for obs in params["observation_models"]
         ]
 
-    return params
+    # Reconstruct the detector instance via its stored class. Reconstructing
+    # with the concrete class (rather than the base detector) is what lets
+    # subclass-only parameters -- e.g. NonLocal*'s ``non_local_position_penalty``
+    # / ``non_local_penalty_std`` -- round-trip. Legacy rows serialized without
+    # a class name fall back to the param dict for backward compatibility.
+    model_class_name = params.pop("class_name", None)
+    if model_class_name is None:
+        return params
+
+    model_classes = _model_class_registry()
+    if model_class_name not in model_classes:
+        raise ValueError(
+            f"Unknown decoder model class '{model_class_name}'. "
+            f"Known classes: {sorted(model_classes)}"
+        )
+    return model_classes[model_class_name](**params)
 
 
 def _convert_algorithm_params(algo_params: dict) -> dict:

--- a/src/spyglass/decoding/v1/dj_decoder_conversion.py
+++ b/src/spyglass/decoding/v1/dj_decoder_conversion.py
@@ -104,7 +104,12 @@ def _map_class_name_to_class(module: object) -> dict:
         for attr_name, attr in [
             (name, getattr(module, name)) for name in module_attributes
         ]
-        if hasattr(attr, "__class__") and attr.__class__.__name__ == "type"
+        # ``isinstance(attr, type)`` -- not ``attr.__class__.__name__ ==
+        # "type"`` -- so that classes with a non-``type`` metaclass are
+        # included. The detector/classifier classes are ``BaseEstimator``
+        # subclasses whose metaclass is ``ABCMeta``; the stricter check would
+        # silently drop every one of them from the registry.
+        if isinstance(attr, type)
     }
 
 

--- a/src/spyglass/decoding/v1/dj_decoder_conversion.py
+++ b/src/spyglass/decoding/v1/dj_decoder_conversion.py
@@ -2,6 +2,7 @@
 so that datajoint can store them in tables."""
 
 import copy
+import inspect
 
 import datajoint as dj
 import non_local_detector
@@ -27,6 +28,77 @@ def _model_class_registry() -> dict:
         **_map_class_name_to_class(non_local_detector),
         **_map_class_name_to_class(nld_base),
     }
+
+
+def _init_param_names(cls: type) -> set:
+    """Constructor parameter names of a detector class (excluding ``self``)."""
+    return set(inspect.signature(cls.__init__).parameters) - {"self"}
+
+
+# Modality-exclusive constructor parameters that identify a legacy row's
+# detector family, paired with that family's base and NonLocal class names.
+_LEGACY_MODALITY_MARKERS = (
+    (
+        "clusterless_algorithm",
+        "ClusterlessDetector",
+        "NonLocalClusterlessDetector",
+    ),
+    (
+        "sorted_spikes_algorithm",
+        "SortedSpikesDetector",
+        "NonLocalSortedSpikesDetector",
+    ),
+)
+
+
+def _restore_legacy_detector(params: dict):
+    """Reconstruct a legacy (``class_name``-less) parameter dict.
+
+    Legacy ``DecodingParameters`` rows were serialized via ``vars(model)`` and
+    record no class name, so two things must be handled:
+
+    1. ``vars(model)`` includes derived internal attributes that are not
+       constructor parameters (e.g. ``_frozen_discrete_transition_rows_mask_``,
+       a mask computed in ``__init__``); these ``_``-prefixed keys are stripped.
+    2. ``NonLocal*`` detectors accept extra constructor parameters
+       (``non_local_position_penalty`` / ``non_local_penalty_std``) that the base
+       detector rejects. Such rows are rebuilt with the concrete NonLocal class
+       so the parameters round-trip instead of raising ``TypeError`` when the
+       make() site constructs the base detector.
+
+    Base / ContFrag rows (whose keys the base detector accepts) are returned as a
+    dict, so the make() sites construct them with the base detector exactly as
+    before. Rows whose keys match neither class -- e.g. serialized by a newer
+    non_local_detector than is installed -- are also returned as a dict, so the
+    base detector raises loudly rather than this helper silently dropping
+    parameters that would change the model.
+
+    Returns
+    -------
+    object or dict
+        A ``NonLocal*`` detector instance for NonLocal legacy rows, otherwise the
+        stripped parameter dict.
+    """
+    params = {
+        key: value for key, value in params.items() if not key.startswith("_")
+    }
+    keys = set(params)
+    registry = _model_class_registry()
+    for marker, base_name, nonlocal_name in _LEGACY_MODALITY_MARKERS:
+        if marker not in keys:
+            continue
+        base_cls = registry.get(base_name)
+        nonlocal_cls = registry.get(nonlocal_name)
+        base_accepts = base_cls is not None and keys <= _init_param_names(
+            base_cls
+        )
+        nonlocal_accepts = (
+            nonlocal_cls is not None and keys <= _init_param_names(nonlocal_cls)
+        )
+        if not base_accepts and nonlocal_accepts:
+            return nonlocal_cls(**params)
+        break
+    return params
 
 
 def _convert_dict_to_class(d: dict, class_conversion: dict) -> object:
@@ -126,10 +198,11 @@ def restore_classes(params: dict) -> dict:
     -------
     model : object or dict
         A reconstructed detector/classifier instance when the stored params
-        carry a ``"class_name"`` (the current format). For legacy rows stored
-        without a class name, the converted parameter ``dict`` is returned (with
-        derived, non-constructor ``_``-prefixed attributes stripped) for
-        backward compatibility.
+        carry a ``"class_name"`` (the current format), or for legacy NonLocal
+        rows whose extra parameters only the concrete NonLocal class accepts.
+        For other legacy rows stored without a class name, the converted
+        parameter ``dict`` is returned (with derived, non-constructor
+        ``_``-prefixed attributes stripped) for backward compatibility.
     """
 
     params = copy.deepcopy(params)
@@ -170,17 +243,10 @@ def restore_classes(params: dict) -> dict:
     # a class name fall back to the param dict for backward compatibility.
     model_class_name = params.pop("class_name", None)
     if model_class_name is None:
-        # Legacy rows serialized via ``vars(model)`` (before this change) may
-        # carry derived internal attributes that are not constructor
-        # parameters -- e.g. ``_frozen_discrete_transition_rows_mask_``, a mask
-        # computed in the detector's ``__init__``. Passing them back into the
-        # base detector raises ``TypeError``, so strip leading-underscore keys;
-        # constructor parameters never start with an underscore.
-        return {
-            key: value
-            for key, value in params.items()
-            if not key.startswith("_")
-        }
+        # Legacy rows serialized via ``vars(model)`` carry no class name: strip
+        # derived internal attributes and rebuild NonLocal rows via their
+        # concrete class (see ``_restore_legacy_detector``).
+        return _restore_legacy_detector(params)
 
     model_classes = _model_class_registry()
     if model_class_name not in model_classes:
@@ -191,8 +257,12 @@ def restore_classes(params: dict) -> dict:
     return model_classes[model_class_name](**params)
 
 
-def _convert_algorithm_params(algo_params: dict) -> dict:
+def _convert_algorithm_params(algo_params: dict | None) -> dict | None:
     """Helper function that adds in the algorithm name to the algorithm parameters dictionary"""
+    # Some detectors default the algorithm params to None (e.g. current
+    # non_local_detector clusterless detectors); there is nothing to convert.
+    if algo_params is None:
+        return None
     try:
         algo_params = algo_params.copy()
         algo_params["model"] = algo_params["model"].__name__

--- a/src/spyglass/decoding/v1/dj_decoder_conversion.py
+++ b/src/spyglass/decoding/v1/dj_decoder_conversion.py
@@ -324,11 +324,18 @@ def convert_classes_to_dict(params: dict) -> dict:
             vars(obs) for obs in params["observation_models"]
         ]
 
-    try:
-        params["clusterless_algorithm_params"] = _convert_algorithm_params(
-            params["clusterless_algorithm_params"]
-        )
-    except KeyError:
-        pass
+    # A given detector carries only one of these keys; the other raises
+    # KeyError and is skipped. Both are handled the same way so sorted-spikes
+    # algorithm params are serialized identically to clusterless ones.
+    for algorithm_params_key in (
+        "clusterless_algorithm_params",
+        "sorted_spikes_algorithm_params",
+    ):
+        try:
+            params[algorithm_params_key] = _convert_algorithm_params(
+                params[algorithm_params_key]
+            )
+        except KeyError:
+            pass
 
     return params

--- a/src/spyglass/decoding/v1/dj_decoder_conversion.py
+++ b/src/spyglass/decoding/v1/dj_decoder_conversion.py
@@ -127,8 +127,9 @@ def restore_classes(params: dict) -> dict:
     model : object or dict
         A reconstructed detector/classifier instance when the stored params
         carry a ``"class_name"`` (the current format). For legacy rows stored
-        without a class name, the converted parameter ``dict`` is returned
-        unchanged for backward compatibility.
+        without a class name, the converted parameter ``dict`` is returned (with
+        derived, non-constructor ``_``-prefixed attributes stripped) for
+        backward compatibility.
     """
 
     params = copy.deepcopy(params)
@@ -169,7 +170,17 @@ def restore_classes(params: dict) -> dict:
     # a class name fall back to the param dict for backward compatibility.
     model_class_name = params.pop("class_name", None)
     if model_class_name is None:
-        return params
+        # Legacy rows serialized via ``vars(model)`` (before this change) may
+        # carry derived internal attributes that are not constructor
+        # parameters -- e.g. ``_frozen_discrete_transition_rows_mask_``, a mask
+        # computed in the detector's ``__init__``. Passing them back into the
+        # base detector raises ``TypeError``, so strip leading-underscore keys;
+        # constructor parameters never start with an underscore.
+        return {
+            key: value
+            for key, value in params.items()
+            if not key.startswith("_")
+        }
 
     model_classes = _model_class_registry()
     if model_class_name not in model_classes:

--- a/src/spyglass/decoding/v1/sorted_spikes.py
+++ b/src/spyglass/decoding/v1/sorted_spikes.py
@@ -168,7 +168,7 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
     def _run_decoder(
         self,
         key: dict,
-        decoding_params: dict,
+        decoding_params: SortedSpikesDetector | dict,
         decoding_kwargs: dict,
         position_info: pd.DataFrame,
         position_variable_names: list[str],
@@ -184,8 +184,9 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
         ----------
         key : dict
             The key for the current decode operation
-        decoding_params : dict
-            Parameters for SortedSpikesDetector initialization
+        decoding_params : SortedSpikesDetector | dict
+            A reconstructed SortedSpikesDetector instance (current-format rows)
+            or kwargs for SortedSpikesDetector initialization (legacy rows)
         decoding_kwargs : dict
             Additional kwargs for fit/predict
         position_info : pd.DataFrame

--- a/src/spyglass/decoding/v1/sorted_spikes.py
+++ b/src/spyglass/decoding/v1/sorted_spikes.py
@@ -231,7 +231,13 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
         ValueError
             If all decoding intervals are empty (no valid time points)
         """
-        classifier = SortedSpikesDetector(**decoding_params)
+        # ``decoding_params`` is a reconstructed detector instance for params
+        # stored in the current format, or a kwargs dict for legacy rows.
+        classifier = (
+            decoding_params
+            if isinstance(decoding_params, SortedSpikesDetector)
+            else SortedSpikesDetector(**decoding_params)
+        )
 
         if key["estimate_decoding_params"]:
             # When estimating parameters, treat times outside decoding intervals
@@ -448,7 +454,13 @@ class SortedSpikesDecodingV1(SpyglassMixin, dj.Computed):
             position_info,
             position_variable_names,
         ) = SortedSpikesDecodingV1.fetch_position_info(key)
-        classifier = SortedSpikesDetector(**decoding_params)
+        # ``decoding_params`` is a reconstructed detector instance for params
+        # stored in the current format, or a kwargs dict for legacy rows.
+        classifier = (
+            decoding_params
+            if isinstance(decoding_params, SortedSpikesDetector)
+            else SortedSpikesDetector(**decoding_params)
+        )
 
         classifier.initialize_environments(
             position=position_info[position_variable_names].to_numpy(),

--- a/tests/decoding/conftest.py
+++ b/tests/decoding/conftest.py
@@ -342,8 +342,12 @@ def decode_clusterless_params_insert(decode_v1, track_graph):
         },
         skip_duplicates=True,
     )
+    # fetch1() reconstructs the stored model as a concrete instance (current
+    # format); it is no longer a kwargs dict to splat into the constructor.
     model_params = (decode_v1.core.DecodingParameters & params_pk).fetch1()
-    ContFragClusterlessClassifier(**model_params["decoding_params"])
+    assert isinstance(
+        model_params["decoding_params"], ContFragClusterlessClassifier
+    )
 
     yield params_pk
 

--- a/tests/decoding/test_core.py
+++ b/tests/decoding/test_core.py
@@ -106,11 +106,15 @@ def test_fetch_position_info_non_chronological_merge_ids():
 
 def test_decode_param_fetch(decode_v1, decode_clusterless_params_insert):
     from non_local_detector.environment import Environment
+    from non_local_detector.models.base import ClusterlessDetector
 
     key = decode_clusterless_params_insert
+    # Current-format rows reconstruct as a concrete detector instance, not a
+    # dict; environments are attributes on that instance.
     ret = (decode_v1.core.DecodingParameters & key).fetch1()["decoding_params"]
-    env = ret["environments"][0]
-    assert isinstance(env, Environment), "fetch failed to restore class"
+    assert isinstance(ret, ClusterlessDetector), "fetch failed to restore class"
+    env = ret.environments[0]
+    assert isinstance(env, Environment), "fetch failed to restore environment"
 
 
 def test_null_pos_group(caplog, decode_v1, pop_pos_group):

--- a/tests/decoding/test_dj_decoder_conversion.py
+++ b/tests/decoding/test_dj_decoder_conversion.py
@@ -65,11 +65,17 @@ def test_decoding_params_roundtrip(class_name):
     from spyglass.decoding.v1.dj_decoder_conversion import restore_classes
 
     cls = getattr(nld, class_name)
-    # NonLocal* models carry subclass-only penalty parameters; set non-default
-    # values so the round-trip is checked by value, not just by key presence.
-    overrides = (
-        NONLOCAL_PARAM_OVERRIDES if class_name.startswith("NonLocal") else {}
-    )
+    # NonLocal* models carry subclass-only penalty parameters in recent
+    # non_local_detector versions; set non-default values so the round-trip is
+    # checked by value, not just key presence. Gate on the params the installed
+    # version actually accepts -- they were added after 0.6.9 -- so older
+    # versions still exercise the isinstance/keys assertions without erroring.
+    available = set(cls().get_params(deep=False))
+    overrides = {
+        name: value
+        for name, value in NONLOCAL_PARAM_OVERRIDES.items()
+        if class_name.startswith("NonLocal") and name in available
+    }
     model = cls(**overrides)
 
     restored = restore_classes(_serialize_like_insert(model))

--- a/tests/decoding/test_dj_decoder_conversion.py
+++ b/tests/decoding/test_dj_decoder_conversion.py
@@ -1,8 +1,10 @@
 """Unit tests for DecodingParameters serialization round-trip.
 
 These exercise the pure conversion helpers in
-``spyglass.decoding.v1.dj_decoder_conversion`` and do not require a live
-database -- they would have caught the registry regression where every
+``spyglass.decoding.v1.dj_decoder_conversion``. They touch no database
+tables or records (no inserts or fetches), though importing the module
+establishes a DataJoint schema connection like the rest of the suite.
+They would have caught the registry regression where every
 detector/classifier class (an ``ABCMeta`` ``BaseEstimator`` subclass) was
 silently excluded from ``_model_class_registry``. See PR #1618.
 """
@@ -17,6 +19,16 @@ DEFAULT_MODEL_CLASSES = [
 ]
 
 BASE_DETECTOR_CLASSES = ["ClusterlessDetector", "SortedSpikesDetector"]
+
+# Non-default subclass-only values for the NonLocal* models, set so the
+# round-trip is asserted by VALUE (not just key presence). Key-set equality is
+# guaranteed by the sklearn get_params contract regardless of correctness, so
+# it cannot detect a corrupted value -- and preserving these subclass-only
+# parameters is the whole point of reconstructing via the concrete class.
+NONLOCAL_PARAM_OVERRIDES = {
+    "non_local_position_penalty": 2.5,
+    "non_local_penalty_std": 0.75,
+}
 
 
 def _serialize_like_insert(model):
@@ -47,27 +59,34 @@ def test_model_class_registry_contains_detectors():
 
 @pytest.mark.parametrize("class_name", DEFAULT_MODEL_CLASSES)
 def test_decoding_params_roundtrip(class_name):
-    """Serialize -> restore returns an instance of the *concrete* subclass."""
+    """Serialize -> restore yields the concrete subclass with values intact."""
     import non_local_detector as nld
 
     from spyglass.decoding.v1.dj_decoder_conversion import restore_classes
 
     cls = getattr(nld, class_name)
-    model = cls()
+    # NonLocal* models carry subclass-only penalty parameters; set non-default
+    # values so the round-trip is checked by value, not just by key presence.
+    overrides = (
+        NONLOCAL_PARAM_OVERRIDES if class_name.startswith("NonLocal") else {}
+    )
+    model = cls(**overrides)
 
     restored = restore_classes(_serialize_like_insert(model))
 
     assert isinstance(restored, cls)
-    # The public constructor contract round-trips key-for-key.
-    assert (
-        restored.get_params(deep=False).keys()
-        == model.get_params(deep=False).keys()
-    )
+    restored_params = restored.get_params(deep=False)
+    assert restored_params.keys() == model.get_params(deep=False).keys()
+    # Subclass-only parameter values survive (the point of concrete-class
+    # reconstruction); reconstructing via the base detector would drop them.
+    for name, value in overrides.items():
+        assert restored_params[name] == value
 
 
 def test_restore_classes_legacy_dict_returns_dict():
-    """Legacy rows (no ``class_name``) return the converted dict unchanged."""
+    """Legacy rows (no ``class_name``) return a dict with nested classes restored."""
     from non_local_detector import ContFragClusterlessClassifier
+    from non_local_detector.environment import Environment
 
     from spyglass.decoding.v1.dj_decoder_conversion import (
         convert_classes_to_dict,
@@ -82,6 +101,8 @@ def test_restore_classes_legacy_dict_returns_dict():
 
     assert isinstance(restored, dict)
     assert "class_name" not in restored
+    # The dict path still rebuilds the nested classes the make() sites need.
+    assert isinstance(restored["environments"][0], Environment)
 
 
 def test_restore_classes_unknown_class_raises():

--- a/tests/decoding/test_dj_decoder_conversion.py
+++ b/tests/decoding/test_dj_decoder_conversion.py
@@ -1,0 +1,97 @@
+"""Unit tests for DecodingParameters serialization round-trip.
+
+These exercise the pure conversion helpers in
+``spyglass.decoding.v1.dj_decoder_conversion`` and do not require a live
+database -- they would have caught the registry regression where every
+detector/classifier class (an ``ABCMeta`` ``BaseEstimator`` subclass) was
+silently excluded from ``_model_class_registry``. See PR #1618.
+"""
+
+import pytest
+
+DEFAULT_MODEL_CLASSES = [
+    "ContFragClusterlessClassifier",
+    "NonLocalClusterlessDetector",
+    "ContFragSortedSpikesClassifier",
+    "NonLocalSortedSpikesDetector",
+]
+
+BASE_DETECTOR_CLASSES = ["ClusterlessDetector", "SortedSpikesDetector"]
+
+
+def _serialize_like_insert(model):
+    """Mirror DecodingParameters.insert serialization of a detector instance."""
+    from spyglass.decoding.v1.dj_decoder_conversion import (
+        convert_classes_to_dict,
+    )
+
+    params = model.get_params(deep=False)
+    params["class_name"] = type(model).__name__
+    return convert_classes_to_dict(params)
+
+
+def test_model_class_registry_contains_detectors():
+    """All concrete detectors plus the two base classes must be resolvable.
+
+    Pins the metaclass-filtering regression directly: detectors use
+    ``ABCMeta``, so a ``__class__.__name__ == "type"`` filter drops them.
+    """
+    from spyglass.decoding.v1.dj_decoder_conversion import (
+        _model_class_registry,
+    )
+
+    registry = _model_class_registry()
+    for name in DEFAULT_MODEL_CLASSES + BASE_DETECTOR_CLASSES:
+        assert name in registry, f"{name} missing from model class registry"
+
+
+@pytest.mark.parametrize("class_name", DEFAULT_MODEL_CLASSES)
+def test_decoding_params_roundtrip(class_name):
+    """Serialize -> restore returns an instance of the *concrete* subclass."""
+    import non_local_detector as nld
+
+    from spyglass.decoding.v1.dj_decoder_conversion import restore_classes
+
+    cls = getattr(nld, class_name)
+    model = cls()
+
+    restored = restore_classes(_serialize_like_insert(model))
+
+    assert isinstance(restored, cls)
+    # The public constructor contract round-trips key-for-key.
+    assert (
+        restored.get_params(deep=False).keys()
+        == model.get_params(deep=False).keys()
+    )
+
+
+def test_restore_classes_legacy_dict_returns_dict():
+    """Legacy rows (no ``class_name``) return the converted dict unchanged."""
+    from non_local_detector import ContFragClusterlessClassifier
+
+    from spyglass.decoding.v1.dj_decoder_conversion import (
+        convert_classes_to_dict,
+        restore_classes,
+    )
+
+    model = ContFragClusterlessClassifier()
+    # Old ``vars()``-style serialization carries no top-level ``class_name``.
+    legacy = convert_classes_to_dict(dict(vars(model)))
+
+    restored = restore_classes(legacy)
+
+    assert isinstance(restored, dict)
+    assert "class_name" not in restored
+
+
+def test_restore_classes_unknown_class_raises():
+    """An unrecognized ``class_name`` fails loudly, listing known classes."""
+    from non_local_detector import ContFragClusterlessClassifier
+
+    from spyglass.decoding.v1.dj_decoder_conversion import restore_classes
+
+    stored = _serialize_like_insert(ContFragClusterlessClassifier())
+    stored["class_name"] = "NotARealDetector"
+
+    with pytest.raises(ValueError, match="Unknown decoder model class"):
+        restore_classes(stored)

--- a/tests/decoding/test_dj_decoder_conversion.py
+++ b/tests/decoding/test_dj_decoder_conversion.py
@@ -111,6 +111,39 @@ def test_restore_classes_legacy_dict_returns_dict():
     assert isinstance(restored["environments"][0], Environment)
 
 
+def test_restore_classes_legacy_dict_strips_derived_attrs():
+    """Legacy rows with a derived ``_``-prefixed attr rebuild via the base detector.
+
+    Rows serialized via ``vars(model)`` before the ``get_params()`` switch could
+    persist detector internals that are not constructor parameters -- notably
+    ``_frozen_discrete_transition_rows_mask_``, a mask computed in ``__init__`` on
+    some non_local_detector versions. Such rows carry no ``class_name``, so they
+    take the dict fallback and are rebuilt with the base detector; without
+    stripping, ``ClusterlessDetector(**restored)`` raises ``TypeError``. The
+    attribute is injected explicitly so the test reproduces a poisoned legacy row
+    regardless of whether the installed version still writes it in ``vars()``.
+    """
+    from non_local_detector import ContFragClusterlessClassifier
+    from non_local_detector.models.base import ClusterlessDetector
+
+    from spyglass.decoding.v1.dj_decoder_conversion import (
+        convert_classes_to_dict,
+        restore_classes,
+    )
+
+    model = ContFragClusterlessClassifier()
+    # Legacy vars()-style serialization: no class_name, plus a derived internal.
+    legacy = convert_classes_to_dict(dict(vars(model)))
+    legacy["_frozen_discrete_transition_rows_mask_"] = None
+
+    restored = restore_classes(legacy)
+
+    assert isinstance(restored, dict)
+    assert "_frozen_discrete_transition_rows_mask_" not in restored
+    # The point of the strip: base-detector reconstruction no longer raises.
+    assert isinstance(ClusterlessDetector(**restored), ClusterlessDetector)
+
+
 def test_restore_classes_unknown_class_raises():
     """An unrecognized ``class_name`` fails loudly, listing known classes."""
     from non_local_detector import ContFragClusterlessClassifier

--- a/tests/decoding/test_dj_decoder_conversion.py
+++ b/tests/decoding/test_dj_decoder_conversion.py
@@ -144,6 +144,45 @@ def test_restore_classes_legacy_dict_strips_derived_attrs():
     assert isinstance(ClusterlessDetector(**restored), ClusterlessDetector)
 
 
+def test_restore_classes_legacy_nonlocal_upgrades_to_concrete_class():
+    """Legacy NonLocal rows rebuild via the concrete class, preserving penalties.
+
+    NonLocal* detectors accept ``non_local_position_penalty`` /
+    ``non_local_penalty_std`` that the base detector rejects. A legacy row (no
+    ``class_name``) carrying them must be rebuilt as the concrete NonLocal class
+    rather than the base detector, or those parameters are lost / raise. Gated
+    on the installed non_local_detector actually exposing the params (added
+    after 0.6.9), mirroring ``test_decoding_params_roundtrip``.
+    """
+    import non_local_detector as nld
+
+    from spyglass.decoding.v1.dj_decoder_conversion import (
+        convert_classes_to_dict,
+        restore_classes,
+    )
+
+    cls = nld.NonLocalClusterlessDetector
+    available = set(cls().get_params(deep=False))
+    overrides = {
+        name: value
+        for name, value in NONLOCAL_PARAM_OVERRIDES.items()
+        if name in available
+    }
+    if not overrides:
+        pytest.skip("installed non_local_detector has no NonLocal-only params")
+
+    model = cls(**overrides)
+    # Legacy vars()-style serialization carries no top-level class_name.
+    legacy = convert_classes_to_dict(dict(vars(model)))
+
+    restored = restore_classes(legacy)
+
+    assert isinstance(restored, cls)
+    restored_params = restored.get_params(deep=False)
+    for name, value in overrides.items():
+        assert restored_params[name] == value
+
+
 def test_restore_classes_unknown_class_raises():
     """An unrecognized ``class_name`` fails loudly, listing known classes."""
     from non_local_detector import ContFragClusterlessClassifier

--- a/tests/decoding/test_dj_decoder_conversion.py
+++ b/tests/decoding/test_dj_decoder_conversion.py
@@ -144,15 +144,21 @@ def test_restore_classes_legacy_dict_strips_derived_attrs():
     assert isinstance(ClusterlessDetector(**restored), ClusterlessDetector)
 
 
-def test_restore_classes_legacy_nonlocal_upgrades_to_concrete_class():
+@pytest.mark.parametrize(
+    "class_name",
+    ["NonLocalClusterlessDetector", "NonLocalSortedSpikesDetector"],
+)
+def test_restore_classes_legacy_nonlocal_upgrades_to_concrete_class(class_name):
     """Legacy NonLocal rows rebuild via the concrete class, preserving penalties.
 
     NonLocal* detectors accept ``non_local_position_penalty`` /
     ``non_local_penalty_std`` that the base detector rejects. A legacy row (no
     ``class_name``) carrying them must be rebuilt as the concrete NonLocal class
-    rather than the base detector, or those parameters are lost / raise. Gated
-    on the installed non_local_detector actually exposing the params (added
-    after 0.6.9), mirroring ``test_decoding_params_roundtrip``.
+    rather than the base detector, or those parameters are lost / raise.
+    Parametrized over both modalities (clusterless and sorted spikes) since each
+    infers its family from a different marker key. Gated on the installed
+    non_local_detector actually exposing the params (added after 0.6.9),
+    mirroring ``test_decoding_params_roundtrip``.
     """
     import non_local_detector as nld
 
@@ -161,7 +167,7 @@ def test_restore_classes_legacy_nonlocal_upgrades_to_concrete_class():
         restore_classes,
     )
 
-    cls = nld.NonLocalClusterlessDetector
+    cls = getattr(nld, class_name)
     available = set(cls().get_params(deep=False))
     overrides = {
         name: value

--- a/tests/decoding/test_dj_decoder_conversion.py
+++ b/tests/decoding/test_dj_decoder_conversion.py
@@ -189,6 +189,34 @@ def test_restore_classes_legacy_nonlocal_upgrades_to_concrete_class(class_name):
         assert restored_params[name] == value
 
 
+def test_convert_classes_to_dict_stringifies_sorted_algorithm_model():
+    """Sorted-spikes algorithm params get the same model->name conversion.
+
+    ``convert_classes_to_dict`` routes both ``clusterless_algorithm_params`` and
+    ``sorted_spikes_algorithm_params`` through ``_convert_algorithm_params``, so a
+    class stored under ``model`` becomes its name for datajoint storage
+    symmetrically across modalities (previously only clusterless was routed).
+    """
+    from non_local_detector import ContFragSortedSpikesClassifier
+
+    from spyglass.decoding.v1.dj_decoder_conversion import (
+        convert_classes_to_dict,
+    )
+
+    class _DummyAlgorithmModel:
+        pass
+
+    params = dict(vars(ContFragSortedSpikesClassifier()))
+    params["sorted_spikes_algorithm_params"] = {"model": _DummyAlgorithmModel}
+
+    converted = convert_classes_to_dict(params)
+
+    assert (
+        converted["sorted_spikes_algorithm_params"]["model"]
+        == "_DummyAlgorithmModel"
+    )
+
+
 def test_restore_classes_unknown_class_raises():
     """An unrecognized ``class_name`` fails loudly, listing known classes."""
     from non_local_detector import ContFragClusterlessClassifier


### PR DESCRIPTION
## Problem

`DecodingParameters` stores a `non_local_detector` detector/classifier by
serializing `vars(model)` (in `DecodingParameters.insert`) and reconstructs it
on fetch with the base detector, `ClusterlessDetector(**params)` /
`SortedSpikesDetector(**params)`. Two properties of the `non_local_detector`
models break this round-trip with recent versions:

1. The models are scikit-learn-style estimators whose `vars()` includes derived
   internal attributes that are not constructor parameters. A current example is
   `_frozen_discrete_transition_rows_mask_`, computed in `__init__`. When it is
   fetched and passed back into the constructor it raises
   `TypeError: __init__() got an unexpected keyword argument '_frozen_discrete_transition_rows_mask_'`.
2. The `NonLocal*` models add subclass-only parameters
   (`non_local_position_penalty`, `non_local_penalty_std`) that the base
   detector does not accept. Reconstructing a NonLocal model with the base
   detector raises
   `TypeError: ... unexpected keyword argument 'non_local_position_penalty'`.

The net effect is that the default decoding parameter sets fail to reconstruct
on fetch, so decoding cannot run from them. Verified against
`non_local_detector` 0.6.10.dev332: reconstructing the four `insert_default`
parameter sets through the base detector fails -- the two ContFrag sets on the
derived-attribute leak (1), and the two NonLocal sets on both (1) and the
subclass parameters (2).

## Solution

Rely on the models' public parameter contract rather than their raw instance
state for the round-trip:

- **Serialize via `get_params()` instead of `vars()`** in
  `DecodingParameters.insert`. `non_local_detector` models are scikit-learn
  `BaseEstimator`s, so `get_params()` returns exactly the constructor parameters
  and excludes derived internals such as `_frozen_discrete_transition_rows_mask_`.
  This is robust to future derived attributes.
- **Reconstruct via the stored model class** in `restore_classes`. The concrete
  class name is recorded on insert, and the instance is rebuilt with that class
  (looked up in a registry of `non_local_detector` model classes) rather than
  the base detector, so subclass-only parameters round-trip. The four `make()`
  construction sites accept the reconstructed instance (or a kwargs dict for
  legacy rows).

The class registry is built by mapping class names to classes across the
`non_local_detector` and `non_local_detector.models.base` namespaces. The
detector/classifier classes are `BaseEstimator` subclasses whose metaclass is
`ABCMeta`, so the name→class mapping selects classes with `isinstance(attr, type)`
(a metaclass-agnostic check); a stricter `type(attr) is type` style check would
silently exclude every `ABCMeta`-metaclassed detector and make reconstruction
raise `ValueError: Unknown decoder model class` for every current-format row.

**Backward compatibility:** rows serialized before this change carry no
`class_name`, so `restore_classes` returns the converted parameter dict and the
`make()` sites construct it with the base detector exactly as today.

## Tests

Added `tests/decoding/test_dj_decoder_conversion.py` (pure conversion-layer unit
tests; touch no tables/records, though importing the module opens a DataJoint
connection like the rest of the suite):

- `test_model_class_registry_contains_detectors` -- pins the metaclass
  regression: all four concrete detectors plus the two base classes resolve.
- `test_decoding_params_roundtrip` -- parametrized over the four defaults;
  serialize (mirroring `insert`) → `restore_classes` returns the correct
  **concrete** subclass, and for the NonLocal models asserts the subclass-only
  penalty parameters survive **by value** (non-default values set on input).
- `test_restore_classes_legacy_dict_returns_dict` -- legacy rows (no
  `class_name`) return a dict with nested classes (e.g. `Environment`) restored.
- `test_restore_classes_unknown_class_raises` -- an unknown class name fails
  loudly with `ValueError`.

Updated the existing `test_decode_param_fetch` and the session-scoped
`decode_clusterless_params_insert` fixture, which assumed `fetch1` returns a
dict, to the new reconstructed-instance return contract.

## Validation

- `python -m py_compile`, `ruff check`, and `black --check` pass on the changed
  files.
- The conversion layer was validated directly against `non_local_detector`
  0.6.10.dev332: `get_params()` exposes every key the converters require,
  excludes the derived mask, includes the NonLocal penalty parameters, and
  registry-based reconstruction rebuilds the correct subclass instance for all
  four defaults (ContFrag/NonLocal × Clusterless/Sorted).
- **Live-database round-trip validated.** Inserted all four default model
  instances into a real MySQL `LONGBLOB` (via the actual `convert_classes_to_dict`)
  and fetched them back through `restore_classes` on `datajoint` 0.14.9 +
  `non_local_detector` 0.6.10.dev332: each restored to the correct concrete
  subclass, with NonLocal's `non_local_position_penalty` preserved.
- **Not yet validated:** the full `*DecodingV1.make()` populate decoding a real
  recording end-to-end. That requires the decoding test suite to run against a
  database with neural-data fixtures; it could not be exercised locally because
  `import spyglass` currently fails under `spikeinterface` 0.104 (an unrelated,
  pre-existing `si.WaveformExtractor` annotation incompatibility on `master`).
  Before merge, the decoding tests and an `insert_default()` → `fetch()` →
  `make()` smoke for a NonLocal parameter set should be run against a test
  database. This is why the PR is a draft.

## This pairs with an upstream change

This pairs with LorenFrankLab/non_local_detector#43, which makes
`_frozen_discrete_transition_rows_mask_` lazy so it no longer appears in
`vars()`/`get_params()`. That change fixes the ContFrag defaults even for
`vars()`-based consumers; this PR additionally fixes the NonLocal defaults via
the class-based reconstruction. Either change is independently beneficial;
together they fully close the issue.

## Risks / possible issues

- For current-format rows, `fetch`/`fetch1` now return a constructed model
  instance rather than a parameter dict. This matches the existing "Return ...
  as a class" docstrings, and the only in-repo consumers are the four `make()`
  sites and the test/fixture updated here. External or notebook code that
  fetched `decoding_params` and indexed it as a dict would need to adapt. Legacy
  rows still return dicts.
- The approach assumes `non_local_detector` models honor the scikit-learn
  `get_params()` contract (constructor parameters stored as identically named
  attributes). The shipped detector/classifier classes do; a custom estimator
  that violates it could serialize incompletely.
- Legacy versioned rows can still fail downstream. `DecodingParameters` default
  names are version-stamped, so rows serialized under an older
  `non_local_detector` persist. The fallback returns them as dicts and
  constructs via the base detector, so a NonLocal row stored before this change
  could still raise on the subclass parameters, and a row from a version with a
  different state/count layout could trip `non_local_detector`'s state-count
  validation. Re-running `insert_default()` for the current version (and
  re-pointing selections) refreshes them.
- No schema or migration change. Only the (de)serialization of the existing
  `decoding_params` LONGBLOB is affected.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>



---

## ⚠️ Before merge — blocked on `non_local_detector` 0.7.0

This PR's serialization robustness targets behaviors that live on `non_local_detector`
**main, unreleased**: the `None`-default `clusterless_algorithm_params`, the `NonLocal*`
`non_local_position_penalty` / `non_local_penalty_std` params, and the frozen-rows mask.
The latest release is `0.6.9`, where none of these exist — so on the nld version CI
currently installs, the new `test_restore_classes_legacy_nonlocal_upgrades_to_concrete_class`
test **skips** and the `None`-guard path is not exercised.

**When `non_local_detector` 0.7.0 is released, pin it here** so CI installs a version that
actually exercises this code and users get a compatible nld. Change in **5 files**:

- [ ] `pyproject.toml`: `"non-local-detector",` → `"non-local-detector>=0.7.0,<0.8",  # 0.7.0: DecodingParameters serialization contract (#1618)`
- [ ] `environments/environment.yml`: `- non_local_detector` → `- non_local_detector>=0.7.0,<0.8`
- [ ] `environments/environment_dlc.yml`: same change
- [ ] `environments/environment_moseq_gpu.yml`: same change
- [ ] `environments/environment_moseq_cpu.yml`: same change

`<0.8` caps at the next minor (nld is pre-1.0 and breaks serialization across minors — this
PR is the 0.6→0.7 case). The pyproject (pip) pin goes green as soon as 0.7.0 is on PyPI; the
conda-env pins need 0.7.0 on conda-forge, which typically lags PyPI by a few days.
