### PR TITLE
Add EEG/EMG ingestion (common_eeg.ImportedEEG)

### DIFF
--- a/src/spyglass/common/__init__.py
+++ b/src/spyglass/common/__init__.py
@@ -19,6 +19,7 @@ from spyglass.common.common_device import (
     ProbeType,
 )
 from spyglass.common.common_dio import DIOEvents
+from spyglass.common.common_eeg import ImportedEEG
 from spyglass.common.common_ephys import (
     LFP,
     Electrode,
@@ -87,6 +88,7 @@ from spyglass.utils.nwb_helper_fn import (
 __all__ = [
     "AnalysisFileIssues",
     "AnalysisRegistry",
+    "ImportedEEG",
     "LabTeam",
     "LinearizationParameters",
     "Nwbfile",

--- a/src/spyglass/common/common_eeg.py
+++ b/src/spyglass/common/common_eeg.py
@@ -1,0 +1,199 @@
+"""Ingestion for chronic-EEG (and co-recorded EMG) signals stored as a raw
+``ElectricalSeries`` in ``nwbfile.acquisition``.
+
+Unlike the LFP pipeline, EEG telemetry is already low-pass filtered/downsampled
+at acquisition, so it is referenced as-is rather than re-filtered. The trace
+stays in the NWB file; ``ImportedEEG`` indexes it by ``object_id`` and records a
+valid-times ``IntervalList`` so it can be time-restricted against the rest of
+Spyglass. Per-channel metadata is *not* duplicated: the ``.Electrode`` part maps
+each series column to the ``common_ephys.Electrode`` row already ingested from
+the file's standard ``electrodes`` table (which carries the EEG/EMG group split).
+
+This targets the probe-less skull-screw / array montages used in chronic-EEG
+setups (e.g. ``DANDI:001888``), where the electrodes group onto a plain
+``Device`` rather than a ``Probe``.
+"""
+
+import datajoint as dj
+import numpy as np
+import pynwb
+
+from spyglass.common.common_ephys import (  # noqa: F401
+    Electrode as CommonElectrode,
+)
+from spyglass.common.common_interval import IntervalList
+from spyglass.common.common_nwbfile import Nwbfile
+from spyglass.common.common_session import Session  # noqa: F401
+from spyglass.utils import SpyglassIngestion, logger
+from spyglass.utils.nwb_helper_fn import estimate_sampling_rate, get_nwb_file
+
+schema = dj.schema("common_eeg")
+
+
+@schema
+class ImportedEEG(SpyglassIngestion, dj.Imported):
+    definition = """
+    # Reference to a raw EEG/telemetry ElectricalSeries in nwbfile.acquisition.
+    # The trace stays in the NWB file; this row indexes it (no filtering applied,
+    # unlike the LFP pipeline) so it can be time-restricted against Spyglass.
+    -> Session
+    eeg_object_id: varchar(40)          # NWB ElectricalSeries object_id
+    ---
+    -> IntervalList                     # the series' valid (recorded) times
+    eeg_sampling_rate: float            # samples/sec
+    name: varchar(80)
+    description: varchar(2000)
+    num_samples: bigint
+    unit: varchar(16)
+    """
+
+    # FKs -> Session (not Nwbfile), so point fetch_nwb() at the file explicitly,
+    # as Raw does.
+    _nwb_table = Nwbfile
+    _source_nwb_object_type = pynwb.ecephys.ElectricalSeries
+
+    class Electrode(SpyglassIngestion, dj.Part):
+        definition = """
+        # One column of the series -> the common_ephys.Electrode it records.
+        # Reuses the already-ingested electrode rows, so the EEG/EMG group split,
+        # region, and hemisphere ride along without duplicated metadata.
+        -> master
+        region_index: int               # 0-based column within the series
+        ---
+        -> CommonElectrode
+        """
+
+    def make(self, key):
+        """Standard Imported entry point.
+
+        ``populate_all_common`` drives ingestion through ``insert_from_nwbfile``;
+        ``dj.Imported`` tables are also expected to support ``populate()``.
+        Delegate to the same path (as ``Raw`` does) so both work.
+        """
+        self.insert_from_nwbfile(key["nwb_file_name"])
+
+    def get_nwb_objects(self, nwb_file, nwb_file_name=None):
+        """Acquisition ElectricalSeries that ``Raw`` does not claim.
+
+        There is no NWB-native "this is EEG" marker, so selection is by exclusion:
+        an ``acquisition`` ``ElectricalSeries`` whose (sanitized) name is not in
+        ``Raw``'s wideband-ephys allowlist. This is safe on standard Frank-lab
+        files (whose only acquisition series is the Raw-named wideband) and picks
+        up dedicated EEG telemetry series. It remains a heuristic: a file with a
+        second genuine raw series would be miscaught -- prefer a naming convention
+        or ingestion config when the producer can provide one.
+        """
+        from spyglass.common.common_ephys import Raw
+
+        raw_names = {
+            self.sanitize_nwb_object_name(n)
+            for n in Raw._source_nwb_object_name
+        }
+        return [
+            obj
+            for obj in nwb_file.acquisition.values()
+            if isinstance(obj, pynwb.ecephys.ElectricalSeries)
+            and self.sanitize_nwb_object_name(obj.name) not in raw_names
+        ]
+
+    def generate_entries_from_nwb_object(self, nwb_obj, base_key=None):
+        """Emit the ``IntervalList`` + master + ``.Electrode`` rows for one series.
+
+        The master stores the object id + trace metadata and references an
+        ``IntervalList`` of the series' valid (recorded) times (as ``Raw`` does).
+        Each series column becomes an ``.Electrode`` row mapping the 0-based
+        ``region_index`` to the ``common_ephys.Electrode`` it records, translated
+        from the ``.electrodes`` region's positional index to the electrode's
+        ``(group_name, id)``. A series without an ``.electrodes`` region inserts
+        the master row only, with a warning.
+        """
+        base_key = (base_key or {}).copy()
+        series = nwb_obj
+        object_id = series.object_id
+        rate = series.rate or estimate_sampling_rate(
+            np.asarray(series.get_timestamps()[: int(1e6)])
+        )
+        interval_list_name = f"{series.name} valid times"
+
+        interval_entry = dict(
+            base_key,
+            interval_list_name=interval_list_name,
+            valid_times=self._valid_times(series, rate),
+            pipeline="imported_eeg",
+        )
+        master_row = dict(
+            base_key,
+            eeg_object_id=object_id,
+            interval_list_name=interval_list_name,
+            eeg_sampling_rate=rate,
+            name=series.name,
+            description=getattr(series, "description", None),
+            num_samples=int(series.data.shape[0]),
+            unit=series.unit,
+        )
+
+        elec_rows = []
+        region = getattr(series, "electrodes", None)
+        if region is None:
+            logger.warning(
+                f"ImportedEEG {series.name!r}: no .electrodes region; storing the "
+                "signal reference without per-channel Electrode links."
+            )
+        else:
+            table = region.table
+            electrode_ids = np.asarray(table.id.data)
+            group_names = table["group_name"].data
+            for region_index, positional in enumerate(region.data):
+                position = int(positional)
+                # A negative index would silently wrap; an out-of-range one would
+                # mis-map. Fail loud and named instead.
+                if not 0 <= position < len(electrode_ids):
+                    raise ValueError(
+                        f"ImportedEEG {series.name!r}: region position "
+                        f"{positional} is out of range for the "
+                        f"{len(electrode_ids)}-row electrodes table."
+                    )
+                elec_rows.append(
+                    dict(
+                        base_key,
+                        eeg_object_id=object_id,
+                        region_index=region_index,
+                        electrode_group_name=str(group_names[position]),
+                        electrode_id=int(electrode_ids[position]),
+                    )
+                )
+
+        # IntervalList before the master (the master FKs it); .Electrode last and
+        # always present (possibly empty) so the multi-object insert loop can
+        # extend every key across series.
+        return {
+            IntervalList: [interval_entry],
+            self: [master_row],
+            self.Electrode: elec_rows,
+        }
+
+    @staticmethod
+    def _valid_times(series, rate):
+        """The series' recorded-time span as a single contiguous ``[start, end]``
+        interval (EEG acquisition is continuous).
+
+        A rate-based series computes its endpoints in O(1) from
+        ``starting_time``/``rate``; an explicit-``timestamps`` series uses its
+        first/last timestamp.
+        """
+        if series.timestamps is not None:
+            timestamps = np.asarray(series.timestamps)
+            return np.array([[timestamps[0], timestamps[-1]]])
+        start = series.starting_time or 0.0
+        end = start + (int(series.data.shape[0]) - 1) / rate
+        return np.array([[start, end]])
+
+    def nwb_object(self, key):
+        """Return the ``ElectricalSeries`` NWB object for one row.
+
+        Uses the full key (``eeg_object_id``): a file may hold several acquisition
+        series, so a ``nwb_file_name``-only fetch would be ambiguous.
+        """
+        object_id = (self & key).fetch1("eeg_object_id")
+        nwbf = get_nwb_file(Nwbfile.get_abs_path(key["nwb_file_name"]))
+        return nwbf.objects[object_id]

--- a/src/spyglass/common/common_eeg.py
+++ b/src/spyglass/common/common_eeg.py
@@ -55,8 +55,8 @@ class ImportedEEG(SpyglassIngestion, dj.Imported):
     class Electrode(SpyglassIngestion, dj.Part):
         definition = """
         # One column of the series -> the common_ephys.Electrode it records.
-        # Reuses the already-ingested electrode rows, so the EEG/EMG group split,
-        # region, and hemisphere ride along without duplicated metadata.
+        # Reuses the already-ingested electrode rows, so the EEG/EMG group split
+        # and brain region ride along without duplicated metadata.
         -> master
         region_index: int               # 0-based column within the series
         ---
@@ -89,12 +89,22 @@ class ImportedEEG(SpyglassIngestion, dj.Imported):
             self.sanitize_nwb_object_name(n)
             for n in Raw._source_nwb_object_name
         }
-        return [
+        selected = [
             obj
             for obj in nwb_file.acquisition.values()
             if isinstance(obj, pynwb.ecephys.ElectricalSeries)
             and self.sanitize_nwb_object_name(obj.name) not in raw_names
         ]
+        # Make the heuristic's action discoverable: a stray/second acquisition
+        # series is claimed as EEG silently otherwise (this runs on every file).
+        if selected:
+            logger.warning(
+                "ImportedEEG: selecting acquisition ElectricalSeries "
+                f"{[o.name for o in selected]} as EEG by name-exclusion "
+                "heuristic; verify these are EEG/telemetry, not a second "
+                "raw/analog series."
+            )
+        return selected
 
     def generate_entries_from_nwb_object(self, nwb_obj, base_key=None):
         """Emit the ``IntervalList`` + master + ``.Electrode`` rows for one series.
@@ -104,14 +114,20 @@ class ImportedEEG(SpyglassIngestion, dj.Imported):
         Each series column becomes an ``.Electrode`` row mapping the 0-based
         ``region_index`` to the ``common_ephys.Electrode`` it records, translated
         from the ``.electrodes`` region's positional index to the electrode's
-        ``(group_name, id)``. A series without an ``.electrodes`` region inserts
-        the master row only, with a warning.
+        ``(group_name, id)``.
         """
         base_key = (base_key or {}).copy()
         series = nwb_obj
         object_id = series.object_id
-        rate = series.rate or estimate_sampling_rate(
-            np.asarray(series.get_timestamps()[: int(1e6)])
+        # Read series.timestamps directly (not get_timestamps()) to match
+        # _valid_times, and use `is not None` so an explicit rate of 0.0 is
+        # preserved rather than silently re-estimated (mirrors Raw._rate_fallback).
+        rate = (
+            series.rate
+            if series.rate is not None
+            else estimate_sampling_rate(
+                np.asarray(series.timestamps[: int(1e6)])
+            )
         )
         interval_list_name = f"{series.name} valid times"
 
@@ -132,36 +148,46 @@ class ImportedEEG(SpyglassIngestion, dj.Imported):
             unit=series.unit,
         )
 
-        elec_rows = []
-        region = getattr(series, "electrodes", None)
-        if region is None:
+        # An ElectricalSeries always carries an .electrodes region (required by
+        # NWB), so map each series column to the common_ephys.Electrode it records.
+        region = series.electrodes
+        table = region.table
+        electrode_ids = np.asarray(table.id.data)
+        group_names = table["group_name"].data
+
+        # The region should list one electrode per trace column; a mismatch means
+        # some columns can't be mapped (or extra rows go unused), so region_index
+        # would no longer track the trace column. Warn rather than silently
+        # mis-map (mirrors the photometry response-series ingestion).
+        n_columns = series.data.shape[1] if series.data.ndim == 2 else 1
+        if len(region.data) != n_columns:
             logger.warning(
-                f"ImportedEEG {series.name!r}: no .electrodes region; storing the "
-                "signal reference without per-channel Electrode links."
+                f"ImportedEEG {series.name!r}: .electrodes region maps "
+                f"{len(region.data)} channel(s) but the trace has {n_columns} "
+                "column(s); the region_index -> Electrode mapping may be wrong."
             )
-        else:
-            table = region.table
-            electrode_ids = np.asarray(table.id.data)
-            group_names = table["group_name"].data
-            for region_index, positional in enumerate(region.data):
-                position = int(positional)
-                # A negative index would silently wrap; an out-of-range one would
-                # mis-map. Fail loud and named instead.
-                if not 0 <= position < len(electrode_ids):
-                    raise ValueError(
-                        f"ImportedEEG {series.name!r}: region position "
-                        f"{positional} is out of range for the "
-                        f"{len(electrode_ids)}-row electrodes table."
-                    )
-                elec_rows.append(
-                    dict(
-                        base_key,
-                        eeg_object_id=object_id,
-                        region_index=region_index,
-                        electrode_group_name=str(group_names[position]),
-                        electrode_id=int(electrode_ids[position]),
-                    )
+
+        elec_rows = []
+        for region_index, positional in enumerate(region.data):
+            position = int(positional)
+            # A negative index would silently wrap to the wrong electrode; an
+            # out-of-range one would raise a cryptic IndexError. Fail loud and
+            # named for both.
+            if not 0 <= position < len(electrode_ids):
+                raise ValueError(
+                    f"ImportedEEG {series.name!r}: region position "
+                    f"{positional} is out of range for the "
+                    f"{len(electrode_ids)}-row electrodes table."
                 )
+            elec_rows.append(
+                dict(
+                    base_key,
+                    eeg_object_id=object_id,
+                    region_index=region_index,
+                    electrode_group_name=str(group_names[position]),
+                    electrode_id=int(electrode_ids[position]),
+                )
+            )
 
         # IntervalList before the master (the master FKs it); .Electrode last and
         # always present (possibly empty) so the multi-object insert loop can

--- a/src/spyglass/common/common_eeg.py
+++ b/src/spyglass/common/common_eeg.py
@@ -25,9 +25,19 @@ from spyglass.common.common_interval import IntervalList
 from spyglass.common.common_nwbfile import Nwbfile
 from spyglass.common.common_session import Session  # noqa: F401
 from spyglass.utils import SpyglassIngestion, logger
-from spyglass.utils.nwb_helper_fn import estimate_sampling_rate, get_nwb_file
+from spyglass.utils.nwb_helper_fn import (
+    estimate_sampling_rate,
+    get_nwb_file,
+    get_valid_intervals,
+)
 
 schema = dj.schema("common_eeg")
+
+# An acquisition ElectricalSeries is treated as EEG when its channels sit in an
+# ElectrodeGroup whose name carries one of these tokens. Selection keys on the
+# *group* name, not the series name: real files name the series opaquely (e.g.
+# "ElectricalSeries_BL2") while the montage lives in "EEGArray"/"EMGArray".
+_EEG_GROUP_TOKENS = ("eeg", "emg")
 
 
 @schema
@@ -73,38 +83,33 @@ class ImportedEEG(SpyglassIngestion, dj.Imported):
         self.insert_from_nwbfile(key["nwb_file_name"])
 
     def get_nwb_objects(self, nwb_file, nwb_file_name=None):
-        """Acquisition ElectricalSeries that ``Raw`` does not claim.
+        """Acquisition ElectricalSeries whose channels are EEG/EMG electrodes.
 
-        There is no NWB-native "this is EEG" marker, so selection is by exclusion:
-        an ``acquisition`` ``ElectricalSeries`` whose (sanitized) name is not in
-        ``Raw``'s wideband-ephys allowlist. This is safe on standard Frank-lab
-        files (whose only acquisition series is the Raw-named wideband) and picks
-        up dedicated EEG telemetry series. It remains a heuristic: a file with a
-        second genuine raw series would be miscaught -- prefer a naming convention
-        or ingestion config when the producer can provide one.
+        Selection keys on the referenced ``ElectrodeGroup`` name (matching
+        ``eeg``/``emg``, case-insensitive), not the series name: in real files
+        the series may be named opaquely (e.g. ``ElectricalSeries_BL2``) while
+        the montage lives in ``EEGArray``/``EMGArray`` groups. Probe-ephys and
+        analog/aux series (non-EEG group names) are excluded, so wiring this into
+        ``populate_all_common`` does not claim a stray acquisition series -- but
+        it does require the producer to name EEG/EMG groups accordingly.
         """
-        from spyglass.common.common_ephys import Raw
-
-        raw_names = {
-            self.sanitize_nwb_object_name(n)
-            for n in Raw._source_nwb_object_name
-        }
-        selected = [
+        return [
             obj
             for obj in nwb_file.acquisition.values()
             if isinstance(obj, pynwb.ecephys.ElectricalSeries)
-            and self.sanitize_nwb_object_name(obj.name) not in raw_names
+            and self._references_eeg_group(obj)
         ]
-        # Make the heuristic's action discoverable: a stray/second acquisition
-        # series is claimed as EEG silently otherwise (this runs on every file).
-        if selected:
-            logger.warning(
-                "ImportedEEG: selecting acquisition ElectricalSeries "
-                f"{[o.name for o in selected]} as EEG by name-exclusion "
-                "heuristic; verify these are EEG/telemetry, not a second "
-                "raw/analog series."
-            )
-        return selected
+
+    @staticmethod
+    def _references_eeg_group(series):
+        """Whether any electrode the series records is in an EEG/EMG group."""
+        region = series.electrodes
+        group_names = region.table["group_name"].data
+        return any(
+            token in str(group_names[int(position)]).lower()
+            for position in region.data
+            for token in _EEG_GROUP_TOKENS
+        )
 
     def generate_entries_from_nwb_object(self, nwb_obj, base_key=None):
         """Emit the ``IntervalList`` + master + ``.Electrode`` rows for one series.
@@ -198,18 +203,24 @@ class ImportedEEG(SpyglassIngestion, dj.Imported):
             self.Electrode: elec_rows,
         }
 
-    @staticmethod
-    def _valid_times(series, rate):
-        """The series' recorded-time span as a single contiguous ``[start, end]``
-        interval (EEG acquisition is continuous).
+    def _valid_times(self, series, rate):
+        """The series' recorded-time intervals, shape ``(n_intervals, 2)``.
 
-        A rate-based series computes its endpoints in O(1) from
-        ``starting_time``/``rate``; an explicit-``timestamps`` series uses its
-        first/last timestamp.
+        A rate-based series is uniformly sampled, so it is one contiguous
+        ``[start, end]`` interval computed in O(1) from ``starting_time``/``rate``.
+        An explicit-``timestamps`` series may have acquisition gaps (wireless EEG
+        telemetry drops packets), so its valid times come from
+        ``get_valid_intervals`` -- gaps are excluded rather than spanned (as
+        ``Raw`` does).
         """
         if series.timestamps is not None:
-            timestamps = np.asarray(series.timestamps)
-            return np.array([[timestamps[0], timestamps[-1]]])
+            return get_valid_intervals(
+                timestamps=np.asarray(series.timestamps),
+                sampling_rate=rate,
+                gap_proportion=1.75,
+                min_valid_len=0,
+                warn=not self._test_mode,
+            )
         start = series.starting_time or 0.0
         end = start + (int(series.data.shape[0]) - 1) / rate
         return np.array([[start, end]])

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -21,6 +21,7 @@ from spyglass.common.common_device import (
     ProbeType,
 )
 from spyglass.common.common_dio import DIOEvents
+from spyglass.common.common_eeg import ImportedEEG
 from spyglass.common.common_ephys import (
     Electrode,
     ElectrodeGroup,
@@ -230,6 +231,7 @@ def populate_all_common(
             StateScriptFile,  # Depends on TaskEpoch
             ImportedPose,  # Depends on Session
             ImportedLFP,  # Depends on ElectrodeGroup
+            ImportedEEG,  # Depends on Session and Electrode
             VirusInjection,  # Depends on Session
             OpticalFiberImplant,  # Depends on Session and OpticalFiberDevice
             OptogeneticProtocol,  # Depends on Session and TaskEpoch

--- a/tests/common/_eeg_fixture.py
+++ b/tests/common/_eeg_fixture.py
@@ -92,12 +92,23 @@ def _add_channels(nwb: NWBFile, electrode_ids=None) -> None:
         nwb.add_electrode(**kwargs)
 
 
-def _add_series(nwb, region, n_cols, *, use_timestamps=False, n_time=N_TIME):
-    """Add one EEG ``ElectricalSeries`` to ``acquisition``.
+def _add_series(
+    nwb,
+    region,
+    n_cols,
+    *,
+    name=EEG_SERIES_NAME,
+    use_timestamps=False,
+    timestamps=None,
+    n_time=N_TIME,
+):
+    """Add one ``ElectricalSeries`` to ``acquisition``.
 
     ``region``: positional indices for the ``.electrodes`` region. ``n_cols``:
     number of trace columns (equals ``len(region)`` for a well-formed file;
-    differ to exercise the mismatch guard). Deterministic content (fixed seed).
+    differ to exercise the mismatch guard). ``timestamps``: explicit time axis
+    (else ``use_timestamps`` synthesizes a gapless one, else a fixed ``rate``).
+    Deterministic content (fixed seed).
     """
     data = (
         np.random.RandomState(0)
@@ -105,10 +116,12 @@ def _add_series(nwb, region, n_cols, *, use_timestamps=False, n_time=N_TIME):
         .astype("float32")
     )
     reg = nwb.create_electrode_table_region(
-        region=list(region), description="EEG/EMG channels"
+        region=list(region), description="channels"
     )
-    kwargs = dict(name=EEG_SERIES_NAME, data=data, electrodes=reg)
-    if use_timestamps:
+    kwargs = dict(name=name, data=data, electrodes=reg)
+    if timestamps is not None:
+        kwargs["timestamps"] = np.asarray(timestamps, dtype="float64")
+    elif use_timestamps:
         kwargs["timestamps"] = (np.arange(n_time) / EEG_RATE).astype("float64")
     else:
         kwargs["starting_time"] = 0.0
@@ -151,6 +164,33 @@ def build_eeg_col_mismatch(nwb: NWBFile, n_time: int = N_TIME) -> NWBFile:
     """
     _add_channels(nwb)
     _add_series(nwb, range(N_CHANNELS), N_CHANNELS + 1, n_time=n_time)
+    return nwb
+
+
+def build_eeg_gappy(nwb: NWBFile, n_time: int = N_TIME) -> NWBFile:
+    """Explicit-``timestamps`` series with a 1 s acquisition gap mid-recording
+    (a dropped-packet burst), so valid_times must split into two intervals."""
+    _add_channels(nwb)
+    timestamps = np.arange(n_time) / EEG_RATE
+    timestamps[n_time // 2 :] += 1.0  # 1 s gap after the first half
+    _add_series(nwb, range(N_CHANNELS), N_CHANNELS, timestamps=timestamps)
+    return nwb
+
+
+def build_non_eeg_series(nwb: NWBFile, n_time: int = N_TIME) -> NWBFile:
+    """An acquisition ElectricalSeries whose electrodes are in a non-EEG group
+    (an analog/aux montage), which the EEG-group gate must exclude."""
+    device = Device(name="AnalogBox", description="analog acquisition")
+    nwb.add_device(device)
+    group = nwb.create_electrode_group(
+        name="AnalogArray",
+        description="analog/aux channels",
+        location="n/a",
+        device=device,
+    )
+    for _ in range(2):
+        nwb.add_electrode(group=group, location="n/a")
+    _add_series(nwb, range(2), 2, name="AnalogSignal", n_time=n_time)
     return nwb
 
 

--- a/tests/common/_eeg_fixture.py
+++ b/tests/common/_eeg_fixture.py
@@ -1,12 +1,16 @@
-"""Builder for a synthetic chronic-EEG NWB fixture (core pynwb, no ndx extension).
+"""Builders for synthetic chronic-EEG NWB fixtures (core pynwb, no ndx extension).
 
 Mirrors the structure of the Gonzalez-Sulser chronic-EEG recordings in
 ``DANDI:001888``: a raw multi-channel ``ElectricalSeries`` in
 ``nwbfile.acquisition`` whose channels are probe-less array/screw electrodes,
 grouped into an EEG and an EMG ``ElectrodeGroup`` on a plain ``Device`` (no
-``Probe``). The series carries an ``.electrodes`` region over all channels. This
+``Probe``). The series carries an ``.electrodes`` region over its channels. This
 is all core ``pynwb.ecephys`` -- no extension is required to exercise the
 ``common_eeg`` ingestion path.
+
+``build_eeg`` is the canonical happy-path fixture; the other builders vary one
+axis (explicit timestamps, non-consecutive electrode ids, region/column-count
+mismatch) to exercise the ingestion edge paths.
 """
 
 from datetime import datetime
@@ -21,6 +25,7 @@ from pynwb.file import Subject
 
 EEG_SERIES_NAME = "ElectricalSeries_EEG"
 EEG_RATE = 250.4  # Hz, matching the DANDI:001888 telemetry rate
+N_TIME = 500  # samples in the synthetic trace
 # Channel names mirror the real montage; the "_R"/"_L" suffix drives hemisphere.
 EEG_CHANNELS = ["S1_Tr_R", "M2_Fra_R", "V1_M_L", "S1Hl_L"]
 EMG_CHANNELS = ["EMG_R"]
@@ -41,14 +46,17 @@ def _new_nwb(identifier: str) -> NWBFile:
     )
 
 
-def build_eeg(nwb: NWBFile, n_time: int = 500) -> NWBFile:
-    """Add a probe-less EEG/EMG acquisition ElectricalSeries to ``nwb``."""
+def _add_channels(nwb: NWBFile, electrode_ids=None) -> None:
+    """Add the device, EEG/EMG groups, and per-channel electrodes.
+
+    ``electrode_ids``: optional length-``N_CHANNELS`` list of explicit row ids
+    (to exercise non-consecutive ids); default lets pynwb assign ``0..N-1``.
+    """
     device = Device(
         name="TainiTecWirelessEEG",
-        description="16-ch wireless EEG/EMG telemetry system",
+        description="14-ch wireless EEG/EMG telemetry system",
     )
     nwb.add_device(device)
-
     eeg_group = nwb.create_electrode_group(
         name="EEGArray",
         description="chronic EEG electrode array",
@@ -61,56 +69,88 @@ def build_eeg(nwb: NWBFile, n_time: int = 500) -> NWBFile:
         location="muscle",
         device=device,
     )
-
-    # Custom columns mirroring the real electrodes table (channel_name,
-    # hemisphere, rel_x, rel_y). Standard location/group/group_name/filtering
-    # columns come for free from add_electrode.
     for col in ("channel_name", "hemisphere"):
         nwb.add_electrode_column(name=col, description=col)
     for col in ("rel_x", "rel_y"):
         nwb.add_electrode_column(name=col, description=f"{col} (um)")
 
-    for i, name in enumerate(EEG_CHANNELS):
-        nwb.add_electrode(
-            group=eeg_group,
-            location="cortex",
+    channels = [(eeg_group, "cortex", n) for n in EEG_CHANNELS] + [
+        (emg_group, "muscle", n) for n in EMG_CHANNELS
+    ]
+    for i, (group, location, name) in enumerate(channels):
+        kwargs = dict(
+            group=group,
+            location=location,
             filtering="none",
             channel_name=name,
             hemisphere="R" if name.endswith("_R") else "L",
-            rel_x=float(i),
-            rel_y=float(i),
+            rel_x=float(i) if location == "cortex" else np.nan,
+            rel_y=float(i) if location == "cortex" else np.nan,
         )
-    for name in EMG_CHANNELS:
-        nwb.add_electrode(
-            group=emg_group,
-            location="muscle",
-            filtering="none",
-            channel_name=name,
-            hemisphere="R" if name.endswith("_R") else "L",
-            rel_x=np.nan,
-            rel_y=np.nan,
-        )
+        if electrode_ids is not None:
+            kwargs["id"] = int(electrode_ids[i])
+        nwb.add_electrode(**kwargs)
 
-    region = nwb.create_electrode_table_region(
-        region=list(range(N_CHANNELS)),
-        description="all EEG + EMG channels",
-    )
-    # Deterministic synthetic trace (fixed seed -> reproducible object_id-independent
-    # content). volts, continuous acquisition at EEG_RATE.
+
+def _add_series(nwb, region, n_cols, *, use_timestamps=False, n_time=N_TIME):
+    """Add one EEG ``ElectricalSeries`` to ``acquisition``.
+
+    ``region``: positional indices for the ``.electrodes`` region. ``n_cols``:
+    number of trace columns (equals ``len(region)`` for a well-formed file;
+    differ to exercise the mismatch guard). Deterministic content (fixed seed).
+    """
     data = (
         np.random.RandomState(0)
-        .standard_normal((n_time, N_CHANNELS))
+        .standard_normal((n_time, n_cols))
         .astype("float32")
     )
-    nwb.add_acquisition(
-        ElectricalSeries(
-            name=EEG_SERIES_NAME,
-            data=data,
-            electrodes=region,
-            starting_time=0.0,
-            rate=EEG_RATE,
-        )
+    reg = nwb.create_electrode_table_region(
+        region=list(region), description="EEG/EMG channels"
     )
+    kwargs = dict(name=EEG_SERIES_NAME, data=data, electrodes=reg)
+    if use_timestamps:
+        kwargs["timestamps"] = (np.arange(n_time) / EEG_RATE).astype("float64")
+    else:
+        kwargs["starting_time"] = 0.0
+        kwargs["rate"] = EEG_RATE
+    nwb.add_acquisition(ElectricalSeries(**kwargs))
+
+
+def build_eeg(nwb: NWBFile, n_time: int = N_TIME) -> NWBFile:
+    """Canonical fixture: rate-based series, region over all channels."""
+    _add_channels(nwb)
+    _add_series(nwb, range(N_CHANNELS), N_CHANNELS, n_time=n_time)
+    return nwb
+
+
+def build_eeg_timestamps(nwb: NWBFile, n_time: int = N_TIME) -> NWBFile:
+    """Explicit-``timestamps`` series (no ``rate``)."""
+    _add_channels(nwb)
+    _add_series(
+        nwb, range(N_CHANNELS), N_CHANNELS, use_timestamps=True, n_time=n_time
+    )
+    return nwb
+
+
+def build_eeg_noncontiguous(nwb: NWBFile, n_time: int = N_TIME) -> NWBFile:
+    """Non-consecutive electrode ids + a permuted, subset region.
+
+    ids are ``10..14``; the region is ``[2, 0, 4]`` -- so a correct
+    position->id translation is the only way to recover the right electrodes.
+    """
+    _add_channels(nwb, electrode_ids=[10, 11, 12, 13, 14])
+    _add_series(nwb, [2, 0, 4], 3, n_time=n_time)
+    return nwb
+
+
+def build_eeg_col_mismatch(nwb: NWBFile, n_time: int = N_TIME) -> NWBFile:
+    """Region length != trace column count (a malformed/hand-edited file).
+
+    The region covers all channels but the trace has one extra column, so the
+    region_index -> column correspondence is broken.
+    """
+    _add_channels(nwb)
+    _add_series(nwb, range(N_CHANNELS), N_CHANNELS + 1, n_time=n_time)
     return nwb
 
 

--- a/tests/common/_eeg_fixture.py
+++ b/tests/common/_eeg_fixture.py
@@ -1,0 +1,124 @@
+"""Builder for a synthetic chronic-EEG NWB fixture (core pynwb, no ndx extension).
+
+Mirrors the structure of the Gonzalez-Sulser chronic-EEG recordings in
+``DANDI:001888``: a raw multi-channel ``ElectricalSeries`` in
+``nwbfile.acquisition`` whose channels are probe-less array/screw electrodes,
+grouped into an EEG and an EMG ``ElectrodeGroup`` on a plain ``Device`` (no
+``Probe``). The series carries an ``.electrodes`` region over all channels. This
+is all core ``pynwb.ecephys`` -- no extension is required to exercise the
+``common_eeg`` ingestion path.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import numpy as np
+from pynwb import NWBHDF5IO, NWBFile
+from pynwb.device import Device
+from pynwb.ecephys import ElectricalSeries
+from pynwb.file import Subject
+
+EEG_SERIES_NAME = "ElectricalSeries_EEG"
+EEG_RATE = 250.4  # Hz, matching the DANDI:001888 telemetry rate
+# Channel names mirror the real montage; the "_R"/"_L" suffix drives hemisphere.
+EEG_CHANNELS = ["S1_Tr_R", "M2_Fra_R", "V1_M_L", "S1Hl_L"]
+EMG_CHANNELS = ["EMG_R"]
+N_CHANNELS = len(EEG_CHANNELS) + len(EMG_CHANNELS)
+
+
+def _new_nwb(identifier: str) -> NWBFile:
+    return NWBFile(
+        session_description="eeg fixture",
+        identifier=identifier,
+        session_start_time=datetime(
+            2025, 10, 2, 11, 48, tzinfo=ZoneInfo("America/Los_Angeles")
+        ),
+        subject=Subject(subject_id="GRIN2B-129", species="Rattus norvegicus"),
+        experimenter=["Test, Experimenter"],
+        lab="Test Lab",
+        institution="Test Institution",
+    )
+
+
+def build_eeg(nwb: NWBFile, n_time: int = 500) -> NWBFile:
+    """Add a probe-less EEG/EMG acquisition ElectricalSeries to ``nwb``."""
+    device = Device(
+        name="TainiTecWirelessEEG",
+        description="16-ch wireless EEG/EMG telemetry system",
+    )
+    nwb.add_device(device)
+
+    eeg_group = nwb.create_electrode_group(
+        name="EEGArray",
+        description="chronic EEG electrode array",
+        location="cortex",
+        device=device,
+    )
+    emg_group = nwb.create_electrode_group(
+        name="EMGArray",
+        description="chronic EMG electrodes",
+        location="muscle",
+        device=device,
+    )
+
+    # Custom columns mirroring the real electrodes table (channel_name,
+    # hemisphere, rel_x, rel_y). Standard location/group/group_name/filtering
+    # columns come for free from add_electrode.
+    for col in ("channel_name", "hemisphere"):
+        nwb.add_electrode_column(name=col, description=col)
+    for col in ("rel_x", "rel_y"):
+        nwb.add_electrode_column(name=col, description=f"{col} (um)")
+
+    for i, name in enumerate(EEG_CHANNELS):
+        nwb.add_electrode(
+            group=eeg_group,
+            location="cortex",
+            filtering="none",
+            channel_name=name,
+            hemisphere="R" if name.endswith("_R") else "L",
+            rel_x=float(i),
+            rel_y=float(i),
+        )
+    for name in EMG_CHANNELS:
+        nwb.add_electrode(
+            group=emg_group,
+            location="muscle",
+            filtering="none",
+            channel_name=name,
+            hemisphere="R" if name.endswith("_R") else "L",
+            rel_x=np.nan,
+            rel_y=np.nan,
+        )
+
+    region = nwb.create_electrode_table_region(
+        region=list(range(N_CHANNELS)),
+        description="all EEG + EMG channels",
+    )
+    # Deterministic synthetic trace (fixed seed -> reproducible object_id-independent
+    # content). volts, continuous acquisition at EEG_RATE.
+    data = (
+        np.random.RandomState(0)
+        .standard_normal((n_time, N_CHANNELS))
+        .astype("float32")
+    )
+    nwb.add_acquisition(
+        ElectricalSeries(
+            name=EEG_SERIES_NAME,
+            data=data,
+            electrodes=region,
+            starting_time=0.0,
+            rate=EEG_RATE,
+        )
+    )
+    return nwb
+
+
+def write(path, builder=build_eeg, identifier=None, **kwargs) -> Path:
+    """Build a fresh NWBFile, apply ``builder``, and write it to ``path``."""
+    path = Path(path)
+    nwb = _new_nwb(identifier or path.stem)
+    builder(nwb, **kwargs)
+    with NWBHDF5IO(str(path), "w") as io:
+        io.write(nwb)
+    return path

--- a/tests/common/test_eeg.py
+++ b/tests/common/test_eeg.py
@@ -1,0 +1,104 @@
+"""Validation slice for chronic-EEG ingestion (``common_eeg.ImportedEEG``).
+
+Exercises the end-to-end path against a synthetic NWB mirroring the
+Gonzalez-Sulser chronic-EEG structure in ``DANDI:001888``: a probe-less
+multi-channel ``ElectricalSeries`` in ``acquisition`` whose channels reuse the
+standard ``common_ephys`` electrode ingestion, referenced (not re-filtered) by
+``ImportedEEG``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tests.common import _eeg_fixture as fx
+
+
+@pytest.fixture
+def insert_eeg(raw_dir, common, data_import):
+    """Factory: build + write + ingest an EEG NWB, with auto-cleanup.
+
+    Returns ``insert(filename, **kwargs) -> key`` where ``key`` restricts to the
+    ingested copy's ``nwb_file_name``.
+    """
+    from spyglass.utils.nwb_helper_fn import get_nwb_copy_filename
+
+    inserted = []
+
+    def _insert(filename, raise_err=True, **builder_kwargs):
+        key = {"nwb_file_name": get_nwb_copy_filename(filename)}
+        inserted.append(key)
+        fx.write(Path(raw_dir) / filename, **builder_kwargs)
+        data_import.insert_sessions(filename, raise_err=raise_err)
+        return key
+
+    yield _insert
+
+    for key in inserted:
+        (common.Nwbfile & key).delete(safemode=False)
+
+
+def test_electrodes_reuse_existing_ingestion(insert_eeg, common):
+    """The probe-less EEG/EMG channels ingest through the standard common_ephys
+    Electrode/ElectrodeGroup tables (no bespoke EEG electrode schema)."""
+    key = insert_eeg("mock_eeg_reuse.nwb")
+
+    groups = (common.ElectrodeGroup & key).fetch("electrode_group_name")
+    assert set(groups) == {"EEGArray", "EMGArray"}
+    assert len(common.Electrode & key) == fx.N_CHANNELS
+
+
+def test_imported_eeg_ingests_acquisition_series(insert_eeg, common):
+    """ImportedEEG references the raw acquisition ElectricalSeries by object_id,
+    keeping the trace in the NWB file (no filtering)."""
+    key = insert_eeg("mock_eeg_series.nwb")
+    common.ImportedEEG().populate(key)
+
+    rows = (common.ImportedEEG & key).fetch(as_dict=True)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["name"] == fx.EEG_SERIES_NAME
+    assert row["num_samples"] == 500
+    assert row["unit"] == "volts"
+    assert row["eeg_sampling_rate"] == pytest.approx(fx.EEG_RATE)
+
+
+def test_imported_eeg_electrode_part_maps_channels(insert_eeg, common):
+    """Each series column maps, via the .Electrode part, to the common Electrode
+    row it records -- carrying the EEG/EMG group split without duplication."""
+    key = insert_eeg("mock_eeg_part.nwb")
+    common.ImportedEEG().populate(key)
+
+    part = common.ImportedEEG.Electrode & key
+    assert len(part) == fx.N_CHANNELS
+    # Region indices are the 0-based column order.
+    assert set(part.fetch("region_index")) == set(range(fx.N_CHANNELS))
+    # The part rows join back to real Electrode rows across both groups.
+    joined = part * common.Electrode
+    assert set(joined.fetch("electrode_group_name")) == {"EEGArray", "EMGArray"}
+
+
+def test_imported_eeg_no_filtering_step(insert_eeg, common):
+    """ImportedEEG stores a reference only -- it must not create any AnalysisNwbfile
+    (i.e. no re-filtered derivative like the LFP pipeline)."""
+    key = insert_eeg("mock_eeg_nofilter.nwb")
+    n_analysis_before = len(common.AnalysisNwbfile & key)
+    common.ImportedEEG().populate(key)
+    assert len(common.AnalysisNwbfile & key) == n_analysis_before
+
+
+def test_populate_all_common_ingests_eeg(insert_eeg, common):
+    """insert_sessions -> populate_all_common auto-ingests ImportedEEG (no manual
+    populate needed), proving the table is wired into the standard pipeline."""
+    key = insert_eeg("mock_eeg_pac.nwb")
+    assert len(common.ImportedEEG & key) == 1
+    assert len(common.ImportedEEG.Electrode & key) == fx.N_CHANNELS
+
+
+def test_imported_eeg_noop_on_non_eeg_file(mini_insert, common, mini_copy_name):
+    """A standard ephys file (only a Raw-named acquisition series) yields no
+    ImportedEEG rows -- the selection heuristic excludes the wideband series, so
+    wiring ImportedEEG into populate_all_common is a safe no-op there."""
+    key = {"nwb_file_name": mini_copy_name}
+    common.ImportedEEG().populate(key)
+    assert len(common.ImportedEEG & key) == 0

--- a/tests/common/test_eeg.py
+++ b/tests/common/test_eeg.py
@@ -14,6 +14,19 @@ import pytest
 from tests.common import _eeg_fixture as fx
 
 
+class _WarnRecorder:
+    """Stand-in ``logger`` that records ``warning`` messages, no-ops the rest."""
+
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, msg, *args, **kwargs):
+        self.messages.append(str(msg))
+
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
 @pytest.fixture
 def insert_eeg(raw_dir, common, data_import):
     """Factory: build + write + ingest an EEG NWB, with auto-cleanup.
@@ -58,7 +71,7 @@ def test_imported_eeg_ingests_acquisition_series(insert_eeg, common):
     assert len(rows) == 1
     row = rows[0]
     assert row["name"] == fx.EEG_SERIES_NAME
-    assert row["num_samples"] == 500
+    assert row["num_samples"] == fx.N_TIME
     assert row["unit"] == "volts"
     assert row["eeg_sampling_rate"] == pytest.approx(fx.EEG_RATE)
 
@@ -102,3 +115,88 @@ def test_imported_eeg_noop_on_non_eeg_file(mini_insert, common, mini_copy_name):
     key = {"nwb_file_name": mini_copy_name}
     common.ImportedEEG().populate(key)
     assert len(common.ImportedEEG & key) == 0
+
+
+def test_imported_eeg_timestamps_series(insert_eeg, common):
+    """An explicit-``timestamps`` series (no ``rate``) ingests without crashing;
+    the rate is estimated and valid_times spans the first/last timestamp."""
+    key = insert_eeg("mock_eeg_ts.nwb", builder=fx.build_eeg_timestamps)
+    common.ImportedEEG().populate(key)
+
+    row = (common.ImportedEEG & key).fetch1()
+    assert row["num_samples"] == fx.N_TIME
+    # rate is estimated from the timestamps (estimate_sampling_rate rounds), so
+    # only assert it lands near the nominal rate, not exactly.
+    assert row["eeg_sampling_rate"] == pytest.approx(fx.EEG_RATE, rel=1e-2)
+
+    valid_times = (
+        common.IntervalList
+        & key
+        & {"interval_list_name": row["interval_list_name"]}
+    ).fetch1("valid_times")
+    assert valid_times[0][0] == pytest.approx(0.0)
+    assert valid_times[0][-1] == pytest.approx(
+        (fx.N_TIME - 1) / fx.EEG_RATE, rel=1e-6
+    )
+
+
+def test_noncontiguous_ids_map_correctly(insert_eeg, common):
+    """With non-consecutive electrode ids and a permuted/subset region, each
+    region_index maps to the correct electrode -- the position->id translation
+    (not a coincidental identity) is what recovers the mapping."""
+    key = insert_eeg(
+        "mock_eeg_noncontig.nwb", builder=fx.build_eeg_noncontiguous
+    )
+    common.ImportedEEG().populate(key)
+
+    part = (common.ImportedEEG.Electrode & key).fetch(
+        "region_index", "electrode_group_name", "electrode_id", as_dict=True
+    )
+    got = {
+        r["region_index"]: (r["electrode_group_name"], r["electrode_id"])
+        for r in part
+    }
+    # region [2, 0, 4] over ids [10..14]: pos2->id12 (EEG), pos0->id10 (EEG),
+    # pos4->id14 (EMG).
+    assert got == {
+        0: ("EEGArray", 12),
+        1: ("EEGArray", 10),
+        2: ("EMGArray", 14),
+    }
+
+
+def test_region_column_mismatch_warns(insert_eeg, common, monkeypatch):
+    """A region whose length disagrees with the trace's column count is warned
+    about (mis-mapping risk), not silently ingested."""
+    rec = _WarnRecorder()
+    monkeypatch.setattr(common.common_eeg, "logger", rec)
+    insert_eeg("mock_eeg_mismatch.nwb", builder=fx.build_eeg_col_mismatch)
+    assert any(
+        "region" in m and "column" in m for m in rec.messages
+    ), rec.messages
+
+
+def test_selection_logs_warning(insert_eeg, common, monkeypatch):
+    """get_nwb_objects logs which acquisition series it claimed as EEG, so the
+    name-exclusion heuristic's action is discoverable."""
+    rec = _WarnRecorder()
+    monkeypatch.setattr(common.common_eeg, "logger", rec)
+    insert_eeg("mock_eeg_sel.nwb")
+    assert any(
+        fx.EEG_SERIES_NAME in m and "EEG" in m for m in rec.messages
+    ), rec.messages
+
+
+def test_nwb_object_round_trip(insert_eeg, common):
+    """nwb_object() re-fetches the referenced ElectricalSeries by object_id --
+    the core "trace stays in the NWB file, this row indexes it" contract."""
+    import pynwb
+
+    key = insert_eeg("mock_eeg_roundtrip.nwb")
+    common.ImportedEEG().populate(key)
+
+    row_key = (common.ImportedEEG & key).fetch1("KEY")
+    series = common.ImportedEEG().nwb_object(row_key)
+    assert isinstance(series, pynwb.ecephys.ElectricalSeries)
+    assert series.object_id == row_key["eeg_object_id"]
+    assert series.data.shape[0] == fx.N_TIME

--- a/tests/common/test_eeg.py
+++ b/tests/common/test_eeg.py
@@ -134,9 +134,12 @@ def test_imported_eeg_timestamps_series(insert_eeg, common):
         & key
         & {"interval_list_name": row["interval_list_name"]}
     ).fetch1("valid_times")
-    assert valid_times[0][0] == pytest.approx(0.0)
+    # Gapless -> one interval spanning [first, last] (get_valid_intervals pads
+    # the edges by a fraction of a sample, so assert with an absolute tolerance).
+    assert len(valid_times) == 1
+    assert valid_times[0][0] == pytest.approx(0.0, abs=1e-3)
     assert valid_times[0][-1] == pytest.approx(
-        (fx.N_TIME - 1) / fx.EEG_RATE, rel=1e-6
+        (fx.N_TIME - 1) / fx.EEG_RATE, abs=1e-3
     )
 
 
@@ -176,15 +179,27 @@ def test_region_column_mismatch_warns(insert_eeg, common, monkeypatch):
     ), rec.messages
 
 
-def test_selection_logs_warning(insert_eeg, common, monkeypatch):
-    """get_nwb_objects logs which acquisition series it claimed as EEG, so the
-    name-exclusion heuristic's action is discoverable."""
-    rec = _WarnRecorder()
-    monkeypatch.setattr(common.common_eeg, "logger", rec)
-    insert_eeg("mock_eeg_sel.nwb")
-    assert any(
-        fx.EEG_SERIES_NAME in m and "EEG" in m for m in rec.messages
-    ), rec.messages
+def test_excludes_non_eeg_group_series(insert_eeg, common):
+    """An acquisition ElectricalSeries whose electrodes are in a non-EEG group
+    (analog/aux) is NOT ingested -- the group-name gate keeps ImportedEEG from
+    claiming a stray acquisition series when wired into populate_all_common."""
+    key = insert_eeg("mock_eeg_analog.nwb", builder=fx.build_non_eeg_series)
+    assert len(common.ImportedEEG & key) == 0
+
+
+def test_gappy_timestamps_split_valid_times(insert_eeg, common):
+    """A dropped-packet gap in a timestamps series splits valid_times into two
+    intervals (the gap is excluded, not marked as valid recording time)."""
+    key = insert_eeg("mock_eeg_gappy.nwb", builder=fx.build_eeg_gappy)
+    common.ImportedEEG().populate(key)
+
+    row = (common.ImportedEEG & key).fetch1()
+    valid_times = (
+        common.IntervalList
+        & key
+        & {"interval_list_name": row["interval_list_name"]}
+    ).fetch1("valid_times")
+    assert len(valid_times) == 2
 
 
 def test_nwb_object_round_trip(insert_eeg, common):

--- a/tests/common/test_region.py
+++ b/tests/common/test_region.py
@@ -1,5 +1,4 @@
 import pytest
-from datajoint import U as dj_U
 
 from ..conftest import TEARDOWN
 
@@ -19,14 +18,17 @@ def brain_region(common, region_dict):
 
 @pytest.mark.skipif(not TEARDOWN, reason="No teardown: no test autoincrement")
 def test_region_add(brain_region, region_dict):
-    next_id = (
-        dj_U().aggr(brain_region, n="max(region_id)").fetch1("n") or 0
-    ) + 1
+    before = set(brain_region.fetch("region_id"))
     region_id = brain_region.fetch_add(
         **region_dict,
         subregion_name="test_subregion_add",
         subsubregion_name="test_subsubregion_add",
     )
-    assert (
-        region_id == next_id
-    ), "Region.fetch_add() should autoincrement region_id."
+    # fetch_add autoincrements: the new region gets a fresh id larger than any
+    # existing one. Assert that directly rather than assuming the AUTO_INCREMENT
+    # counter equals max(region_id)+1 -- it does not once earlier rows have been
+    # inserted and deleted (InnoDB does not reclaim the counter).
+    assert region_id not in before, "fetch_add should create a new region_id."
+    assert region_id == max(
+        brain_region.fetch("region_id")
+    ), "the new region should hold the largest region_id."


### PR DESCRIPTION
## Summary

First implementation for **#1634** (Support EEG data): a `common_eeg` schema that ingests raw chronic-EEG/EMG recordings stored as an `ElectricalSeries` in `nwbfile.acquisition`, as used by the SFARI ARC chronic-EEG labs (validated against the Gonzalez-Sulser data in `DANDI:001888`).

Unlike the LFP pipeline, EEG telemetry is already low-pass filtered/downsampled at acquisition, so `ImportedEEG` **references** the trace as-is rather than re-filtering it — mirroring the `ImportedLFP` idea but reading from `acquisition` and keeping the trace in the NWB file.

Marking **draft** for design discussion (see open questions below) before it lands.

## What it adds

- **`common_eeg.ImportedEEG`** (`dj.Imported`): references the series by `object_id`, records a valid-times `IntervalList`, stores trace metadata; `fetch_nwb()` / `nwb_object()` retrieve the trace from the file (no data copied into Spyglass).
- **`ImportedEEG.Electrode`** part: maps each series column (`region_index`) to the `common_ephys.Electrode` it records, translated from the `.electrodes` region's positional index to the electrode `(group_name, id)`.
- Registered in **`populate_all_common`** (after `Electrode`).

## Design decisions

- **Reuse `common_ephys.Electrode`/`ElectrodeGroup`, no new electrode schema.** Chronic-EEG NWB files already model probe-less screws/arrays with a standard `electrodes` table + `ElectrodeGroup` on a plain `Device`; the existing ingestion handles it (the `Probe` FKs are already nullable). The `.Electrode` part reuses those rows so the EEG/EMG group split rides along without duplication.
- **Selection keys on the `ElectrodeGroup` name** (`eeg`/`emg`, case-insensitive), not the series name — in real files the series is named opaquely (e.g. `ElectricalSeries_BL2`) while the montage lives in `EEGArray`/`EMGArray` groups. This excludes probe-ephys and analog/aux series, so wiring into `populate_all_common` doesn't claim a stray acquisition series.
- **No re-filtering step** (asserted by a test that no `AnalysisNwbfile` is created).
- **Gap-aware `valid_times`:** an explicit-`timestamps` series routes through `get_valid_intervals` like `Raw`, so dropped-packet gaps in wireless telemetry are excluded rather than spanned. Rate-based series (uniform) stay one interval.

## Testing

- **12 unit tests** (`tests/common/test_eeg.py`) against synthetic NWB fixtures mirroring `DANDI:001888`: electrode reuse, series ingestion, per-channel mapping (incl. **non-consecutive/permuted ids** so the position→id translation isn't a coincidental identity), no-filtering contract, `populate_all_common` wiring, non-EEG-group exclusion, region/column-count mismatch warning, explicit-timestamps + gappy-timestamps valid_times, and `nwb_object` round-trip.
- **Real-data smoke test** on the actual `sub-GRIN2B-129_ses-BL2` (353 MB) — ingested end-to-end in ~10 s: 16 electrodes reused (14 EEG + 2 EMG), one `ImportedEEG` row over the 21.6 M-sample series, correct 24 h `valid_times`, `fetch_nwb` round-trip verified.
- Passes alongside the existing `common` suite (`test_ephys`, `test_insert`); black / ruff / codespell clean.

## Open questions for discussion

1. **Group-naming convention.** Selection relies on EEG/EMG groups being named accordingly. Worth confirming with the data producers (CatalystNeuro) as the convention, or replacing with an explicit marker/config if one becomes available.
2. **Electrode coordinates.** The real file stores `rel_x`/`rel_y` on the electrodes table, but `common_ephys.Electrode` reads `x`/`y`/`z`. Capturing them would need either a producer-side change or a `rel_*` fallback in `common_ephys.Electrode` (deferred; happy to add as a follow-up).
3. **EEG + EMG share one series** (14 + 2), split only by `ElectrodeGroup` — kept bundled here; confirm that's the intended shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
