### PR TITLE
fix(spikesorting v2): project probe to 2D in build_analyzer so unit_locations / GUI work

### DIFF
--- a/src/spyglass/spikesorting/v2/_sorting_compute.py
+++ b/src/spyglass/spikesorting/v2/_sorting_compute.py
@@ -764,6 +764,20 @@ def build_analyzer(
     if job_kwargs is None:
         job_kwargs = _resolved_job_kwargs(sorter_row["job_kwargs"])
 
+    # Project the probe to 2D before building the analyzer. Spyglass electrode
+    # geometry is stored in 3D (the z coordinate is typically 0), but several
+    # SortingAnalyzer extensions and consumers assume 2D contact positions:
+    # ``unit_locations`` (monopolar_triangulation / center_of_mass) and the
+    # spikeinterface-gui probe view both raise
+    # ``could not broadcast input array from shape (3,) into shape (2,)`` on a
+    # 3D probe. The in-plane (x, y) coordinates are unchanged by the projection,
+    # so sparsity, templates, and waveforms are unaffected; only the dropped
+    # all-zero z axis goes away. Done here (rather than at recording
+    # materialization) so the sort itself still sees the recording untouched.
+    probe = recording.get_probe()
+    if probe.ndim == 3:
+        recording = recording.set_probe(probe.to_2d())
+
     try:
         analyzer = si.create_sorting_analyzer(
             sorting=sorting,

--- a/tests/spikesorting/v2/test_build_analyzer_probe.py
+++ b/tests/spikesorting/v2/test_build_analyzer_probe.py
@@ -1,0 +1,69 @@
+"""``build_analyzer`` projects a 3D probe to 2D before building the analyzer.
+
+Spyglass stores electrode geometry in 3D (z is typically 0), but the
+SortingAnalyzer ``unit_locations`` extension and the spikeinterface-gui probe
+view assume 2D contact positions and raise
+``could not broadcast input array from shape (3,) into shape (2,)`` on a 3D
+probe. ``build_analyzer`` projects the probe to 2D so both work; this is the
+regression guard. It is a fast, DB-free unit test: it drives ``build_analyzer``
+directly with a synthetic recording carrying a 3D probe, passing ``sorter_row``
+/ ``job_kwargs`` / ``analyzer_folder`` so no database read happens.
+"""
+
+from __future__ import annotations
+
+import pytest
+import spikeinterface.full as si
+
+from spyglass.spikesorting.v2._sorting_compute import build_analyzer
+
+
+@pytest.fixture
+def recording_3d_and_sorting():
+    """A synthetic recording (forced to a 3D probe) and its sorting."""
+    recording, sorting = si.generate_ground_truth_recording(
+        durations=[10.0], num_channels=8, num_units=4, seed=0
+    )
+    recording = recording.set_probe(recording.get_probe().to_3d(axes="xy"))
+    assert recording.get_probe().ndim == 3
+    return recording, sorting
+
+
+class TestBuildAnalyzerProbeProjection:
+    def test_analyzer_probe_is_2d(self, recording_3d_and_sorting, tmp_path):
+        recording, sorting = recording_3d_and_sorting
+        folder = tmp_path / "sort.analyzer"
+
+        build_analyzer(
+            sorting,
+            recording,
+            key={"sorting_id": "test-3d-probe"},
+            sorter_row={"job_kwargs": {}},
+            job_kwargs={},
+            analyzer_folder=folder,
+        )
+
+        analyzer = si.load_sorting_analyzer(folder)
+        assert analyzer.get_probe().ndim == 2
+
+    def test_unit_locations_computes_after_projection(
+        self, recording_3d_and_sorting, tmp_path
+    ):
+        # Without the 2D projection this raises ValueError:
+        # "could not broadcast input array from shape (3,) into shape (2,)".
+        recording, sorting = recording_3d_and_sorting
+        folder = tmp_path / "sort.analyzer"
+
+        build_analyzer(
+            sorting,
+            recording,
+            key={"sorting_id": "test-3d-probe"},
+            sorter_row={"job_kwargs": {}},
+            job_kwargs={},
+            analyzer_folder=folder,
+        )
+
+        analyzer = si.load_sorting_analyzer(folder)
+        analyzer.compute("unit_locations")
+        unit_locations = analyzer.get_extension("unit_locations").get_data()
+        assert unit_locations.shape[0] == sorting.get_num_units()


### PR DESCRIPTION
Targets the Spike Sorting v2 branch (#1609).

While driving the v2 single-session pipeline into a manual-curation pass in `spikeinterface-gui`, I hit this: the `SortingAnalyzer` that `build_analyzer` creates — and that `Sorting.get_analyzer` returns — carries a **3D probe**, because Spyglass stores electrode geometry with a z coordinate (typically 0). The build succeeds, but computing `unit_locations` on it, or opening it in `spikeinterface-gui`, raises:

```
ValueError: could not broadcast input array from shape (3,) into shape (2,)
```

The localization estimators (`monopolar_triangulation` / `center_of_mass`) and the GUI probe view assume 2D contact positions.

**Fix:** project the probe to 2D (`axes="xy"`) before `create_sorting_analyzer` when it is 3D. In-plane x/y are unchanged, so sparsity/templates/waveforms are unaffected — only the all-zero z axis is dropped. Confined to the analyzer build, so the sort still sees the untouched recording. Adds a DB-free regression test driving `build_analyzer` with a synthetic 3D-probe recording.