### PR TITLE
Clear the error log before a new populate_all_common attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,9 @@ for label, interval_data in results.groupby("interval_labels"):
         available #1546
     - Fix bug from overlapping intervals in interval union #1520
     - Bypass delete permission check when removing null `PositionIntervalMap` entries in `convert_epoch_interval_name_to_position_interval_name` #1640
+    - Clear a file's existing `InsertError` rows at the start of
+        `populate_all_common`, so a rerun no longer reports or rolls back on
+        failures logged by an earlier attempt #1497
 
 - Decoding
 

--- a/src/spyglass/common/populate_all_common.py
+++ b/src/spyglass/common/populate_all_common.py
@@ -176,6 +176,12 @@ def populate_all_common(
     -------
     List
         A list of keys for InsertError entries if any errors occurred.
+
+    Notes
+    -----
+    InsertError rows logged by an earlier attempt at the same file, under the
+    same user and connection, are cleared before population starts, so the
+    returned list only ever describes the current attempt.
     """
     from spyglass.lfp.lfp_imported import ImportedLFP
     from spyglass.position.v1.imported_pose import ImportedPose
@@ -188,6 +194,12 @@ def populate_all_common(
         connection_id=dj.conn().connection_id,
         nwb_file_name=nwb_file_name,
     )
+
+    # Drop errors logged by an earlier attempt at this same file, user, and
+    # connection. Without this, the check below reports stale failures and can
+    # roll back an otherwise clean ingestion. See issue #1497. InsertError has
+    # no dependent tables, so delete_quick is safe here.
+    (InsertError & error_constants).delete_quick()
 
     table_lists: List[List[dj.Table]] = [
         # Tables that can be inserted in a single transaction

--- a/tests/common/test_populate_all_common.py
+++ b/tests/common/test_populate_all_common.py
@@ -1,0 +1,85 @@
+"""#1497: populate_all_common reported errors left over from earlier attempts."""
+
+from importlib import import_module
+
+import pytest
+
+
+@pytest.fixture
+def populate_module(common):
+    """The populate_all_common module, not the same-named function on common."""
+    return import_module("spyglass.common.populate_all_common")
+
+
+@pytest.fixture
+def stale_error(populate_module):
+    """Seed an InsertError row that looks like it came from an earlier run."""
+    import datajoint as dj
+
+    from spyglass.common.common_usage import InsertError
+
+    nwb_file_name = "stale_error_1497_.nwb"
+    constants = dict(
+        dj_user=dj.config["database.user"],
+        connection_id=dj.conn().connection_id,
+        nwb_file_name=nwb_file_name,
+    )
+    InsertError.insert1(
+        dict(
+            **constants,
+            table="Session",
+            error_type="ValueError",
+            error_message="stale failure from a previous attempt",
+            error_raw="stale failure from a previous attempt",
+        )
+    )
+
+    yield nwb_file_name, constants
+
+    (InsertError & constants).delete_quick()
+
+
+def test_clears_errors_from_previous_attempt(
+    populate_module, stale_error, monkeypatch
+):
+    """#1497: a clean run must not report an earlier attempt's errors."""
+    from spyglass.common.common_usage import InsertError
+
+    nwb_file_name, constants = stale_error
+    assert len(InsertError & constants) == 1, "Stale error was not seeded"
+
+    # Stand in for ingestion so nothing new is logged and the only candidate
+    # error is the stale row seeded above.
+    monkeypatch.setattr(
+        populate_module, "single_transaction_make", lambda **kwargs: None
+    )
+
+    assert populate_module.populate_all_common(nwb_file_name) is None
+    assert len(InsertError & constants) == 0
+
+
+def test_still_reports_errors_from_this_attempt(
+    populate_module, stale_error, monkeypatch
+):
+    """Clearing the log must not hide failures from the current run."""
+    from spyglass.common.common_session import Session
+    from spyglass.common.common_usage import InsertError
+
+    nwb_file_name, constants = stale_error
+
+    def _fail(**kwargs):
+        populate_module.log_insert_error(
+            table=Session,
+            err=ValueError("failure from this attempt"),
+            error_constants=kwargs["error_constants"],
+        )
+
+    monkeypatch.setattr(populate_module, "single_transaction_make", _fail)
+
+    result = populate_module.populate_all_common(nwb_file_name)
+    messages = (InsertError & constants).fetch("error_message")
+
+    assert result is not None, "Errors from this attempt were not reported"
+    assert len(result) == len(messages)
+    assert all("this attempt" in message for message in messages)
+    assert not any("previous attempt" in message for message in messages)


### PR DESCRIPTION
Closes #1497.

`populate_all_common` decides whether an ingestion failed by querying `InsertError` for the current `dj_user`, `connection_id`, and `nwb_file_name`. Nothing ever removed rows from a prior attempt, so a rerun within the same session inherited the earlier run's failures. It reported tables that had actually succeeded, and with `rollback_on_fail=True` it deleted an ingestion that was clean.

The `err_query = InsertError & error_constants` check near the end of `src/spyglass/common/populate_all_common.py` is scoped to a triple that is stable across repeated attempts in one session, so stale rows match it.

This deletes the `InsertError` rows matching that same triple immediately after `error_constants` is built and before population starts. Scoping to the full triple means only this user's own prior attempts at this specific file are cleared, never another user's and never another file's. `InsertError` has no dependent tables, so `delete_quick` is correct here. A `Notes` section in the docstring records the new behavior.

Tested with a new `tests/common/test_populate_all_common.py` holding two tests. The first seeds a stale `InsertError` row, stubs out `single_transaction_make`, and asserts a clean run returns `None` and leaves no rows. The second confirms the clear does not hide real failures: it makes the stubbed ingestion log an error and asserts those are still returned and that no stale message survives. Restoring the source from `master` makes both fail, and both pass after.

These ran against the real backend, using the repo's docker MySQL fixture and the session-autouse `mini_insert` fixture.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
