### PR TITLE
fix(install): prevent silent stall during conda environment creation

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -653,13 +653,17 @@ class CondaManager:
             package_spec = f"{package_spec}[{','.join(extras)}]"
 
         # Stream pip's output directly to the terminal so progress and any
-        # errors stay visible; capturing it hid a multi-minute install behind
-        # a silent prompt, indistinguishable from a stall.
+        # errors stay visible; hiding it made a multi-minute install
+        # indistinguishable from a stall. `conda run` buffers the child's
+        # output by default, so "--no-capture-output" is required for it to
+        # actually stream (not capturing at the subprocess layer is not
+        # enough on its own).
         try:
             subprocess.run(
                 [
                     conda_cmd,
                     "run",
+                    "--no-capture-output",
                     "-n",
                     self.env_name,
                     "pip",

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -608,8 +608,13 @@ class CondaManager:
 
         env_file_path = REPO_ROOT / env_file
 
+        # Let conda stream its own progress/prompts directly to the terminal.
+        # Capturing its output (the previous behavior) hid conda's
+        # confirmation prompt, so `conda env create` blocked invisibly on
+        # stdin and the installer appeared to stall with no report. "-y"
+        # auto-confirms so the command runs non-interactively.
         try:
-            with subprocess.Popen(
+            subprocess.run(
                 [
                     conda_cmd,
                     "env",
@@ -618,25 +623,10 @@ class CondaManager:
                     str(env_file_path),
                     "-n",
                     self.env_name,
+                    "-y",
                 ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-            ) as process:
-                for line in process.stdout:
-                    if any(
-                        kw in line
-                        for kw in ["Solving", "Downloading", "Extracting"]
-                    ):
-                        print(".", end="", flush=True)
-                Console.print("")
-
-            if process.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    process.returncode, conda_cmd
-                )
-
+                check=True,
+            )
             Console.success(f"Environment '{self.env_name}' created")
 
         except subprocess.CalledProcessError as e:

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -651,6 +651,10 @@ class CondaManager:
         package_spec = str(REPO_ROOT)
         if extras:
             package_spec = f"{package_spec}[{','.join(extras)}]"
+
+        # Stream pip's output directly to the terminal so progress and any
+        # errors stay visible; capturing it hid a multi-minute install behind
+        # a silent prompt, indistinguishable from a stall.
         try:
             subprocess.run(
                 [
@@ -664,45 +668,18 @@ class CondaManager:
                     package_spec,
                 ],
                 check=True,
-                capture_output=True,
-                text=True,
             )
             Console.success("Spyglass installed")
         except subprocess.CalledProcessError as e:
-            error_output = e.stderr if e.stderr else str(e)
-            error_lower = error_output.lower()
-
-            # Platform-specific disk space command
             disk_space_cmd = "dir" if sys.platform == "win32" else "df -h"
-
-            if "no space left" in error_lower or "disk" in error_lower:
-                primary_cause = "Disk space is full"
-                primary_fix = (
-                    f"Free up disk space: {disk_space_cmd} shows usage"
-                )
-            elif "connection" in error_lower or "timeout" in error_lower:
-                primary_cause = "Network connection issue"
-                primary_fix = "Check internet connection and retry"
-            elif "permission" in error_lower or "access" in error_lower:
-                primary_cause = "Permission denied"
-                primary_fix = "Check write permissions in the install directory"
-            else:
-                primary_cause = "Package installation failed"
-                primary_fix = (
-                    f"Update pip: {conda_cmd} run -n {self.env_name} "
-                    "pip install --upgrade pip"
-                )
-
             raise RuntimeError(
-                f"Failed to install spyglass package.\n\n"
-                f"Most likely cause: {primary_cause}\n"
-                f"Recommended fix: {primary_fix}\n\n"
-                f"If that doesn't help, try these steps:\n"
+                "Failed to install spyglass package. "
+                "See the pip output above for the specific error.\n\n"
+                "Common fixes:\n"
                 f"  1. Update pip: {conda_cmd} run -n {self.env_name} pip install --upgrade pip\n"
                 f"  2. Check disk space: {disk_space_cmd}\n"
-                f"  3. Check network connection\n"
-                f"  4. Retry the installation\n\n"
-                f"Error details: {error_output[:500]}"
+                "  3. Check network connection\n"
+                "  4. Retry the installation"
             ) from e
 
 

--- a/tests/setup/test_install.py
+++ b/tests/setup/test_install.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(scripts_dir))
 
 from install import (
     CondaManager,
+    Console,
     DockerManager,
     Validators,
     build_directory_structure,
@@ -164,21 +165,59 @@ class TestCondaManagerCreate:
         """A failed create surfaces an actionable RuntimeError."""
         mock_create.side_effect = subprocess.CalledProcessError(1, "conda")
 
-        with pytest.raises(
-            RuntimeError, match="Failed to create environment"
-        ):
+        with pytest.raises(RuntimeError, match="Failed to create environment"):
             CondaManager("spyglass-test").create(
                 "environments/environment_min.yml", force=True
             )
+
+    def test_existing_env_declined_skips_create_and_remove(self):
+        """Declining the overwrite prompt must not destroy or recreate the env.
+
+        The overwrite path runs the destructive `conda env remove`; a user who
+        answers "no" must keep their environment untouched (no remove, no
+        create).
+        """
+        with (
+            patch("install.subprocess.run") as mock_run,
+            patch.object(CondaManager, "exists", return_value=True),
+            patch.object(CondaManager, "get_command", return_value="conda"),
+            patch.object(CondaManager, "remove") as mock_remove,
+            patch.object(Console, "prompt_yes_no", return_value=False),
+        ):
+            CondaManager("spyglass-test").create(
+                "environments/environment_min.yml", force=False
+            )
+
+        mock_remove.assert_not_called()
+        mock_run.assert_not_called()
+
+    def test_force_removes_existing_env_before_create(self):
+        """force=True removes the existing env, then creates a fresh one."""
+        with (
+            patch("install.subprocess.run") as mock_run,
+            patch.object(CondaManager, "exists", return_value=True),
+            patch.object(CondaManager, "get_command", return_value="conda"),
+            patch.object(CondaManager, "remove") as mock_remove,
+        ):
+            mock_run.return_value = Mock(returncode=0)
+            CondaManager("spyglass-test").create(
+                "environments/environment_min.yml", force=True
+            )
+
+        mock_remove.assert_called_once()
+        assert mock_run.call_args.args[0][:3] == ["conda", "env", "create"]
 
 
 class TestCondaManagerInstallPackage:
     """Tests for CondaManager.install_package().
 
     Like environment creation, the editable install can run for a while;
-    capturing its output (the previous behavior) left users staring at a
-    silent terminal with no way to tell "slow" from "stalled". The install
-    must stream its output so progress and any pip errors stay visible.
+    capturing its output left users staring at a silent terminal with no way
+    to tell "slow" from "stalled". The install must stream its output so
+    progress and any pip errors stay visible. Because the install runs via
+    ``conda run`` -- which buffers the child's stdout/stderr by default --
+    streaming requires both not capturing at the ``subprocess.run`` layer and
+    passing ``--no-capture-output`` to ``conda run``.
     """
 
     @pytest.fixture
@@ -200,14 +239,18 @@ class TestCondaManagerInstallPackage:
         assert not kwargs.get("capture_output", False)
         assert kwargs.get("stdout") is None
         assert kwargs.get("stderr") is None
+        # conda run buffers by default; this flag is what actually makes pip
+        # stream live through the wrapper.
+        assert "--no-capture-output" in mock_install.call_args.args[0]
 
     def test_installs_editable_local_package(self, mock_install):
         """Runs `pip install -e` inside the target environment."""
         CondaManager("spyglass-test").install_package()
 
         cmd = mock_install.call_args.args[0]
-        assert cmd[:5] == ["conda", "run", "-n", "spyglass-test", "pip"]
-        assert "install" in cmd and "-e" in cmd
+        assert cmd[:3] == ["conda", "run", "--no-capture-output"]
+        assert cmd[3:5] == ["-n", "spyglass-test"]
+        assert cmd[5:8] == ["pip", "install", "-e"]
 
     def test_extras_appended_to_package_spec(self, mock_install):
         """Optional extras are appended to the editable spec."""
@@ -220,9 +263,7 @@ class TestCondaManagerInstallPackage:
         """A failed install surfaces an actionable RuntimeError."""
         mock_install.side_effect = subprocess.CalledProcessError(1, "pip")
 
-        with pytest.raises(
-            RuntimeError, match="Failed to install spyglass"
-        ):
+        with pytest.raises(RuntimeError, match="Failed to install spyglass"):
             CondaManager("spyglass-test").install_package()
 
 

--- a/tests/setup/test_install.py
+++ b/tests/setup/test_install.py
@@ -172,6 +172,60 @@ class TestCondaManagerCreate:
             )
 
 
+class TestCondaManagerInstallPackage:
+    """Tests for CondaManager.install_package().
+
+    Like environment creation, the editable install can run for a while;
+    capturing its output (the previous behavior) left users staring at a
+    silent terminal with no way to tell "slow" from "stalled". The install
+    must stream its output so progress and any pip errors stay visible.
+    """
+
+    @pytest.fixture
+    def mock_install(self):
+        """Isolate install_package() from a real conda/pip invocation."""
+        with (
+            patch("install.subprocess.run") as mock_run,
+            patch.object(CondaManager, "get_command", return_value="conda"),
+        ):
+            mock_run.return_value = Mock(returncode=0)
+            yield mock_run
+
+    def test_streams_output_not_captured(self, mock_install):
+        """pip output must stream to the terminal, not into a hidden pipe."""
+        CondaManager("spyglass-test").install_package()
+
+        assert mock_install.called
+        kwargs = mock_install.call_args.kwargs
+        assert not kwargs.get("capture_output", False)
+        assert kwargs.get("stdout") is None
+        assert kwargs.get("stderr") is None
+
+    def test_installs_editable_local_package(self, mock_install):
+        """Runs `pip install -e` inside the target environment."""
+        CondaManager("spyglass-test").install_package()
+
+        cmd = mock_install.call_args.args[0]
+        assert cmd[:5] == ["conda", "run", "-n", "spyglass-test", "pip"]
+        assert "install" in cmd and "-e" in cmd
+
+    def test_extras_appended_to_package_spec(self, mock_install):
+        """Optional extras are appended to the editable spec."""
+        CondaManager("spyglass-test").install_package(extras=["kachery-cloud"])
+
+        spec = mock_install.call_args.args[0][-1]
+        assert spec.endswith("[kachery-cloud]")
+
+    def test_raises_helpful_error_on_failure(self, mock_install):
+        """A failed install surfaces an actionable RuntimeError."""
+        mock_install.side_effect = subprocess.CalledProcessError(1, "pip")
+
+        with pytest.raises(
+            RuntimeError, match="Failed to install spyglass"
+        ):
+            CondaManager("spyglass-test").install_package()
+
+
 # =============================================================================
 # Base Directory Resolution Tests
 # =============================================================================

--- a/tests/setup/test_install.py
+++ b/tests/setup/test_install.py
@@ -100,6 +100,78 @@ class TestCondaManagerGetCommand:
                 CondaManager.get_command()
 
 
+class TestCondaManagerCreate:
+    """Regression tests for the installer stalling during env creation.
+
+    ``conda env create`` prompts for confirmation by default. The original
+    implementation captured conda's stdout/stderr into a hidden pipe while
+    passing no auto-confirm flag, so conda blocked reading stdin with its
+    prompt invisible -- a silent deadlock users experienced as the installer
+    "stalling" with no output. ``create()`` must run non-interactively (``-y``)
+    and must not capture conda's output, so prompts/progress/errors stay
+    visible on the terminal.
+    """
+
+    @pytest.fixture
+    def mock_create(self):
+        """Isolate ``create()`` from real conda.
+
+        Stubs the existence/command lookups and neuters the legacy ``Popen``
+        path so neither the old nor new implementation can launch conda.
+        Yields the ``subprocess.run`` mock for assertions.
+        """
+        with (
+            patch("install.subprocess.run") as mock_run,
+            patch("install.subprocess.Popen") as mock_popen,
+            patch.object(CondaManager, "exists", return_value=False),
+            patch.object(CondaManager, "get_command", return_value="conda"),
+        ):
+            mock_run.return_value = Mock(returncode=0)
+            legacy = mock_popen.return_value.__enter__.return_value
+            legacy.stdout = iter(())
+            legacy.returncode = 0
+            yield mock_run
+
+    def test_passes_yes_flag_for_noninteractive_create(self, mock_create):
+        """create() auto-confirms so conda never blocks on its prompt."""
+        CondaManager("spyglass-test").create(
+            "environments/environment_min.yml", force=True
+        )
+
+        assert mock_create.called, (
+            "create() must run conda via streaming subprocess.run, "
+            "not a captured Popen pipe"
+        )
+        cmd = mock_create.call_args.args[0]
+        assert cmd[:3] == ["conda", "env", "create"]
+        assert "-y" in cmd or "--yes" in cmd, (
+            "env create must auto-confirm; otherwise conda blocks on its "
+            "'Proceed ([y]/n)?' prompt and the installer stalls silently"
+        )
+
+    def test_does_not_capture_conda_output(self, mock_create):
+        """Conda's output must stream to the terminal, not into a pipe."""
+        CondaManager("spyglass-test").create(
+            "environments/environment_min.yml", force=True
+        )
+
+        kwargs = mock_create.call_args.kwargs
+        assert not kwargs.get("capture_output", False)
+        assert kwargs.get("stdout") is None
+        assert kwargs.get("stderr") is None
+
+    def test_raises_helpful_error_on_failure(self, mock_create):
+        """A failed create surfaces an actionable RuntimeError."""
+        mock_create.side_effect = subprocess.CalledProcessError(1, "conda")
+
+        with pytest.raises(
+            RuntimeError, match="Failed to create environment"
+        ):
+            CondaManager("spyglass-test").create(
+                "environments/environment_min.yml", force=True
+            )
+
+
 # =============================================================================
 # Base Directory Resolution Tests
 # =============================================================================


### PR DESCRIPTION
## Problem

Users reported `scripts/install.py` **stalling with no output during environment creation**. They could create the conda env manually with `conda env create` without issue.

## Root cause

`CondaManager.create()` ran `conda env create` while capturing its stdout/stderr into a pipe (printing only `.` for keyword-matching lines) and passing **no `-y` flag**. In conda 26.x, `conda env create` prompts `Proceed ([y]/n)?` by default:

1. The prompt was written into the **invisible** captured pipe (the keyword filter never matched it, and with no trailing newline the read loop never yielded it).
2. conda then **blocked reading the inherited terminal stdin**, waiting for a `y` the user couldn't see they needed to type.
3. The parent **blocked reading stdout**.

→ permanent stall, no report. Running conda manually worked because it inherits the TTY and shows the prompt. I reproduced the deadlock with a minimal harness (a fake child that prompts without a newline then reads stdin → confirmed hang).

## Fix

- **`create()`**: stream `conda env create` output directly to the terminal (so progress, prompts, and errors stay visible) and pass `-y` to run non-interactively. Mirrors the sibling `remove()`, which already used `-y`.
- **`install_package()` (follow-up)**: the editable `pip install -e` ran via `conda run`, which **buffers child output by default**, so a multi-minute install looked like a stall too. Stream it by dropping `capture_output` *and* passing `conda run --no-capture-output` (the flag is required — not capturing at the subprocess layer alone is not enough). Verified on conda 26.5.2 that the inner exit code still propagates, so `check=True` stays reliable. The error handler now points at the now-visible pip output instead of parsing captured stderr.

## Tests

`create()` and `install_package()` previously had **zero** coverage. Added `TestCondaManagerCreate` and `TestCondaManagerInstallPackage`:
- `create()` passes `-y`, does not capture output, raises a helpful `RuntimeError` on failure, and — for the destructive overwrite path — does **not** run `conda env remove`/create when the user declines, and removes-before-create under `--force`.
- `install_package()` streams (`--no-capture-output`, no capture), runs `pip install -e` in the env, appends extras, and raises a helpful `RuntimeError` on failure.

**157/157** install tests pass; black-clean (line-length 80); `--dry-run` verified.

## Review

Reviewed with the pr-review-toolkit agents (code / errors / comments / tests). The `conda run --no-capture-output` gap and the missing destructive-path coverage were review findings, now addressed; the loss of stderr-based error classification was evaluated and accepted (the real error now streams live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)