### PR TITLE
Fix SortGroup.set_group_by_shank crash on non-numeric electrode_group_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,9 @@ for label, interval_data in results.groupby("interval_labels"):
         `curation_label` column #1626
     - Fix `MetricCuration` dropping non-empty `merge_groups` when writing to NWB
         #1626
+    - Sort electrode group names with a numeric-aware natural sort in
+        `get_group_by_shank`, so `SortGroup.set_group_by_shank` no longer raises
+        `ValueError` on descriptive names such as `probe1_shank1` #1623
 
 ## [0.5.5] (Aug 6, 2025)
 

--- a/src/spyglass/spikesorting/utils.py
+++ b/src/spyglass/spikesorting/utils.py
@@ -1,5 +1,6 @@
+import re
 import warnings
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import datajoint as dj
 import numpy as np
@@ -8,6 +9,38 @@ import spikeinterface as si
 
 from spyglass.common.common_ephys import Electrode
 from spyglass.utils import logger
+
+_DIGIT_RUN = re.compile(r"(\d+)")
+
+
+def natural_sort_key(name) -> List[Tuple[int, int, str]]:
+    """Build a sort key that orders digit runs numerically and text lexically.
+
+    Electrode group names are often plain numbers ("0", "1", "10"), but NWB
+    files may name their groups descriptively instead ("probe1_shank1"). This
+    key preserves the numeric ordering of the former while still giving a
+    total order for the latter, so that names like "shank2" sort before
+    "shank10" rather than after.
+
+    Parameters
+    ----------
+    name : str
+        The name to build a sort key for. Cast to str before splitting, so
+        numpy string scalars and integers are both accepted.
+
+    Returns
+    -------
+    List[Tuple[int, int, str]]
+        One (kind, number, text) triple per run in the name. Digit runs use
+        kind 0 and compare on the number field, text runs use kind 1 and
+        compare on the case-folded text field. Every triple has the same
+        field types, so no comparison ever mixes int with str.
+    """
+    return [
+        (0, int(part), "") if part.isdigit() else (1, 0, part.lower())
+        for part in _DIGIT_RUN.split(str(name))
+        if part
+    ]
 
 
 def get_group_by_shank(
@@ -47,7 +80,9 @@ def get_group_by_shank(
     ).fetch()
 
     e_groups = list(np.unique(electrodes["electrode_group_name"]))
-    e_groups.sort(key=int)  # sort electrode groups numerically
+    # Numeric-aware sort. Plain `key=int` raised ValueError on descriptive
+    # group names such as "probe1_shank1". See issue #1623.
+    e_groups.sort(key=natural_sort_key)
 
     sort_group = 0
     sg_keys, sge_keys = list(), list()

--- a/tests/spikesorting/test_utils.py
+++ b/tests/spikesorting/test_utils.py
@@ -1,0 +1,121 @@
+"""#1623: get_group_by_shank crashed on non-numeric electrode_group_name."""
+
+import numpy as np
+import pytest
+
+
+def _electrode_array(group_names, n_per_group=4):
+    """Build the minimal Electrode fetch() result get_group_by_shank reads.
+
+    One shank per group and a shared reference electrode, so each electrode
+    group yields exactly one sort group and sort_group_id encodes the order
+    in which the group names were visited.
+    """
+    dtype = [
+        ("electrode_id", "i8"),
+        ("electrode_group_name", "U32"),
+        ("probe_shank", "i8"),
+        ("original_reference_electrode", "i8"),
+    ]
+    rows = []
+    for group_name in group_names:
+        for _ in range(n_per_group):
+            rows.append((len(rows), group_name, 1, 0))
+    return np.array(rows, dtype=dtype)
+
+
+class _FakeElectrode:
+    """Stand-in for the Electrode table that returns a fixed fetch() result.
+
+    get_group_by_shank only ever calls ``Electrode() & restr & restr`` then
+    ``.fetch()``, so faking those three steps exercises the real grouping and
+    sorting logic without a database.
+    """
+
+    def __init__(self, table):
+        self._table = table
+
+    def __call__(self):
+        return self
+
+    def __and__(self, _restriction):
+        return self
+
+    def fetch(self):
+        return self._table
+
+
+@pytest.fixture
+def group_order(monkeypatch):
+    """Return a helper mapping electrode group names to their sort order."""
+    from spyglass.spikesorting import utils as sg_utils
+
+    def _run(group_names):
+        monkeypatch.setattr(
+            sg_utils,
+            "Electrode",
+            _FakeElectrode(_electrode_array(group_names)),
+        )
+        _, sge_keys = sg_utils.get_group_by_shank(nwb_file_name="test.nwb")
+
+        by_sort_group = {}
+        for key in sge_keys:
+            by_sort_group.setdefault(
+                key["sort_group_id"], key["electrode_group_name"]
+            )
+        return [by_sort_group[i] for i in sorted(by_sort_group)]
+
+    return _run
+
+
+def test_natural_sort_key_orders_numbers_numerically():
+    """Digit runs compare as numbers, not as text."""
+    from spyglass.spikesorting.utils import natural_sort_key
+
+    names = ["10", "2", "1", "0"]
+    assert sorted(names, key=natural_sort_key) == ["0", "1", "2", "10"]
+
+
+def test_natural_sort_key_accepts_non_numeric_names():
+    """Descriptive names sort naturally instead of raising ValueError."""
+    from spyglass.spikesorting.utils import natural_sort_key
+
+    names = ["probe1_shank10", "probe1_shank2", "probe1_shank1"]
+    assert sorted(names, key=natural_sort_key) == [
+        "probe1_shank1",
+        "probe1_shank2",
+        "probe1_shank10",
+    ]
+
+
+def test_natural_sort_key_mixes_numeric_and_text_names():
+    """A mix of numeric and descriptive names still yields a total order."""
+    from spyglass.spikesorting.utils import natural_sort_key
+
+    names = ["probe1_shank1", "2", "0"]
+    assert sorted(names, key=natural_sort_key) == [
+        "0",
+        "2",
+        "probe1_shank1",
+    ]
+
+
+def test_group_by_shank_numeric_groups_unchanged(group_order):
+    """Numeric group names keep the numeric ordering they had before #1623."""
+    assert group_order(["10", "2", "1", "0"]) == ["0", "1", "2", "10"]
+
+
+def test_group_by_shank_non_numeric_groups(group_order):
+    """#1623: a non-numeric electrode_group_name no longer raises ValueError."""
+    assert group_order(
+        ["probe1_shank10", "probe1_shank2", "probe1_shank1"]
+    ) == ["probe1_shank1", "probe1_shank2", "probe1_shank10"]
+
+
+def test_group_by_shank_mixed_groups(group_order):
+    """#1623: numeric and descriptive names can coexist in one file."""
+    assert group_order(["probe1_shank1", "2", "0"]) == [
+        "0",
+        "2",
+        "probe1_shank1",
+    ]


### PR DESCRIPTION
Closes #1623.

`SortGroup.set_group_by_shank(nwb_file_name=...)` raises `ValueError: invalid literal for int() with base 10: ...` for any session whose electrodes carry a non-numeric `electrode_group_name`. This blocks the standard sort-group setup step entirely, leaving manual `SortGroup` and `SortGroup.SortGroupElectrode` inserts as the only workaround.

The cause is in `get_group_by_shank` in `src/spyglass/spikesorting/utils.py`, which sorted the electrode group names with `e_groups.sort(key=int)`. That assumes every group name is a numeric string. NWB files that name their electrode groups descriptively, for example `probe1_shank1`, fail the `int()` cast. Both the v0 and v1 `set_group_by_shank` entry points route through this one helper.

This replaces the hard-coded `int` key with a numeric-aware natural sort key, exposed as `natural_sort_key` in the same module. It splits a name on digit runs and emits uniformly typed `(kind, number, text)` triples, so no comparison ever mixes `int` with `str`. Purely numeric names keep the exact ordering they had before, which matters because iteration order determines `sort_group_id` assignment. Descriptive names now order `shank2` ahead of `shank10` rather than raising. Plain lexicographic ordering, the other option floated in the issue, would have put `shank10` before `shank2`.

Tested with a new `tests/spikesorting/test_utils.py` holding six tests. Three cover `natural_sort_key` directly. Three drive the real `get_group_by_shank` against a synthetic electrode array injected by monkeypatching the module-level `Electrode` symbol, which exercises the actual grouping and sorting path without needing lab data. Restoring the source from `master` makes five of the six fail with the exact `ValueError` from the issue. The sixth, `test_group_by_shank_numeric_groups_unchanged`, passes in both halves by design, since it is the guard proving numeric group names keep their existing ordering.

These ran against the real backend, using the repo's docker MySQL fixture and the session-autouse `mini_insert` fixture. I did not run the full suite. Separately, `tests/spikesorting/v1/test_recording.py` errors in fixture setup with `FileNotFoundError: 'conda'` from the `UserEnvironment` recompute-tracking path, which I confirmed is pre-existing on a clean tree and unrelated to this change.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
