### PR TITLE
Deletion safety in analysis dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ for label, interval_data in results.groupby("interval_labels"):
     instead of a `describe_dims` flag on `filter_data_fir`, so each returns one
     type and arguments that cannot affect the sizing answer are rejected rather
     than ignored #1635
+- Safety check for number of deleted files in `_remove_untracked_files` #1656
 
 ### Pipelines
 

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -698,9 +698,9 @@ class AnalysisNwbfile(SpyglassAnalysis, dj.Manual):
 
         if len(to_delete) > DELETION_SAFETY_THRESHOLD * len(tracked):
             raise RuntimeError(
-                f"Attempting to delete {len(to_delete)} files, which is more than "
-                f"{DELETION_SAFETY_THRESHOLD*100}% of tracked files ({len(tracked)}). "
-                "Aborting to prevent accidental mass deletion."
+                f"Attempting to delete {len(to_delete)} files from {self._analysis_dir}"
+                f", which is more than {DELETION_SAFETY_THRESHOLD*100}% of tracked files"
+                f" ({len(tracked)}). Aborting to prevent accidental mass deletion."
             )
 
         for path in to_delete:

--- a/src/spyglass/common/common_nwbfile.py
+++ b/src/spyglass/common/common_nwbfile.py
@@ -20,6 +20,8 @@ from spyglass.utils.dj_helper_fn import get_child_tables
 from spyglass.utils.nwb_hash import NwbfileHasher
 from spyglass.utils.nwb_helper_fn import get_electrode_indices, get_nwb_file
 
