### PR TITLE
Skip permission check in `convert_epoch_interval_name_to_position_interval_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,8 +255,7 @@ for label, interval_data in results.groupby("interval_labels"):
     - Fix bug with `LabTeam().create_new_team` when `google_user_name` is not
         available #1546
     - Fix bug from overlapping intervals in interval union #1520
-    - Remove admin requirement in `convert_epoch_interval_name_to_position_interval_name`
-      #1640
+    - Bypass delete permission check when removing null `PositionIntervalMap` entries in `convert_epoch_interval_name_to_position_interval_name` #1640
 
 - Decoding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,8 @@ for label, interval_data in results.groupby("interval_labels"):
     - Fix bug with `LabTeam().create_new_team` when `google_user_name` is not
         available #1546
     - Fix bug from overlapping intervals in interval union #1520
+    - Remove admin requirement in `convert_epoch_interval_name_to_position_interval_name`
+      #1640
 
 - Decoding
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1006,7 +1006,7 @@ def convert_epoch_interval_name_to_position_interval_name(
 
     if populate_missing and (no_entries or null_entry):
         if null_entry:
-            pos_query.delete(safemode=False)  # no prompt
+            pos_query.delete(force_permission=True, safemode=False)  # no prompt
         PositionIntervalMap()._no_transaction_make(key)
         pos_query = PositionIntervalMap & key
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1006,7 +1006,7 @@ def convert_epoch_interval_name_to_position_interval_name(
 
     if populate_missing and (no_entries or null_entry):
         if null_entry:
-            pos_query.delete(force_permission=True, safemode=False)  # no prompt
+            pos_query.delete(force_permission=True, safemode=False)  # no prompt; bypass delete permission check for null placeholder entry
         PositionIntervalMap()._no_transaction_make(key)
         pos_query = PositionIntervalMap & key
 

--- a/src/spyglass/common/common_behav.py
+++ b/src/spyglass/common/common_behav.py
@@ -1006,7 +1006,9 @@ def convert_epoch_interval_name_to_position_interval_name(
 
     if populate_missing and (no_entries or null_entry):
         if null_entry:
-            pos_query.delete(force_permission=True, safemode=False)  # no prompt; bypass delete permission check for null placeholder entry
+            pos_query.delete(
+                force_permission=True, safemode=False
+            )  # no prompt; bypass delete permission check for null placeholder entry
         PositionIntervalMap()._no_transaction_make(key)
         pos_query = PositionIntervalMap & key
 


### PR DESCRIPTION
# Description

Fixes #1639
- skips permissions check when deleting null entry in `PositionIntervalMap`


# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] NA If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] NA If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] NA If this PR makes changes to position, I ran the relevant tests locally.
- [x] NA If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