+DELETION_SAFETY_THRESHOLD = 1.0
+
 # A trigger is a DB object that is automatically executed when INSERT occurs
 SQL_TRIGGER_QUERY = """
 SELECT COUNT(*)
@@ -693,6 +695,13 @@ class AnalysisNwbfile(SpyglassAnalysis, dj.Manual):
         if dry_run:
             logger.info(f"  {len(to_delete)} untracked or empty analysis files")
             return to_delete, tracked
+
+        if len(to_delete) > DELETION_SAFETY_THRESHOLD * len(tracked):
+            raise RuntimeError(
+                f"Attempting to delete {len(to_delete)} files, which is more than "
+                f"{DELETION_SAFETY_THRESHOLD*100}% of tracked files ({len(tracked)}). "
+                "Aborting to prevent accidental mass deletion."
+            )
 
         for path in to_delete:
             try:

--- a/tests/common/test_custom_analysis.py
+++ b/tests/common/test_custom_analysis.py
@@ -421,6 +421,40 @@ class TestCleanupAndRegistry:
         assert Path(valid_fp).exists(), "Valid file should remain"
         assert Path(export_fp).exists(), "Exported valid file should remain"
 
+    def test_safety_threshold_prevents_mass_deletion(
+        self,
+        analysis_registry,
+        custom_analysis_tables,
+        mini_copy_name,
+        base_dir,
+        teardown,
+        common,
+        mock_create,
+    ):
+        """Test that deletion safety threshold prevents mass deletion."""
+        # change to a temporary directory to avoid deleting real files
+        master_table = common.common_nwbfile.AnalysisNwbfile()
+        tmp_dir = Path("tmp_analysis_files")
+        tmp_dir.mkdir(exist_ok=True)
+        master_table._analysis_dir = tmp_dir
+
+        # Create multiple files to exceed the threshold without adding to the table
+        num_files = 20
+        created_files = []
+        for _ in range(num_files):
+            fname = mock_create(master_table)
+            created_files.append(fname)
+
+        with pytest.raises(RuntimeError, match="Attempting to delete"):
+            master_table.cleanup()
+
+        # Cleanup created files manually
+        if teardown:
+            for fname in created_files:
+                fp = tmp_dir / fname
+                if Path(fp).exists():
+                    Path(fp).unlink()
+
     def test_registry_entry_has_metadata(
         self, analysis_registry, custom_analysis_table
     ):

--- a/tests/common/test_custom_analysis.py
+++ b/tests/common/test_custom_analysis.py
@@ -434,7 +434,9 @@ class TestCleanupAndRegistry:
         """Test that deletion safety threshold prevents mass deletion."""
         # Use an isolated directory under the pytest base_dir to avoid touching any real analysis files
         master_table = common.common_nwbfile.AnalysisNwbfile()
-        tmp_dir = base_dir / f"tmp_analysis_files_{random.randint(0, 1_000_000)}"
+        tmp_dir = (
+            base_dir / f"tmp_analysis_files_{random.randint(0, 1_000_000)}"
+        )
         tmp_dir.mkdir(parents=True, exist_ok=True)
         master_table._analysis_dir = tmp_dir
 
@@ -444,7 +446,9 @@ class TestCleanupAndRegistry:
             (tmp_dir / f"untracked_{i}.nwb").write_text("test")
 
         with pytest.raises(RuntimeError, match="Attempting to delete"):
-            master_table._remove_untracked_files(custom_tables=[], dry_run=False)
+            master_table._remove_untracked_files(
+                custom_tables=[], dry_run=False
+            )
 
         # Cleanup created files manually
         if teardown:

--- a/tests/common/test_custom_analysis.py
+++ b/tests/common/test_custom_analysis.py
@@ -432,28 +432,25 @@ class TestCleanupAndRegistry:
         mock_create,
     ):
         """Test that deletion safety threshold prevents mass deletion."""
-        # change to a temporary directory to avoid deleting real files
+        # Use an isolated directory under the pytest base_dir to avoid touching any real analysis files
         master_table = common.common_nwbfile.AnalysisNwbfile()
-        tmp_dir = Path("tmp_analysis_files")
-        tmp_dir.mkdir(exist_ok=True)
+        tmp_dir = base_dir / f"tmp_analysis_files_{random.randint(0, 1_000_000)}"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
         master_table._analysis_dir = tmp_dir
 
-        # Create multiple files to exceed the threshold without adding to the table
+        # Create multiple untracked NWB files to exceed the threshold without inserting table entries
         num_files = 20
-        created_files = []
-        for _ in range(num_files):
-            fname = mock_create(master_table)
-            created_files.append(fname)
+        for i in range(num_files):
+            (tmp_dir / f"untracked_{i}.nwb").write_text("test")
 
         with pytest.raises(RuntimeError, match="Attempting to delete"):
-            master_table.cleanup()
+            master_table._remove_untracked_files(custom_tables=[], dry_run=False)
 
         # Cleanup created files manually
         if teardown:
-            for fname in created_files:
-                fp = tmp_dir / fname
-                if Path(fp).exists():
-                    Path(fp).unlink()
+            for fp in tmp_dir.glob("untracked_*.nwb"):
+                fp.unlink(missing_ok=True)
+            tmp_dir.rmdir()
 
     def test_registry_entry_has_metadata(
         self, analysis_registry, custom_analysis_table


### PR DESCRIPTION
# Description

Quick fix for #1573 pending more extensive rework in # 1574

- Adds a check for `DELETION_SAFETY_THRESHOLD`
- In `_remove_untracked_files`
    - If the number of files to delete is (`> DELETION_SAFETY_THRESHOLD * len(tracked)`) raise error to prevent deleting unintended directory

Open to suggestion on appropriate threshold limit (current = 1.0)

# Checklist:

<!--
For items below with `if`, please mark those that do not apply with N/A

For example:
- [X] N/A. If this PR X, related item.
- [X] If this PR Y, other item.
- [X] I have updated the `CHANGELOG.md` ...

Alter notes example:
```python
from spyglass.example import Table
Table.alter() # Comment regarding the change
```
-->

- [x] If this PR should be accompanied by a release, I have updated the `CITATION.cff`
- [x] If this PR edits table definitions, I have included an `alter` snippet for release notes.
- [x] If this PR makes changes to position, I ran the relevant tests locally.
- [x] If this PR makes user-facing changes, I have added/edited docs/notebooks to reflect the changes
- [x] I have updated the `CHANGELOG.md` with PR number and description.
